### PR TITLE
fix: Thread Deletion Foreign Key Constraint Error

### DIFF
--- a/alembic/versions/20250831174511_add_cascade_delete_for_runs_thread_fkey.py
+++ b/alembic/versions/20250831174511_add_cascade_delete_for_runs_thread_fkey.py
@@ -1,0 +1,45 @@
+"""add_cascade_delete_for_runs_thread_fkey
+
+Revision ID: 11b2402d4be1
+Revises: 5931cd77e93b
+Create Date: 2025-08-31 17:45:11.723042
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '11b2402d4be1'
+down_revision = '5931cd77e93b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add ON DELETE CASCADE to runs.thread_id foreign key constraint."""
+    
+    # Drop the existing foreign key constraint
+    op.drop_constraint('runs_thread_id_fkey', 'runs', type_='foreignkey')
+    
+    # Recreate the foreign key constraint with CASCADE DELETE
+    op.create_foreign_key(
+        'runs_thread_id_fkey',
+        'runs', 'thread',
+        ['thread_id'], ['thread_id'],
+        ondelete='CASCADE'
+    )
+
+
+def downgrade() -> None:
+    """Remove CASCADE DELETE from runs.thread_id foreign key constraint."""
+    
+    # Drop the CASCADE foreign key constraint
+    op.drop_constraint('runs_thread_id_fkey', 'runs', type_='foreignkey')
+    
+    # Recreate the original foreign key constraint without CASCADE
+    op.create_foreign_key(
+        'runs_thread_id_fkey',
+        'runs', 'thread',
+        ['thread_id'], ['thread_id']
+    )

--- a/e2e/test_thread_deletion.py
+++ b/e2e/test_thread_deletion.py
@@ -1,0 +1,197 @@
+import pytest
+from e2e._utils import get_e2e_client, elog
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_thread_deletion_with_active_runs():
+    """
+    Test that thread deletion with active runs works seamlessly via SDK.
+    
+    The API should automatically cancel active runs and delete the thread.
+    """
+    client = get_e2e_client()
+    
+    # 1. Create assistant and thread
+    assistant = await client.assistants.create(
+        graph_id="agent",
+        config={"tags": ["thread-deletion-active-runs"]},
+        if_exists="do_nothing",
+    )
+    thread = await client.threads.create()
+    thread_id = thread["thread_id"]
+    assistant_id = assistant["assistant_id"]
+    
+    elog("Created thread and assistant", {
+        "thread_id": thread_id,
+        "assistant_id": assistant_id
+    })
+    
+    # 2. Create an active run
+    run = await client.runs.create(
+        thread_id=thread_id,
+        assistant_id=assistant_id,
+        input={"messages": [{"role": "user", "content": "Start processing"}]},
+    )
+    run_id = run["run_id"]
+    
+    elog("Created run", {
+        "run_id": run_id,
+        "status": run["status"]
+    })
+    
+    # 3. Verify run exists and is active
+    runs_list = await client.runs.list(thread_id)
+    assert len(runs_list["runs"]) >= 1
+    active_run = next(r for r in runs_list["runs"] if r["run_id"] == run_id)
+    assert active_run["status"] in ["pending", "running", "streaming"]
+    
+    # 4. Delete thread via SDK - should work seamlessly
+    await client.threads.delete(thread_id)
+    elog("Thread deleted successfully via SDK", {"thread_id": thread_id})
+    
+    # 5. Verify thread is actually deleted
+    try:
+        await client.threads.get(thread_id)
+        pytest.fail("Thread should have been deleted but still exists")
+    except Exception:
+        # Expected - thread should be gone
+        elog("Thread properly deleted (404 as expected)", {"thread_id": thread_id})
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_thread_deletion_with_completed_runs():
+    """
+    Test that thread deletion with completed runs works via SDK.
+    
+    Completed runs should not interfere with thread deletion.
+    """
+    client = get_e2e_client()
+    
+    # 1. Create assistant and thread
+    assistant = await client.assistants.create(
+        graph_id="agent",
+        config={"tags": ["thread-deletion-completed-runs"]},
+        if_exists="do_nothing",
+    )
+    thread = await client.threads.create()
+    thread_id = thread["thread_id"]
+    assistant_id = assistant["assistant_id"]
+    
+    # 2. Create and complete a run
+    run = await client.runs.create(
+        thread_id=thread_id,
+        assistant_id=assistant_id,
+        input={"messages": [{"role": "user", "content": "Say hello"}]},
+    )
+    run_id = run["run_id"]
+    
+    # 3. Wait for run to complete
+    final_state = await client.runs.join(thread_id, run_id)
+    elog("Run completed", {"final_state_keys": list(final_state.keys()) if final_state else None})
+    
+    # 4. Verify run is completed
+    completed_run = await client.runs.get(thread_id, run_id)
+    assert completed_run["status"] in ("completed", "failed")
+    elog("Run status verified", {"status": completed_run["status"]})
+    
+    # 5. Delete thread via SDK - should work fine
+    await client.threads.delete(thread_id)
+    elog("Thread with completed runs deleted successfully", {"thread_id": thread_id})
+    
+    # 6. Verify thread is deleted
+    try:
+        await client.threads.get(thread_id)
+        pytest.fail("Thread should have been deleted but still exists")
+    except Exception:
+        # Expected - thread should be gone
+        pass
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_thread_deletion_empty_thread():
+    """
+    Test that deleting empty threads works via SDK.
+    
+    This is the baseline case - should always work.
+    """
+    client = get_e2e_client()
+    
+    # 1. Create empty thread
+    thread = await client.threads.create()
+    thread_id = thread["thread_id"]
+    
+    elog("Created empty thread", {"thread_id": thread_id})
+    
+    # 2. Verify no runs exist
+    runs_list = await client.runs.list(thread_id)
+    assert len(runs_list["runs"]) == 0
+    
+    # 3. Delete thread via SDK
+    await client.threads.delete(thread_id)
+    elog("Empty thread deleted successfully", {"thread_id": thread_id})
+    
+    # 4. Verify thread is deleted
+    try:
+        await client.threads.get(thread_id)
+        pytest.fail("Thread should have been deleted but still exists")
+    except Exception:
+        # Expected - thread should be gone
+        pass
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_thread_deletion_multiple_runs():
+    """
+    Test that thread deletion works with multiple runs (active and completed).
+    
+    Should cancel all active runs and delete the thread.
+    """
+    client = get_e2e_client()
+    
+    # 1. Create assistant and thread
+    assistant = await client.assistants.create(
+        graph_id="agent",
+        config={"tags": ["thread-deletion-multiple-runs"]},
+        if_exists="do_nothing",
+    )
+    thread = await client.threads.create()
+    thread_id = thread["thread_id"]
+    assistant_id = assistant["assistant_id"]
+    
+    # 2. Create multiple runs
+    run1 = await client.runs.create(
+        thread_id=thread_id,
+        assistant_id=assistant_id,
+        input={"messages": [{"role": "user", "content": "First run"}]},
+    )
+    
+    run2 = await client.runs.create(
+        thread_id=thread_id,
+        assistant_id=assistant_id,
+        input={"messages": [{"role": "user", "content": "Second run"}]},
+    )
+    
+    elog("Created multiple runs", {
+        "run1_id": run1["run_id"],
+        "run2_id": run2["run_id"]
+    })
+    
+    # 3. Verify multiple runs exist
+    runs_list = await client.runs.list(thread_id)
+    assert len(runs_list["runs"]) >= 2
+    
+    # 4. Delete thread via SDK - should cancel all runs and delete thread
+    await client.threads.delete(thread_id)
+    elog("Thread with multiple runs deleted successfully", {"thread_id": thread_id})
+    
+    # 5. Verify thread is deleted
+    try:
+        await client.threads.get(thread_id)
+        pytest.fail("Thread should have been deleted but still exists")
+    except Exception:
+        # Expected - thread should be gone
+        pass

--- a/src/agent_server/core/orm.py
+++ b/src/agent_server/core/orm.py
@@ -90,7 +90,7 @@ class Run(Base):
 
     # TEXT PK with DB-side generation using uuid_generate_v4()::text
     run_id: Mapped[str] = mapped_column(Text, primary_key=True, server_default=text("uuid_generate_v4()::text"))
-    thread_id: Mapped[str] = mapped_column(Text, ForeignKey("thread.thread_id"), nullable=False)
+    thread_id: Mapped[str] = mapped_column(Text, ForeignKey("thread.thread_id", ondelete="CASCADE"), nullable=False)
     assistant_id: Mapped[str | None] = mapped_column(Text, ForeignKey("assistant.assistant_id"))
     status: Mapped[str] = mapped_column(Text, server_default=text("'pending'"))
     input: Mapped[dict | None] = mapped_column(JSONB, server_default=text("'{}'::jsonb"))


### PR DESCRIPTION

### Problem
When attempting to delete a thread with active runs, the API returns a 500 internal server error due to a PostgreSQL foreign key constraint violation:

```json
{
  "error": "internal_error", 
  "message": "An unexpected error occurred",
  "details": {
    "exception": "ForeignKeyViolationError: update or delete on table \"thread\" violates foreign key constraint \"runs_thread_id_fkey\" on table \"runs\""
  }
}
```

**Root Cause**: The `runs.thread_id` foreign key constraint lacked `ON DELETE CASCADE`, preventing thread deletion when runs existed.

### Solution
Implemented a hybrid approach combining database-level CASCADE DELETE with application-level resource cleanup:

#### 🗄️ **Database Level**
- Added migration to enable `ON DELETE CASCADE` on `runs.thread_id` foreign key
- Automatic cleanup of run records when threads are deleted
- Updated ORM definition to reflect CASCADE constraint

#### 🔧 **Application Level** 
- Enhanced thread deletion API to automatically cancel active runs before deletion
- Proper cleanup of background tasks, streaming services, and brokers
- Simplified API - no complex parameters needed

### Changes Made

1. **Database Migration** (`20250831174511_add_cascade_delete_for_runs_thread_fkey.py`)
   - Drops existing foreign key constraint
   - Recreates with `ON DELETE CASCADE`
   - Includes proper rollback in downgrade

2. **API Enhancement** (`src/agent_server/api/threads.py`)
   - Automatically detects and cancels active runs before deletion
   - Proper resource cleanup (tasks, streams, brokers)
   - Replaced print statements with structured logging
   - Removed inline imports for better code quality

3. **ORM Update** (`src/agent_server/core/orm.py`)
   - Added `ondelete="CASCADE"` to foreign key definition
   - Keeps ORM in sync with actual database schema

4. **Comprehensive Testing** (`e2e/test_thread_deletion.py`)
   - 4 test scenarios covering all cases
   - Uses SDK only (no custom HTTP requests)
   - Tests active runs, completed runs, empty threads, and multiple runs

### Behavior Changes

**Before**: 
```
DELETE /threads/{thread_id} → 500 ForeignKeyViolationError
```

**After**:
```
DELETE /threads/{thread_id} → 200 Success (auto-cancels active runs)
```

### Benefits

- ✅ **Fixes the bug**: No more 500 errors when deleting threads with runs
- ✅ **Better UX**: Thread deletion "just works" - no parameters needed  
- ✅ **Vendor alignment**: Matches vendored LangGraph behavior
- ✅ **Resource safety**: Proper cleanup of active tasks and streams
- ✅ **Performance**: Database handles bulk deletion efficiently
- ✅ **SDK compatibility**: Works seamlessly with existing SDK calls

### Testing

All tests pass:
```bash
pytest -m e2e e2e/test_thread_deletion.py -v
# 4 passed in 22.00s
```

**Test Coverage**:
- Thread deletion with active runs ✅
- Thread deletion with completed runs ✅  
- Empty thread deletion ✅
- Multiple runs scenario ✅

### Migration Safety

- ✅ **Backward compatible**: Existing functionality unchanged
- ✅ **Rollback available**: Migration includes proper downgrade
- ✅ **No data loss**: CASCADE only affects deletion, not data integrity

---

**Closes**: #7
**Type**: Bug Fix  
**Breaking Changes**: None