### PR TITLE
Fix LangSmith Studio integration issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,12 @@ services:
       context: .
       dockerfile: deployments/docker/Dockerfile
     ports:
-      - "2024:2024"
+      - "${PORT:-8000}:${PORT:-8000}"
     environment:
       - DATABASE_URL=postgresql+asyncpg://user:password@postgres:5432/aegra
       - AUTH_TYPE=noop
       - DEBUG=true
+      - PORT=${PORT:-8000}
     depends_on:
       postgres:
         condition: service_healthy
@@ -42,7 +43,7 @@ services:
         echo 'Running database migrations...' &&
         alembic upgrade head &&
         echo 'Starting Aegra server...' &&
-        uvicorn src.agent_server.main:app --host 0.0.0.0 --port 2024 --reload
+        uvicorn src.agent_server.main:app --host 0.0.0.0 --port $${PORT:-8000} --reload
       "
 
   # Redis (optional - for advanced queuing in future phases)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: deployments/docker/Dockerfile
     ports:
-      - "8000:8000"
+      - "2024:2024"
     environment:
       - DATABASE_URL=postgresql+asyncpg://user:password@postgres:5432/aegra
       - AUTH_TYPE=noop
@@ -42,7 +42,7 @@ services:
         echo 'Running database migrations...' &&
         alembic upgrade head &&
         echo 'Starting Aegra server...' &&
-        uvicorn src.agent_server.main:app --host 0.0.0.0 --port 8000 --reload
+        uvicorn src.agent_server.main:app --host 0.0.0.0 --port 2024 --reload
       "
 
   # Redis (optional - for advanced queuing in future phases)

--- a/e2e/test_assistant_graph.py
+++ b/e2e/test_assistant_graph.py
@@ -1,0 +1,290 @@
+import pytest
+from e2e._utils import get_e2e_client, elog
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_get_assistant_graph():
+    """
+    Test that we can retrieve the graph structure for an assistant.
+    """
+    client = get_e2e_client()
+
+    # 1. Create an assistant
+    assistant = await client.assistants.create(
+        name="Test Graph Assistant",
+        description="Assistant for testing graph endpoint",
+        graph_id="agent",
+    )
+
+    try:
+        # 2. Get the graph structure without xray
+        graph = await client.assistants.get_graph(
+            assistant_id=assistant["assistant_id"]
+        )
+
+        # 3. Verify graph structure
+        assert "nodes" in graph, "Graph should have nodes"
+        assert "edges" in graph, "Graph should have edges"
+        assert isinstance(graph["nodes"], list), "Nodes should be a list"
+        assert isinstance(graph["edges"], list), "Edges should be a list"
+        assert len(graph["nodes"]) > 0, "Graph should have at least one node"
+
+        elog(
+            "Graph structure retrieved successfully",
+            {
+                "assistant_id": assistant["assistant_id"],
+                "node_count": len(graph["nodes"]),
+                "edge_count": len(graph["edges"])
+            }
+        )
+
+    finally:
+        # Cleanup
+        await client.assistants.delete(assistant_id=assistant["assistant_id"])
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_get_assistant_graph_with_xray_boolean():
+    """
+    Test that we can retrieve the graph structure with xray=True.
+    """
+    client = get_e2e_client()
+
+    # 1. Create an assistant
+    assistant = await client.assistants.create(
+        name="Test Graph XRay Assistant",
+        description="Assistant for testing graph endpoint with xray",
+        graph_id="agent",
+    )
+
+    try:
+        # 2. Get the graph structure with xray=True
+        graph = await client.assistants.get_graph(
+            assistant_id=assistant["assistant_id"],
+            xray=True
+        )
+
+        # 3. Verify graph structure
+        assert "nodes" in graph, "Graph should have nodes"
+        assert "edges" in graph, "Graph should have edges"
+        assert isinstance(graph["nodes"], list), "Nodes should be a list"
+        assert isinstance(graph["edges"], list), "Edges should be a list"
+
+        elog(
+            "Graph structure with xray retrieved successfully",
+            {
+                "assistant_id": assistant["assistant_id"],
+                "node_count": len(graph["nodes"]),
+                "edge_count": len(graph["edges"])
+            }
+        )
+
+    finally:
+        # Cleanup
+        await client.assistants.delete(assistant_id=assistant["assistant_id"])
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_get_assistant_graph_with_xray_integer():
+    """
+    Test that we can retrieve the graph structure with xray as an integer depth.
+    """
+    client = get_e2e_client()
+
+    # 1. Create an assistant
+    assistant = await client.assistants.create(
+        name="Test Graph XRay Depth Assistant",
+        description="Assistant for testing graph endpoint with xray depth",
+        graph_id="agent",
+    )
+
+    try:
+        # 2. Get the graph structure with xray=1 (depth of 1)
+        graph = await client.assistants.get_graph(
+            assistant_id=assistant["assistant_id"],
+            xray=1
+        )
+
+        # 3. Verify graph structure
+        assert "nodes" in graph, "Graph should have nodes"
+        assert "edges" in graph, "Graph should have edges"
+        assert isinstance(graph["nodes"], list), "Nodes should be a list"
+        assert isinstance(graph["edges"], list), "Edges should be a list"
+
+        elog(
+            "Graph structure with xray depth retrieved successfully",
+            {
+                "assistant_id": assistant["assistant_id"],
+                "xray_depth": 1,
+                "node_count": len(graph["nodes"]),
+                "edge_count": len(graph["edges"])
+            }
+        )
+
+    finally:
+        # Cleanup
+        await client.assistants.delete(assistant_id=assistant["assistant_id"])
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_get_assistant_graph_not_found():
+    """
+    Test that getting a graph for a non-existent assistant returns 404.
+    """
+    client = get_e2e_client()
+
+    # Try to get graph for non-existent assistant
+    with pytest.raises(Exception) as exc_info:
+        await client.assistants.get_graph(
+            assistant_id="00000000-0000-0000-0000-000000000000"
+        )
+
+    # Verify it's a 404 error
+    assert "404" in str(exc_info.value) or "not found" in str(exc_info.value).lower()
+
+    elog("Graph endpoint correctly returns 404 for non-existent assistant", {})
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_get_assistant_subgraphs():
+    """
+    Test that we can retrieve subgraphs for an assistant.
+    Uses subgraph_agent which has actual subgraphs.
+    """
+    client = get_e2e_client()
+
+    # 1. Create an assistant with a graph that has subgraphs
+    assistant = await client.assistants.create(
+        name="Test Subgraphs Assistant",
+        description="Assistant for testing subgraphs endpoint",
+        graph_id="subgraph_agent",
+    )
+
+    try:
+        # 2. Get the subgraphs
+        subgraphs = await client.assistants.get_subgraphs(
+            assistant_id=assistant["assistant_id"]
+        )
+
+        # 3. Verify subgraphs structure
+        assert isinstance(subgraphs, dict), "Subgraphs should be a dictionary"
+        assert len(subgraphs) > 0, "subgraph_agent should have subgraphs"
+
+        elog(
+            "Subgraphs retrieved successfully",
+            {
+                "assistant_id": assistant["assistant_id"],
+                "subgraph_count": len(subgraphs),
+                "subgraph_names": list(subgraphs.keys())
+            }
+        )
+
+    finally:
+        # Cleanup
+        await client.assistants.delete(assistant_id=assistant["assistant_id"])
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_get_assistant_subgraphs_with_recurse():
+    """
+    Test that we can retrieve subgraphs recursively.
+    Uses subgraph_agent which has actual subgraphs.
+    """
+    client = get_e2e_client()
+
+    # 1. Create an assistant with a graph that has subgraphs
+    assistant = await client.assistants.create(
+        name="Test Subgraphs Recurse Assistant",
+        description="Assistant for testing subgraphs endpoint with recurse",
+        graph_id="subgraph_agent",
+    )
+
+    try:
+        # 2. Get the subgraphs recursively
+        subgraphs = await client.assistants.get_subgraphs(
+            assistant_id=assistant["assistant_id"],
+            recurse=True
+        )
+
+        # 3. Verify subgraphs structure
+        assert isinstance(subgraphs, dict), "Subgraphs should be a dictionary"
+        assert len(subgraphs) > 0, "subgraph_agent should have subgraphs"
+
+        elog(
+            "Subgraphs with recurse retrieved successfully",
+            {
+                "assistant_id": assistant["assistant_id"],
+                "subgraph_count": len(subgraphs),
+                "subgraph_names": list(subgraphs.keys()),
+                "recurse": True
+            }
+        )
+
+    finally:
+        # Cleanup
+        await client.assistants.delete(assistant_id=assistant["assistant_id"])
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_get_assistant_subgraphs_not_found():
+    """
+    Test that getting subgraphs for a non-existent assistant returns 404.
+    """
+    client = get_e2e_client()
+
+    # Try to get subgraphs for non-existent assistant
+    with pytest.raises(Exception) as exc_info:
+        await client.assistants.get_subgraphs(
+            assistant_id="00000000-0000-0000-0000-000000000000"
+        )
+
+    # Verify it's a 404 error
+    assert "404" in str(exc_info.value) or "not found" in str(exc_info.value).lower()
+
+    elog("Subgraphs endpoint correctly returns 404 for non-existent assistant", {})
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_system_assistant_graph_access():
+    """
+    Test that we can access graph for system-created assistants.
+    """
+    client = get_e2e_client()
+
+    # Get the system assistant (should be created on startup)
+    assistants = await client.assistants.search()
+    
+    # Find a system assistant (created with graph_id)
+    system_assistant = None
+    for assistant in assistants:
+        if assistant.get("user_id") == "system":
+            system_assistant = assistant
+            break
+    
+    if system_assistant:
+        # Try to get the graph for system assistant
+        graph = await client.assistants.get_graph(
+            assistant_id=system_assistant["assistant_id"]
+        )
+
+        # Verify graph structure
+        assert "nodes" in graph, "Graph should have nodes"
+        assert "edges" in graph, "Graph should have edges"
+
+        elog(
+            "System assistant graph accessed successfully",
+            {
+                "assistant_id": system_assistant["assistant_id"],
+                "node_count": len(graph["nodes"])
+            }
+        )
+    else:
+        elog("No system assistant found, skipping test", {})

--- a/run_server.py
+++ b/run_server.py
@@ -62,14 +62,14 @@ def main():
     configure_logging(os.getenv("LOG_LEVEL", "INFO"))
 
     print("🚀 Starting Aegra...")
-    print("📍 Server will be available at: http://localhost:8000")
-    print("📊 API docs will be available at: http://localhost:8000/docs")
+    print("📍 Server will be available at: http://localhost:2024")
+    print("📊 API docs will be available at: http://localhost:2024/docs")
     print("🧪 Test with: python test_sdk_integration.py")
 
     uvicorn.run(
         "src.agent_server.main:app",
         host="0.0.0.0",
-        port=8000,
+        port=2024,
         reload=True,
         log_level=os.getenv("UVICORN_LOG_LEVEL", "debug"),
     )

--- a/run_server.py
+++ b/run_server.py
@@ -61,15 +61,17 @@ def main():
     setup_environment()
     configure_logging(os.getenv("LOG_LEVEL", "INFO"))
 
+    port = int(os.getenv("PORT", "8000"))
+    
     print("🚀 Starting Aegra...")
-    print("📍 Server will be available at: http://localhost:2024")
-    print("📊 API docs will be available at: http://localhost:2024/docs")
+    print(f"📍 Server will be available at: http://localhost:{port}")
+    print(f"📊 API docs will be available at: http://localhost:{port}/docs")
     print("🧪 Test with: python test_sdk_integration.py")
 
     uvicorn.run(
         "src.agent_server.main:app",
         host="0.0.0.0",
-        port=2024,
+        port=port,
         reload=True,
         log_level=os.getenv("UVICORN_LOG_LEVEL", "debug"),
     )

--- a/src/agent_server/api/assistants.py
+++ b/src/agent_server/api/assistants.py
@@ -1,143 +1,45 @@
-"""Assistant endpoints for Agent Protocol"""
-from uuid import uuid4
-from datetime import datetime, UTC
+"""Assistant endpoints for Agent Protocol
+
+NOTE: This API follows a layered architecture pattern with business logic 
+separated into a service layer (assistant_service.py). This was the first 
+API to be refactored, and the plan is to gradually refactor all other APIs 
+(runs, threads, etc.) to follow this same pattern for better code 
+organization, testability, and maintainability.
+
+Architecture:
+- API Layer (this file): Thin FastAPI route handlers, request/response handling
+- Service Layer (assistant_service.py): Business logic, validation, orchestration
+"""
 from typing import List
 from fastapi import APIRouter, HTTPException, Depends, Body
-import uuid
-from sqlalchemy import select, update, delete, func, or_
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..models import Assistant, AssistantCreate, AssistantUpdate, AssistantList, AssistantSearchRequest, AgentSchemas, User
-from ..services.langgraph_service import get_langgraph_service
+from ..models import Assistant, AssistantCreate, AssistantUpdate, AssistantList, AssistantSearchRequest, User
 from ..core.auth_deps import get_current_user
-from ..core.orm import Assistant as AssistantORM, AssistantVersion as AssistantVersionORM, get_session
+from ..services.assistant_service import AssistantService, get_assistant_service
 
 router = APIRouter()
-
-
-def to_pydantic(row: AssistantORM) -> Assistant:
-    """Convert SQLAlchemy ORM object to Pydantic model with proper type casting."""
-    row_dict = {c.name: getattr(row, c.name) for c in row.__table__.columns}
-    # Cast UUIDs to str so they match the Pydantic schema
-    if "assistant_id" in row_dict and row_dict["assistant_id"] is not None:
-        row_dict["assistant_id"] = str(row_dict["assistant_id"])
-    if "user_id" in row_dict and isinstance(row_dict["user_id"], uuid.UUID):
-        row_dict["user_id"] = str(row_dict["user_id"])
-    return Assistant.model_validate(row_dict)
 
 
 @router.post("/assistants", response_model=Assistant)
 async def create_assistant(
     request: AssistantCreate,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """Create a new assistant"""
-    # Get LangGraph service to validate graph
-    langgraph_service = get_langgraph_service()
-    available_graphs = langgraph_service.list_graphs()
-    
-    # Use graph_id as the main identifier
-    graph_id = request.graph_id
-    
-    if graph_id not in available_graphs:
-        raise HTTPException(
-            400,
-            f"Graph '{graph_id}' not found in aegra.json. Available: {list(available_graphs.keys())}"
-        )
-    
-    # Validate graph can be loaded
-    try:
-        graph = await langgraph_service.get_graph(graph_id)
-    except Exception as e:
-        raise HTTPException(400, f"Failed to load graph: {str(e)}")
-
-    config = request.config
-    context = request.context
-
-    if config.get("configurable") and context:
-        raise HTTPException(
-            status_code=400,
-            detail="Cannot specify both configurable and context. Prefer setting context alone. Context was introduced in LangGraph 0.6.0 and is the long term planned replacement for configurable.",
-        )
-
-    # Keep config and context up to date with one another
-    if config.get("configurable"):
-        context = config["configurable"]
-    elif context:
-        config["configurable"] = context
-    
-    # Generate assistant_id if not provided
-    assistant_id = request.assistant_id or str(uuid4())
-    
-    # Generate name if not provided
-    name = request.name or f"Assistant for {graph_id}"
-    
-    # Check if an assistant already exists for this user, graph and config pair
-    existing_stmt = select(AssistantORM).where(
-        AssistantORM.user_id == user.identity,
-        or_(
-            (AssistantORM.graph_id == graph_id) & (AssistantORM.config == config),
-            AssistantORM.assistant_id == assistant_id
-        )
-    )
-    existing = await session.scalar(existing_stmt)
-    
-    if existing:
-        if request.if_exists == "do_nothing":
-            return to_pydantic(existing)
-        else:  # error (default)
-            raise HTTPException(409, f"Assistant '{assistant_id}' already exists")
-    
-    # Create assistant record
-    assistant_orm = AssistantORM(
-        assistant_id=assistant_id,
-        name=name,
-        description=request.description,
-        config=config,
-        context=context,
-        graph_id=graph_id,
-        user_id=user.identity,
-        metadata_dict=request.metadata,
-        version=1
-    )
-    
-    session.add(assistant_orm)
-    await session.commit()
-    await session.refresh(assistant_orm)
-
-    # Create initial version record
-    assistant_version_orm = AssistantVersionORM(
-        assistant_id=assistant_id,
-        version=1,
-        graph_id=graph_id,
-        config=config,
-        context=context,
-        created_at=datetime.now(UTC),
-        name=name,
-        description=request.description,
-        metadata_dict=request.metadata
-    )
-    session.add(assistant_version_orm)
-    await session.commit()
-    
-    return to_pydantic(assistant_orm)
+    return await service.create_assistant(request, user.identity)
 
 
 @router.get("/assistants", response_model=AssistantList)
 async def list_assistants(
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """List user's assistants"""
-    # Filter assistants by user
-    stmt = select(AssistantORM).where(AssistantORM.user_id == user.identity)
-    result = await session.scalars(stmt)
-    user_assistants = [to_pydantic(a) for a in result.all()]
-    
+    assistants = await service.list_assistants(user.identity)
     return AssistantList(
-        assistants=user_assistants,
-        total=len(user_assistants)
+        assistants=assistants,
+        total=len(assistants)
     )
 
 
@@ -145,376 +47,82 @@ async def list_assistants(
 async def search_assistants(
     request: AssistantSearchRequest,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """Search assistants with filters"""
-    # Start with user's assistants
-    stmt = select(AssistantORM).where(AssistantORM.user_id == user.identity)
-    
-    # Apply filters
-    if request.name:
-        stmt = stmt.where(AssistantORM.name.ilike(f"%{request.name}%"))
-    
-    if request.description:
-        stmt = stmt.where(AssistantORM.description.ilike(f"%{request.description}%"))
-    
-    if request.graph_id:
-        stmt = stmt.where(AssistantORM.graph_id == request.graph_id)
-
-    if request.metadata:
-        stmt = stmt.where(AssistantORM.metadata_dict.op("@>")(request.metadata))
-    
-    # Apply pagination
-    offset = request.offset or 0
-    limit = request.limit or 20
-    stmt = stmt.offset(offset).limit(limit)
-    
-    result = await session.scalars(stmt)
-    paginated_assistants = [to_pydantic(a) for a in result.all()]
-    
-    return paginated_assistants
+    return await service.search_assistants(request, user.identity)
 
 
 @router.post("/assistants/count", response_model=int)
 async def count_assistants(
     request: AssistantSearchRequest,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """Count assistants with filters"""
-    stmt = select(func.count()).where(AssistantORM.user_id == user.identity)
-
-    if request.name:
-        stmt = stmt.where(AssistantORM.name.ilike(f"%{request.name}%"))
-
-    if request.description:
-        stmt = stmt.where(AssistantORM.description.ilike(f"%{request.description}%"))
-
-    if request.graph_id:
-        stmt = stmt.where(AssistantORM.graph_id == request.graph_id)
-
-    if request.metadata:
-        stmt = stmt.where(AssistantORM.metadata_dict.op("@>")(request.metadata))
-
-    total = await session.scalar(stmt)
-    return total or 0
+    return await service.count_assistants(request, user.identity)
 
 
 @router.get("/assistants/{assistant_id}", response_model=Assistant)
 async def get_assistant(
     assistant_id: str, 
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """Get assistant by ID"""
-    stmt = select(AssistantORM).where(
-        AssistantORM.assistant_id == assistant_id,
-        or_(
-            AssistantORM.user_id == user.identity,
-            AssistantORM.user_id == "system"
-        )
-    )
-    assistant = await session.scalar(stmt)
-    
-    if not assistant:
-        raise HTTPException(404, f"Assistant '{assistant_id}' not found")
-    
-    return to_pydantic(assistant)
+    return await service.get_assistant(assistant_id, user.identity)
 
 
 @router.patch("/assistants/{assistant_id}", response_model=Assistant)
 async def update_assistant(
-        assistant_id: str,
-        request: AssistantUpdate,
-        user: User = Depends(get_current_user),
-        session: AsyncSession = Depends(get_session)
+    assistant_id: str,
+    request: AssistantUpdate,
+    user: User = Depends(get_current_user),
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """Update assistant by ID"""
-    metadata = request.metadata or {}
-    config = request.config or {}
-    context = request.context or {}
-
-    if config.get("configurable") and context:
-        raise HTTPException(
-            status_code=400,
-            detail="Cannot specify both configurable and context. Use only one.",
-        )
-
-    # Keep config and context up to date with one another
-    if config.get("configurable"):
-        context = config["configurable"]
-    elif context:
-        config["configurable"] = context
-
-    stmt = select(AssistantORM).where(
-        AssistantORM.assistant_id == assistant_id,
-        AssistantORM.user_id == user.identity
-    )
-    assistant = await session.scalar(stmt)
-    if not assistant:
-        raise HTTPException(404, f"Assistant '{assistant_id}' not found")
-
-    now = datetime.now(UTC)
-    version_stmt = select(func.max(AssistantVersionORM.version)).where(
-        AssistantVersionORM.assistant_id == assistant_id
-    )
-    max_version = await session.scalar(version_stmt)
-    new_version = (max_version or 1) + 1  if max_version is not None else 1
-
-    new_version_details = {
-        "assistant_id": assistant_id,
-        "version": new_version,
-        "graph_id": request.graph_id or assistant.graph_id,
-        "config": config,
-        "context": context,
-        "created_at": now,
-        "name": request.name or assistant.name,
-        "description": request.description or assistant.description,
-        "metadata_dict": metadata
-    }
-
-    assistant_version_orm = AssistantVersionORM(**new_version_details)
-    session.add(assistant_version_orm)
-    await session.commit()
-
-    assistant_update = update(AssistantORM).where(
-        AssistantORM.assistant_id == assistant_id,
-        AssistantORM.user_id == user.identity
-    ).values(
-        name=new_version_details["name"],
-        description=new_version_details["description"],
-        graph_id=new_version_details["graph_id"],
-        config=new_version_details["config"],
-        context=new_version_details["context"],
-        version=new_version,
-        updated_at=now,
-    )
-    await session.execute(assistant_update)
-    await session.commit()
-    updated_assistant = await session.scalar(stmt)
-    return to_pydantic(updated_assistant)
+    return await service.update_assistant(assistant_id, request, user.identity)
 
 
 @router.delete("/assistants/{assistant_id}")
 async def delete_assistant(
     assistant_id: str, 
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """Delete assistant by ID"""
-    stmt = select(AssistantORM).where(
-        AssistantORM.assistant_id == assistant_id,
-        AssistantORM.user_id == user.identity
-    )
-    assistant = await session.scalar(stmt)
-    
-    if not assistant:
-        raise HTTPException(404, f"Assistant '{assistant_id}' not found")
-    
-    await session.delete(assistant)
-    await session.commit()
-
-    return {"status": "deleted"}
+    return await service.delete_assistant(assistant_id, user.identity)
 
 
 @router.post("/assistants/{assistant_id}/latest", response_model=Assistant)
 async def set_assistant_latest(
-        assistant_id: str,
-        version: int = Body(..., embed=True, description="The version number to set as latest"),
-        user: User = Depends(get_current_user),
-        session: AsyncSession = Depends(get_session)
+    assistant_id: str,
+    version: int = Body(..., embed=True, description="The version number to set as latest"),
+    user: User = Depends(get_current_user),
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """Set the given version as the latest version of an assistant"""
-    stmt = select(AssistantORM).where(
-        AssistantORM.assistant_id == assistant_id,
-        AssistantORM.user_id == user.identity
-    )
-    assistant = await session.scalar(stmt)
-    if not assistant:
-        raise HTTPException(404, f"Assistant '{assistant_id}' not found")
-
-    version_stmt = select(AssistantVersionORM).where(
-        AssistantVersionORM.assistant_id == assistant_id,
-        AssistantVersionORM.version == version
-    )
-    assistant_version = await session.scalar(version_stmt)
-    if not assistant_version:
-        raise HTTPException(404, f"Version '{version}' for Assistant '{assistant_id}' not found")
-
-    assistant_update = update(AssistantORM).where(
-        AssistantORM.assistant_id == assistant_id,
-        AssistantORM.user_id == user.identity
-    ).values(
-        name=assistant_version.name,
-        description=assistant_version.description,
-        config=assistant_version.config,
-        context=assistant_version.context,
-        graph_id=assistant_version.graph_id,
-        version=version,
-        updated_at=datetime.now(UTC)
-    )
-    await session.execute(assistant_update)
-    await session.commit()
-    updated_assistant = await session.scalar(stmt)
-    return to_pydantic(updated_assistant)
+    return await service.set_assistant_latest(assistant_id, version, user.identity)
 
 
 @router.post("/assistants/{assistant_id}/versions", response_model=List[Assistant])
 async def list_assistant_versions(
     assistant_id: str,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """List all versions of an assistant"""
-    stmt = select(AssistantORM).where(
-        AssistantORM.assistant_id == assistant_id,
-        AssistantORM.user_id == user.identity
-    )
-    assistant = await session.scalar(stmt)
-    if not assistant:
-        raise HTTPException(404, f"Assistant '{assistant_id}' not found")
-
-    stmt = select(AssistantVersionORM).where(
-        AssistantVersionORM.assistant_id == assistant_id
-    ).order_by(AssistantVersionORM.version.desc())
-    result = await session.scalars(stmt)
-    versions = result.all()
-
-    if not versions:
-        raise HTTPException(404, f"No versions found for Assistant '{assistant_id}'")
-
-    # Convert to Pydantic models
-    version_list = [
-        Assistant(
-            assistant_id=assistant_id,
-            name=v.name,
-            description=v.description,
-            config=v.config,
-            context=v.context,
-            graph_id=v.graph_id,
-            user_id=user.identity,
-            version=v.version,
-            created_at=v.created_at,
-            updated_at=v.created_at,
-            metadata_dict=v.metadata_dict
-        ) for v in versions
-    ]
-
-    return version_list
-
-
-def _state_jsonschema(graph) -> dict | None:
-    """Extract state schema from graph channels"""
-    from typing import Any
-    from langgraph._internal._pydantic import create_model
-    
-    fields: dict = {}
-    for k in graph.stream_channels_list:
-        v = graph.channels[k]
-        try:
-            create_model(k, __root__=(v.UpdateType, None)).model_json_schema()
-            fields[k] = (v.UpdateType, None)
-        except Exception:
-            fields[k] = (Any, None)
-    return create_model(graph.get_name("State"), **fields).model_json_schema()
-
-
-def _get_configurable_jsonschema(graph) -> dict:
-    """Get the JSON schema for the configurable part of the graph"""
-    from pydantic import TypeAdapter
-    
-    EXCLUDED_CONFIG_SCHEMA = {"__pregel_resuming", "__pregel_checkpoint_id"}
-    
-    config_schema = graph.config_schema()
-    model_fields = getattr(config_schema, "model_fields", None) or getattr(
-        config_schema, "__fields__", None
-    )
-    
-    if model_fields is not None and "configurable" in model_fields:
-        configurable = TypeAdapter(model_fields["configurable"].annotation)
-        json_schema = configurable.json_schema()
-        if json_schema:
-            for key in EXCLUDED_CONFIG_SCHEMA:
-                json_schema["properties"].pop(key, None)
-        if (
-            hasattr(graph, "config_type")
-            and graph.config_type is not None
-            and hasattr(graph.config_type, "__name__")
-        ):
-            json_schema["title"] = graph.config_type.__name__
-        return json_schema
-    return {}
-
-
-def _extract_graph_schemas(graph) -> dict:
-    """Extract schemas from a compiled LangGraph graph object"""
-    try:
-        input_schema = graph.get_input_jsonschema()
-    except Exception:
-        input_schema = None
-    
-    try:
-        output_schema = graph.get_output_jsonschema()
-    except Exception:
-        output_schema = None
-    
-    try:
-        state_schema = _state_jsonschema(graph)
-    except Exception:
-        state_schema = None
-    
-    try:
-        config_schema = _get_configurable_jsonschema(graph)
-    except Exception:
-        config_schema = None
-    
-    try:
-        context_schema = graph.get_context_jsonschema()
-    except Exception:
-        context_schema = None
-    
-    return {
-        "input_schema": input_schema,
-        "output_schema": output_schema,
-        "state_schema": state_schema,
-        "config_schema": config_schema,
-        "context_schema": context_schema,
-    }
+    return await service.list_assistant_versions(assistant_id, user.identity)
 
 
 @router.get("/assistants/{assistant_id}/schemas")
 async def get_assistant_schemas(
     assistant_id: str, 
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """Get input, output, state, config and context schemas for an assistant"""
-    
-    stmt = select(AssistantORM).where(
-        AssistantORM.assistant_id == assistant_id,
-        or_(
-            AssistantORM.user_id == user.identity,
-            AssistantORM.user_id == "system"
-        )
-    )
-    assistant = await session.scalar(stmt)
-    
-    if not assistant:
-        raise HTTPException(404, f"Assistant '{assistant_id}' not found")
-    
-    langgraph_service = get_langgraph_service()
-    
-    try:
-        graph = await langgraph_service.get_graph(assistant.graph_id)
-        schemas = _extract_graph_schemas(graph)
-        
-        return {
-            "graph_id": assistant.graph_id,
-            **schemas
-        }
-        
-    except Exception as e:
-        raise HTTPException(400, f"Failed to extract schemas: {str(e)}")
+    return await service.get_assistant_schemas(assistant_id, user.identity)
 
 
 @router.get("/assistants/{assistant_id}/graph")
@@ -522,57 +130,10 @@ async def get_assistant_graph(
     assistant_id: str,
     xray: str | None = None,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """Get the graph structure for visualization"""
-    
-    stmt = select(AssistantORM).where(
-        AssistantORM.assistant_id == assistant_id,
-        or_(
-            AssistantORM.user_id == user.identity,
-            AssistantORM.user_id == "system"
-        )
-    )
-    assistant = await session.scalar(stmt)
-    
-    if not assistant:
-        raise HTTPException(404, f"Assistant '{assistant_id}' not found")
-    
-    langgraph_service = get_langgraph_service()
-    
-    try:
-        graph = await langgraph_service.get_graph(assistant.graph_id)
-        
-        xray_value: bool | int = False
-        if xray:
-            if xray in ("true", "True"):
-                xray_value = True
-            elif xray in ("false", "False"):
-                xray_value = False
-            else:
-                try:
-                    xray_value = int(xray)
-                    if xray_value <= 0:
-                        raise HTTPException(422, detail="Invalid xray value")
-                except ValueError:
-                    raise HTTPException(422, detail="Invalid xray value")
-        
-        try:
-            drawable_graph = await graph.aget_graph(xray=xray_value)
-            json_graph = drawable_graph.to_json()
-            
-            for node in json_graph.get("nodes", []):
-                if (data := node.get("data")) and isinstance(data, dict):
-                    data.pop("id", None)
-            
-            return json_graph
-        except NotImplementedError:
-            raise HTTPException(422, detail="The graph does not support visualization")
-        
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(400, f"Failed to get graph: {str(e)}")
+    return await service.get_assistant_graph(assistant_id, xray, user.identity)
 
 
 @router.get("/assistants/{assistant_id}/subgraphs")
@@ -581,42 +142,7 @@ async def get_assistant_subgraphs(
     namespace: str | None = None,
     recurse: str | None = None,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session)
+    service: AssistantService = Depends(get_assistant_service)
 ):
     """Get subgraphs of an assistant"""
-    
-    stmt = select(AssistantORM).where(
-        AssistantORM.assistant_id == assistant_id,
-        or_(
-            AssistantORM.user_id == user.identity,
-            AssistantORM.user_id == "system"
-        )
-    )
-    assistant = await session.scalar(stmt)
-    
-    if not assistant:
-        raise HTTPException(404, f"Assistant '{assistant_id}' not found")
-    
-    langgraph_service = get_langgraph_service()
-    
-    try:
-        graph = await langgraph_service.get_graph(assistant.graph_id)
-        
-        recurse_value = recurse in ("true", "True") if recurse else False
-        
-        try:
-            subgraphs = {
-                ns: _extract_graph_schemas(subgraph)
-                async for ns, subgraph in graph.aget_subgraphs(
-                    namespace=namespace,
-                    recurse=recurse_value
-                )
-            }
-            return subgraphs
-        except NotImplementedError:
-            raise HTTPException(422, detail="The graph does not support subgraphs")
-        
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(400, f"Failed to get subgraphs: {str(e)}")
+    return await service.get_assistant_subgraphs(assistant_id, namespace, recurse, user.identity)

--- a/src/agent_server/api/assistants.py
+++ b/src/agent_server/api/assistants.py
@@ -209,7 +209,10 @@ async def get_assistant(
     """Get assistant by ID"""
     stmt = select(AssistantORM).where(
         AssistantORM.assistant_id == assistant_id,
-        AssistantORM.user_id == user.identity
+        or_(
+            AssistantORM.user_id == user.identity,
+            AssistantORM.user_id == "system"
+        )
     )
     assistant = await session.scalar(stmt)
     
@@ -489,7 +492,10 @@ async def get_assistant_schemas(
     
     stmt = select(AssistantORM).where(
         AssistantORM.assistant_id == assistant_id,
-        AssistantORM.user_id == user.identity
+        or_(
+            AssistantORM.user_id == user.identity,
+            AssistantORM.user_id == "system"
+        )
     )
     assistant = await session.scalar(stmt)
     
@@ -522,7 +528,10 @@ async def get_assistant_graph(
     
     stmt = select(AssistantORM).where(
         AssistantORM.assistant_id == assistant_id,
-        AssistantORM.user_id == user.identity
+        or_(
+            AssistantORM.user_id == user.identity,
+            AssistantORM.user_id == "system"
+        )
     )
     assistant = await session.scalar(stmt)
     
@@ -578,7 +587,10 @@ async def get_assistant_subgraphs(
     
     stmt = select(AssistantORM).where(
         AssistantORM.assistant_id == assistant_id,
-        AssistantORM.user_id == user.identity
+        or_(
+            AssistantORM.user_id == user.identity,
+            AssistantORM.user_id == "system"
+        )
     )
     assistant = await session.scalar(stmt)
     

--- a/src/agent_server/api/assistants.py
+++ b/src/agent_server/api/assistants.py
@@ -128,19 +128,21 @@ async def get_assistant_schemas(
 @router.get("/assistants/{assistant_id}/graph")
 async def get_assistant_graph(
     assistant_id: str,
-    xray: str | None = None,
+    xray: bool | int | None = None,
     user: User = Depends(get_current_user),
     service: AssistantService = Depends(get_assistant_service)
 ):
     """Get the graph structure for visualization"""
-    return await service.get_assistant_graph(assistant_id, xray, user.identity)
+    # Default to False if not provided
+    xray_value = xray if xray is not None else False
+    return await service.get_assistant_graph(assistant_id, xray_value, user.identity)
 
 
 @router.get("/assistants/{assistant_id}/subgraphs")
 async def get_assistant_subgraphs(
     assistant_id: str,
+    recurse: bool = False,
     namespace: str | None = None,
-    recurse: str | None = None,
     user: User = Depends(get_current_user),
     service: AssistantService = Depends(get_assistant_service)
 ):

--- a/src/agent_server/api/runs.py
+++ b/src/agent_server/api/runs.py
@@ -136,17 +136,6 @@ async def create_run(
     config = request.config
     context = request.context
 
-    if config.get("configurable") and context:
-        raise HTTPException(
-            status_code=400,
-            detail="Cannot specify both configurable and context. Prefer setting context alone. Context was introduced in LangGraph 0.6.0 and is the long term planned replacement for configurable.",
-        )
-
-    # Keep config and context up to date with one another
-    if config.get("configurable"):
-        context = config["configurable"]
-    elif context:
-        config["configurable"] = context
 
     assistant_stmt = select(AssistantORM).where(
         AssistantORM.assistant_id == resolved_assistant_id,
@@ -261,17 +250,6 @@ async def create_and_stream_run(
     config = request.config
     context = request.context
 
-    if config.get("configurable") and context:
-        raise HTTPException(
-            status_code=400,
-            detail="Cannot specify both configurable and context. Prefer setting context alone. Context was introduced in LangGraph 0.6.0 and is the long term planned replacement for configurable.",
-        )
-
-    # Keep config and context up to date with one another
-    if config.get("configurable"):
-        context = config["configurable"]
-    elif context:
-        config["configurable"] = context
 
     assistant_stmt = select(AssistantORM).where(
         AssistantORM.assistant_id == resolved_assistant_id,

--- a/src/agent_server/constants.py
+++ b/src/agent_server/constants.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
-# Project-specific namespace for deriving deterministic assistant IDs from graph IDs.
+# Standard namespace UUID for deriving deterministic assistant IDs from graph IDs.
 # IMPORTANT: Do not change after initial deploy unless you plan a data migration.
-ASSISTANT_NAMESPACE_UUID = UUID("b8b8132e-6d5a-4f6e-9d2d-8c8a3f7a4c11")
+ASSISTANT_NAMESPACE_UUID = UUID("6ba7b821-9dad-11d1-80b4-00c04fd430c8")
 
 

--- a/src/agent_server/main.py
+++ b/src/agent_server/main.py
@@ -135,4 +135,4 @@ async def root():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=2024)

--- a/src/agent_server/main.py
+++ b/src/agent_server/main.py
@@ -20,8 +20,6 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.middleware.authentication import AuthenticationMiddleware
-from starlette.types import ASGIApp, Receive, Send, Scope
-import json
 import logging
 
 from .core.database import db_manager
@@ -32,68 +30,12 @@ from .api.runs import router as runs_router
 from .api.store import router as store_router
 from .models.errors import AgentProtocolError, get_error_type
 from .core.auth_middleware import get_auth_backend, on_auth_error
+from .middleware import DoubleEncodedJSONMiddleware
 
 # Task management for run cancellation
 active_runs: Dict[str, asyncio.Task] = {}
 
 logger = logging.getLogger(__name__)
-
-
-class DoubleEncodedJSONMiddleware:
-    def __init__(self, app: ASGIApp):
-        self.app = app
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send):
-        if scope["type"] != "http":
-            await self.app(scope, receive, send)
-            return
-
-        method = scope["method"]
-        headers = dict(scope.get("headers", []))
-        content_type = headers.get(b"content-type", b"").decode("latin1")
-
-        if method in ["POST", "PUT", "PATCH"] and content_type:
-            body_parts = []
-            
-            async def receive_wrapper():
-                message = await receive()
-                if message["type"] == "http.request":
-                    body_parts.append(message.get("body", b""))
-                    
-                    if not message.get("more_body", False):
-                        body = b"".join(body_parts)
-                        
-                        if body:
-                            try:
-                                decoded = body.decode("utf-8")
-                                parsed = json.loads(decoded)
-                                
-                                if isinstance(parsed, str):
-                                    parsed = json.loads(parsed)
-                                
-                                new_body = json.dumps(parsed).encode("utf-8")
-                                
-                                if b"content-type" in headers and content_type != "application/json":
-                                    new_headers = []
-                                    for name, value in scope.get("headers", []):
-                                        if name != b"content-type":
-                                            new_headers.append((name, value))
-                                    new_headers.append((b"content-type", b"application/json"))
-                                    scope["headers"] = new_headers
-                                
-                                return {
-                                    "type": "http.request",
-                                    "body": new_body,
-                                    "more_body": False
-                                }
-                            except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
-                                pass
-                
-                return message
-
-            await self.app(scope, receive_wrapper, send)
-        else:
-            await self.app(scope, receive, send)
 
 
 @asynccontextmanager

--- a/src/agent_server/main.py
+++ b/src/agent_server/main.py
@@ -20,6 +20,9 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.types import ASGIApp, Receive, Send, Scope
+import json
+import logging
 
 from .core.database import db_manager
 from .core.health import router as health_router
@@ -32,6 +35,65 @@ from .core.auth_middleware import get_auth_backend, on_auth_error
 
 # Task management for run cancellation
 active_runs: Dict[str, asyncio.Task] = {}
+
+logger = logging.getLogger(__name__)
+
+
+class DoubleEncodedJSONMiddleware:
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope["method"]
+        headers = dict(scope.get("headers", []))
+        content_type = headers.get(b"content-type", b"").decode("latin1")
+
+        if method in ["POST", "PUT", "PATCH"] and content_type:
+            body_parts = []
+            
+            async def receive_wrapper():
+                message = await receive()
+                if message["type"] == "http.request":
+                    body_parts.append(message.get("body", b""))
+                    
+                    if not message.get("more_body", False):
+                        body = b"".join(body_parts)
+                        
+                        if body:
+                            try:
+                                decoded = body.decode("utf-8")
+                                parsed = json.loads(decoded)
+                                
+                                if isinstance(parsed, str):
+                                    parsed = json.loads(parsed)
+                                
+                                new_body = json.dumps(parsed).encode("utf-8")
+                                
+                                if b"content-type" in headers and content_type != "application/json":
+                                    new_headers = []
+                                    for name, value in scope.get("headers", []):
+                                        if name != b"content-type":
+                                            new_headers.append((name, value))
+                                    new_headers.append((b"content-type", b"application/json"))
+                                    scope["headers"] = new_headers
+                                
+                                return {
+                                    "type": "http.request",
+                                    "body": new_body,
+                                    "more_body": False
+                                }
+                            except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+                                pass
+                
+                return message
+
+            await self.app(scope, receive_wrapper, send)
+        else:
+            await self.app(scope, receive, send)
 
 
 @asynccontextmanager
@@ -80,6 +142,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Add middleware to handle double-encoded JSON from frontend
+app.add_middleware(DoubleEncodedJSONMiddleware)
 
 # Add authentication middleware (must be added after CORS)
 app.add_middleware(

--- a/src/agent_server/main.py
+++ b/src/agent_server/main.py
@@ -200,4 +200,6 @@ async def root():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=2024)
+    import os
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/src/agent_server/middleware/__init__.py
+++ b/src/agent_server/middleware/__init__.py
@@ -1,0 +1,3 @@
+from .double_encoded_json import DoubleEncodedJSONMiddleware
+
+__all__ = ["DoubleEncodedJSONMiddleware"]

--- a/src/agent_server/middleware/double_encoded_json.py
+++ b/src/agent_server/middleware/double_encoded_json.py
@@ -1,0 +1,69 @@
+import json
+import logging
+from starlette.types import ASGIApp, Receive, Send, Scope
+
+logger = logging.getLogger(__name__)
+
+
+class DoubleEncodedJSONMiddleware:
+    """Middleware to handle double-encoded JSON payloads from frontend.
+    
+    Some frontend clients may send JSON that's been stringified twice,
+    resulting in payloads like '"{\"key\":\"value\"}"' instead of '{"key":"value"}'.
+    This middleware detects and corrects such cases.
+    """
+
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope["method"]
+        headers = dict(scope.get("headers", []))
+        content_type = headers.get(b"content-type", b"").decode("latin1")
+
+        if method in ["POST", "PUT", "PATCH"] and content_type:
+            body_parts = []
+
+            async def receive_wrapper():
+                message = await receive()
+                if message["type"] == "http.request":
+                    body_parts.append(message.get("body", b""))
+
+                    if not message.get("more_body", False):
+                        body = b"".join(body_parts)
+
+                        if body:
+                            try:
+                                decoded = body.decode("utf-8")
+                                parsed = json.loads(decoded)
+
+                                if isinstance(parsed, str):
+                                    parsed = json.loads(parsed)
+
+                                new_body = json.dumps(parsed).encode("utf-8")
+
+                                if b"content-type" in headers and content_type != "application/json":
+                                    new_headers = []
+                                    for name, value in scope.get("headers", []):
+                                        if name != b"content-type":
+                                            new_headers.append((name, value))
+                                    new_headers.append((b"content-type", b"application/json"))
+                                    scope["headers"] = new_headers
+
+                                return {
+                                    "type": "http.request",
+                                    "body": new_body,
+                                    "more_body": False
+                                }
+                            except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+                                pass
+
+                return message
+
+            await self.app(scope, receive_wrapper, send)
+        else:
+            await self.app(scope, receive, send)

--- a/src/agent_server/services/assistant_service.py
+++ b/src/agent_server/services/assistant_service.py
@@ -1,0 +1,611 @@
+"""Service layer for assistant business logic
+
+This service encapsulates all business logic for assistant management, following
+a layered architecture pattern. The code was extracted from api/assistants.py
+to separate concerns and improve maintainability.
+
+Responsibilities:
+- Business logic and validation
+- Database operations via SQLAlchemy ORM
+- Graph schema extraction and manipulation
+- Coordination between different components
+
+This is the first service layer implementation in Aegra. The pattern will be
+applied to other APIs (runs, threads, crons) as part of ongoing refactoring.
+"""
+from uuid import uuid4
+from datetime import datetime, UTC
+from typing import List, Dict, Any, Optional
+import uuid
+from sqlalchemy import select, update, delete, func, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi import Depends, HTTPException
+
+from ..models import Assistant, AssistantCreate, AssistantUpdate
+from ..core.orm import Assistant as AssistantORM, AssistantVersion as AssistantVersionORM, get_session
+from ..services.langgraph_service import LangGraphService, get_langgraph_service
+
+
+def to_pydantic(row: AssistantORM) -> Assistant:
+    """Convert SQLAlchemy ORM object to Pydantic model with proper type casting."""
+    row_dict = {c.name: getattr(row, c.name) for c in row.__table__.columns}
+    # Cast UUIDs to str so they match the Pydantic schema
+    if "assistant_id" in row_dict and row_dict["assistant_id"] is not None:
+        row_dict["assistant_id"] = str(row_dict["assistant_id"])
+    if "user_id" in row_dict and isinstance(row_dict["user_id"], uuid.UUID):
+        row_dict["user_id"] = str(row_dict["user_id"])
+    return Assistant.model_validate(row_dict)
+
+
+def _state_jsonschema(graph) -> dict | None:
+    """Extract state schema from graph channels"""
+    from typing import Any
+    from langgraph._internal._pydantic import create_model
+    
+    fields: dict = {}
+    for k in graph.stream_channels_list:
+        v = graph.channels[k]
+        try:
+            create_model(k, __root__=(v.UpdateType, None)).model_json_schema()
+            fields[k] = (v.UpdateType, None)
+        except Exception:
+            fields[k] = (Any, None)
+    return create_model(graph.get_name("State"), **fields).model_json_schema()
+
+
+def _get_configurable_jsonschema(graph) -> dict:
+    """Get the JSON schema for the configurable part of the graph"""
+    from pydantic import TypeAdapter
+    
+    EXCLUDED_CONFIG_SCHEMA = {"__pregel_resuming", "__pregel_checkpoint_id"}
+    
+    config_schema = graph.config_schema()
+    model_fields = getattr(config_schema, "model_fields", None) or getattr(
+        config_schema, "__fields__", None
+    )
+    
+    if model_fields is not None and "configurable" in model_fields:
+        configurable = TypeAdapter(model_fields["configurable"].annotation)
+        json_schema = configurable.json_schema()
+        if json_schema:
+            for key in EXCLUDED_CONFIG_SCHEMA:
+                json_schema["properties"].pop(key, None)
+        if (
+            hasattr(graph, "config_type")
+            and graph.config_type is not None
+            and hasattr(graph.config_type, "__name__")
+        ):
+            json_schema["title"] = graph.config_type.__name__
+        return json_schema
+    return {}
+
+
+def _extract_graph_schemas(graph) -> dict:
+    """Extract schemas from a compiled LangGraph graph object"""
+    try:
+        input_schema = graph.get_input_jsonschema()
+    except Exception:
+        input_schema = None
+    
+    try:
+        output_schema = graph.get_output_jsonschema()
+    except Exception:
+        output_schema = None
+    
+    try:
+        state_schema = _state_jsonschema(graph)
+    except Exception:
+        state_schema = None
+    
+    try:
+        config_schema = _get_configurable_jsonschema(graph)
+    except Exception:
+        config_schema = None
+    
+    try:
+        context_schema = graph.get_context_jsonschema()
+    except Exception:
+        context_schema = None
+    
+    return {
+        "input_schema": input_schema,
+        "output_schema": output_schema,
+        "state_schema": state_schema,
+        "config_schema": config_schema,
+        "context_schema": context_schema,
+    }
+
+
+class AssistantService:
+    """Service for managing assistants"""
+    
+    def __init__(self, session: AsyncSession, langgraph_service: LangGraphService):
+        self.session = session
+        self.langgraph_service = langgraph_service
+    
+    async def create_assistant(
+        self,
+        request: AssistantCreate,
+        user_identity: str
+    ) -> Assistant:
+        """Create a new assistant"""
+        # Get LangGraph service to validate graph
+        available_graphs = self.langgraph_service.list_graphs()
+        
+        # Use graph_id as the main identifier
+        graph_id = request.graph_id
+        
+        if graph_id not in available_graphs:
+            raise HTTPException(
+                400,
+                f"Graph '{graph_id}' not found in aegra.json. Available: {list(available_graphs.keys())}"
+            )
+        
+        # Validate graph can be loaded
+        try:
+            graph = await self.langgraph_service.get_graph(graph_id)
+        except Exception as e:
+            raise HTTPException(400, f"Failed to load graph: {str(e)}")
+
+        config = request.config
+        context = request.context
+
+        if config.get("configurable") and context:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot specify both configurable and context. Prefer setting context alone. Context was introduced in LangGraph 0.6.0 and is the long term planned replacement for configurable.",
+            )
+
+        # Keep config and context up to date with one another
+        if config.get("configurable"):
+            context = config["configurable"]
+        elif context:
+            config["configurable"] = context
+        
+        # Generate assistant_id if not provided
+        assistant_id = request.assistant_id or str(uuid4())
+        
+        # Generate name if not provided
+        name = request.name or f"Assistant for {graph_id}"
+        
+        # Check if an assistant already exists for this user, graph and config pair
+        existing_stmt = select(AssistantORM).where(
+            AssistantORM.user_id == user_identity,
+            or_(
+                (AssistantORM.graph_id == graph_id) & (AssistantORM.config == config),
+                AssistantORM.assistant_id == assistant_id
+            )
+        )
+        existing = await self.session.scalar(existing_stmt)
+        
+        if existing:
+            if request.if_exists == "do_nothing":
+                return to_pydantic(existing)
+            else:  # error (default)
+                raise HTTPException(409, f"Assistant '{assistant_id}' already exists")
+        
+        # Create assistant record
+        assistant_orm = AssistantORM(
+            assistant_id=assistant_id,
+            name=name,
+            description=request.description,
+            config=config,
+            context=context,
+            graph_id=graph_id,
+            user_id=user_identity,
+            metadata_dict=request.metadata,
+            version=1
+        )
+        
+        self.session.add(assistant_orm)
+        await self.session.commit()
+        await self.session.refresh(assistant_orm)
+
+        # Create initial version record
+        assistant_version_orm = AssistantVersionORM(
+            assistant_id=assistant_id,
+            version=1,
+            graph_id=graph_id,
+            config=config,
+            context=context,
+            created_at=datetime.now(UTC),
+            name=name,
+            description=request.description,
+            metadata_dict=request.metadata
+        )
+        self.session.add(assistant_version_orm)
+        await self.session.commit()
+        
+        return to_pydantic(assistant_orm)
+    
+    async def list_assistants(
+        self,
+        user_identity: str
+    ) -> List[Assistant]:
+        """List user's assistants"""
+        # Filter assistants by user
+        stmt = select(AssistantORM).where(AssistantORM.user_id == user_identity)
+        result = await self.session.scalars(stmt)
+        user_assistants = [to_pydantic(a) for a in result.all()]
+        return user_assistants
+    
+    async def search_assistants(
+        self,
+        request: Any,  # AssistantSearchRequest
+        user_identity: str
+    ) -> List[Assistant]:
+        """Search assistants with filters"""
+        # Start with user's assistants
+        stmt = select(AssistantORM).where(AssistantORM.user_id == user_identity)
+        
+        # Apply filters
+        if request.name:
+            stmt = stmt.where(AssistantORM.name.ilike(f"%{request.name}%"))
+        
+        if request.description:
+            stmt = stmt.where(AssistantORM.description.ilike(f"%{request.description}%"))
+        
+        if request.graph_id:
+            stmt = stmt.where(AssistantORM.graph_id == request.graph_id)
+
+        if request.metadata:
+            stmt = stmt.where(AssistantORM.metadata_dict.op("@>")(request.metadata))
+        
+        # Apply pagination
+        offset = request.offset or 0
+        limit = request.limit or 20
+        stmt = stmt.offset(offset).limit(limit)
+        
+        result = await self.session.scalars(stmt)
+        paginated_assistants = [to_pydantic(a) for a in result.all()]
+        
+        return paginated_assistants
+    
+    async def count_assistants(
+        self,
+        request: Any,  # AssistantSearchRequest
+        user_identity: str
+    ) -> int:
+        """Count assistants with filters"""
+        stmt = select(func.count()).where(AssistantORM.user_id == user_identity)
+
+        if request.name:
+            stmt = stmt.where(AssistantORM.name.ilike(f"%{request.name}%"))
+
+        if request.description:
+            stmt = stmt.where(AssistantORM.description.ilike(f"%{request.description}%"))
+
+        if request.graph_id:
+            stmt = stmt.where(AssistantORM.graph_id == request.graph_id)
+
+        if request.metadata:
+            stmt = stmt.where(AssistantORM.metadata_dict.op("@>")(request.metadata))
+
+        total = await self.session.scalar(stmt)
+        return total or 0
+    
+    async def get_assistant(
+        self,
+        assistant_id: str,
+        user_identity: str
+    ) -> Assistant:
+        """Get assistant by ID"""
+        stmt = select(AssistantORM).where(
+            AssistantORM.assistant_id == assistant_id,
+            or_(
+                AssistantORM.user_id == user_identity,
+                AssistantORM.user_id == "system"
+            )
+        )
+        assistant = await self.session.scalar(stmt)
+        
+        if not assistant:
+            raise HTTPException(404, f"Assistant '{assistant_id}' not found")
+        
+        return to_pydantic(assistant)
+    
+    async def update_assistant(
+        self,
+        assistant_id: str,
+        request: AssistantUpdate,
+        user_identity: str
+    ) -> Assistant:
+        """Update assistant by ID"""
+        metadata = request.metadata or {}
+        config = request.config or {}
+        context = request.context or {}
+
+        if config.get("configurable") and context:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot specify both configurable and context. Use only one.",
+            )
+
+        # Keep config and context up to date with one another
+        if config.get("configurable"):
+            context = config["configurable"]
+        elif context:
+            config["configurable"] = context
+
+        stmt = select(AssistantORM).where(
+            AssistantORM.assistant_id == assistant_id,
+            AssistantORM.user_id == user_identity
+        )
+        assistant = await self.session.scalar(stmt)
+        if not assistant:
+            raise HTTPException(404, f"Assistant '{assistant_id}' not found")
+
+        now = datetime.now(UTC)
+        version_stmt = select(func.max(AssistantVersionORM.version)).where(
+            AssistantVersionORM.assistant_id == assistant_id
+        )
+        max_version = await self.session.scalar(version_stmt)
+        new_version = (max_version or 1) + 1  if max_version is not None else 1
+
+        new_version_details = {
+            "assistant_id": assistant_id,
+            "version": new_version,
+            "graph_id": request.graph_id or assistant.graph_id,
+            "config": config,
+            "context": context,
+            "created_at": now,
+            "name": request.name or assistant.name,
+            "description": request.description or assistant.description,
+            "metadata_dict": metadata
+        }
+
+        assistant_version_orm = AssistantVersionORM(**new_version_details)
+        self.session.add(assistant_version_orm)
+        await self.session.commit()
+
+        assistant_update = update(AssistantORM).where(
+            AssistantORM.assistant_id == assistant_id,
+            AssistantORM.user_id == user_identity
+        ).values(
+            name=new_version_details["name"],
+            description=new_version_details["description"],
+            graph_id=new_version_details["graph_id"],
+            config=new_version_details["config"],
+            context=new_version_details["context"],
+            version=new_version,
+            updated_at=now,
+        )
+        await self.session.execute(assistant_update)
+        await self.session.commit()
+        updated_assistant = await self.session.scalar(stmt)
+        return to_pydantic(updated_assistant)
+    
+    async def delete_assistant(
+        self,
+        assistant_id: str,
+        user_identity: str
+    ) -> dict:
+        """Delete assistant by ID"""
+        stmt = select(AssistantORM).where(
+            AssistantORM.assistant_id == assistant_id,
+            AssistantORM.user_id == user_identity
+        )
+        assistant = await self.session.scalar(stmt)
+        
+        if not assistant:
+            raise HTTPException(404, f"Assistant '{assistant_id}' not found")
+        
+        await self.session.delete(assistant)
+        await self.session.commit()
+
+        return {"status": "deleted"}
+    
+    async def set_assistant_latest(
+        self,
+        assistant_id: str,
+        version: int,
+        user_identity: str
+    ) -> Assistant:
+        """Set the given version as the latest version of an assistant"""
+        stmt = select(AssistantORM).where(
+            AssistantORM.assistant_id == assistant_id,
+            AssistantORM.user_id == user_identity
+        )
+        assistant = await self.session.scalar(stmt)
+        if not assistant:
+            raise HTTPException(404, f"Assistant '{assistant_id}' not found")
+
+        version_stmt = select(AssistantVersionORM).where(
+            AssistantVersionORM.assistant_id == assistant_id,
+            AssistantVersionORM.version == version
+        )
+        assistant_version = await self.session.scalar(version_stmt)
+        if not assistant_version:
+            raise HTTPException(404, f"Version '{version}' for Assistant '{assistant_id}' not found")
+
+        assistant_update = update(AssistantORM).where(
+            AssistantORM.assistant_id == assistant_id,
+            AssistantORM.user_id == user_identity
+        ).values(
+            name=assistant_version.name,
+            description=assistant_version.description,
+            config=assistant_version.config,
+            context=assistant_version.context,
+            graph_id=assistant_version.graph_id,
+            version=version,
+            updated_at=datetime.now(UTC)
+        )
+        await self.session.execute(assistant_update)
+        await self.session.commit()
+        updated_assistant = await self.session.scalar(stmt)
+        return to_pydantic(updated_assistant)
+    
+    async def list_assistant_versions(
+        self,
+        assistant_id: str,
+        user_identity: str
+    ) -> List[Assistant]:
+        """List all versions of an assistant"""
+        stmt = select(AssistantORM).where(
+            AssistantORM.assistant_id == assistant_id,
+            AssistantORM.user_id == user_identity
+        )
+        assistant = await self.session.scalar(stmt)
+        if not assistant:
+            raise HTTPException(404, f"Assistant '{assistant_id}' not found")
+
+        stmt = select(AssistantVersionORM).where(
+            AssistantVersionORM.assistant_id == assistant_id
+        ).order_by(AssistantVersionORM.version.desc())
+        result = await self.session.scalars(stmt)
+        versions = result.all()
+
+        if not versions:
+            raise HTTPException(404, f"No versions found for Assistant '{assistant_id}'")
+
+        # Convert to Pydantic models
+        version_list = [
+            Assistant(
+                assistant_id=assistant_id,
+                name=v.name,
+                description=v.description,
+                config=v.config,
+                context=v.context,
+                graph_id=v.graph_id,
+                user_id=user_identity,
+                version=v.version,
+                created_at=v.created_at,
+                updated_at=v.created_at,
+                metadata_dict=v.metadata_dict
+            ) for v in versions
+        ]
+
+        return version_list
+    
+    async def get_assistant_schemas(
+        self,
+        assistant_id: str,
+        user_identity: str
+    ) -> dict:
+        """Get input, output, state, config and context schemas for an assistant"""
+        stmt = select(AssistantORM).where(
+            AssistantORM.assistant_id == assistant_id,
+            or_(
+                AssistantORM.user_id == user_identity,
+                AssistantORM.user_id == "system"
+            )
+        )
+        assistant = await self.session.scalar(stmt)
+        
+        if not assistant:
+            raise HTTPException(404, f"Assistant '{assistant_id}' not found")
+        
+        try:
+            graph = await self.langgraph_service.get_graph(assistant.graph_id)
+            schemas = _extract_graph_schemas(graph)
+            
+            return {
+                "graph_id": assistant.graph_id,
+                **schemas
+            }
+            
+        except Exception as e:
+            raise HTTPException(400, f"Failed to extract schemas: {str(e)}")
+    
+    async def get_assistant_graph(
+        self,
+        assistant_id: str,
+        xray: str | None,
+        user_identity: str
+    ) -> dict:
+        """Get the graph structure for visualization"""
+        stmt = select(AssistantORM).where(
+            AssistantORM.assistant_id == assistant_id,
+            or_(
+                AssistantORM.user_id == user_identity,
+                AssistantORM.user_id == "system"
+            )
+        )
+        assistant = await self.session.scalar(stmt)
+        
+        if not assistant:
+            raise HTTPException(404, f"Assistant '{assistant_id}' not found")
+        
+        try:
+            graph = await self.langgraph_service.get_graph(assistant.graph_id)
+            
+            xray_value: bool | int = False
+            if xray:
+                if xray in ("true", "True"):
+                    xray_value = True
+                elif xray in ("false", "False"):
+                    xray_value = False
+                else:
+                    try:
+                        xray_value = int(xray)
+                        if xray_value <= 0:
+                            raise HTTPException(422, detail="Invalid xray value")
+                    except ValueError:
+                        raise HTTPException(422, detail="Invalid xray value")
+            
+            try:
+                drawable_graph = await graph.aget_graph(xray=xray_value)
+                json_graph = drawable_graph.to_json()
+                
+                for node in json_graph.get("nodes", []):
+                    if (data := node.get("data")) and isinstance(data, dict):
+                        data.pop("id", None)
+                
+                return json_graph
+            except NotImplementedError:
+                raise HTTPException(422, detail="The graph does not support visualization")
+            
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(400, f"Failed to get graph: {str(e)}")
+    
+    async def get_assistant_subgraphs(
+        self,
+        assistant_id: str,
+        namespace: str | None,
+        recurse: str | None,
+        user_identity: str
+    ) -> dict:
+        """Get subgraphs of an assistant"""
+        stmt = select(AssistantORM).where(
+            AssistantORM.assistant_id == assistant_id,
+            or_(
+                AssistantORM.user_id == user_identity,
+                AssistantORM.user_id == "system"
+            )
+        )
+        assistant = await self.session.scalar(stmt)
+        
+        if not assistant:
+            raise HTTPException(404, f"Assistant '{assistant_id}' not found")
+        
+        try:
+            graph = await self.langgraph_service.get_graph(assistant.graph_id)
+            
+            recurse_value = recurse in ("true", "True") if recurse else False
+            
+            try:
+                subgraphs = {
+                    ns: _extract_graph_schemas(subgraph)
+                    async for ns, subgraph in graph.aget_subgraphs(
+                        namespace=namespace,
+                        recurse=recurse_value
+                    )
+                }
+                return subgraphs
+            except NotImplementedError:
+                raise HTTPException(422, detail="The graph does not support subgraphs")
+            
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(400, f"Failed to get subgraphs: {str(e)}")
+
+
+def get_assistant_service(
+    session: AsyncSession = Depends(get_session),
+    langgraph_service: LangGraphService = Depends(get_langgraph_service)
+) -> AssistantService:
+    """Dependency injection for AssistantService"""
+    return AssistantService(session, langgraph_service)

--- a/src/agent_server/services/streaming_service.py
+++ b/src/agent_server/services/streaming_service.py
@@ -1,19 +1,14 @@
 """Streaming service for orchestrating SSE streaming"""
 import asyncio
 import logging
-from datetime import datetime, UTC
 from typing import Dict, AsyncIterator, Optional, Any
 
-from ..models import Run, User
+from ..models import Run
 from ..core.sse import (
-    create_metadata_event, create_values_event, create_updates_event,
-    create_end_event, create_error_event, create_events_event,
-    create_messages_event, create_state_event, create_logs_event,
-    create_tasks_event, create_subgraphs_event, create_debug_event,
-    create_checkpoints_event, create_custom_event
+    create_metadata_event, create_error_event
 )
+from ..utils import generate_event_id, extract_event_sequence
 from .event_store import event_store, store_sse_event
-from .langgraph_service import get_langgraph_service, create_run_config
 from .broker import broker_manager
 from .event_converter import EventConverter
 
@@ -133,7 +128,7 @@ class StreamingService:
         """Signal that a run was cancelled"""
         counter = self.event_counters.get(run_id, 0) + 1
         self.event_counters[run_id] = counter
-        event_id = f"{run_id}_event_{counter}"
+        event_id = generate_event_id(run_id, counter)
         
         broker = broker_manager.get_or_create_broker(run_id)
         if broker:
@@ -145,7 +140,7 @@ class StreamingService:
         """Signal that a run encountered an error"""
         counter = self.event_counters.get(run_id, 0) + 1
         self.event_counters[run_id] = counter
-        event_id = f"{run_id}_event_{counter}"
+        event_id = generate_event_id(run_id, counter)
         
         broker = broker_manager.get_or_create_broker(run_id)
         if broker:
@@ -155,10 +150,7 @@ class StreamingService:
     
     def _extract_event_sequence(self, event_id: str) -> int:
         """Extract numeric sequence from event_id format: {run_id}_event_{sequence}"""
-        try:
-            return int(event_id.split("_event_")[-1])
-        except (ValueError, IndexError):
-            return 0
+        return extract_event_sequence(event_id)
     
     async def stream_run_execution(
         self, 
@@ -169,9 +161,10 @@ class StreamingService:
         """Stream run execution with unified producer-consumer pattern"""
         run_id = run.run_id
         try:
-            # Send metadata event first
+            # Send metadata event first (sequence 0, not stored)
             if not last_event_id:
-                metadata_event = create_metadata_event(run_id, f"{int(datetime.now(UTC).timestamp() * 1000)}-0")
+                event_id = generate_event_id(run_id, 0)
+                metadata_event = create_metadata_event(run_id, event_id)
                 yield metadata_event
             
             # Replay stored events first

--- a/src/agent_server/services/streaming_service.py
+++ b/src/agent_server/services/streaming_service.py
@@ -1,6 +1,7 @@
 """Streaming service for orchestrating SSE streaming"""
 import asyncio
 import logging
+from datetime import datetime, UTC
 from typing import Dict, AsyncIterator, Optional, Any
 
 from ..models import Run, User
@@ -168,6 +169,11 @@ class StreamingService:
         """Stream run execution with unified producer-consumer pattern"""
         run_id = run.run_id
         try:
+            # Send metadata event first
+            if not last_event_id:
+                metadata_event = create_metadata_event(run_id, f"{int(datetime.now(UTC).timestamp() * 1000)}-0")
+                yield metadata_event
+            
             # Replay stored events first
             last_sent_sequence = 0
             if last_event_id:

--- a/src/agent_server/utils/__init__.py
+++ b/src/agent_server/utils/__init__.py
@@ -1,0 +1,9 @@
+from .sse_utils import (
+    generate_event_id,
+    extract_event_sequence
+)
+
+__all__ = [
+    "generate_event_id",
+    "extract_event_sequence"
+]

--- a/src/agent_server/utils/sse_utils.py
+++ b/src/agent_server/utils/sse_utils.py
@@ -1,0 +1,26 @@
+def generate_event_id(run_id: str, sequence: int) -> str:
+    """Generate SSE event ID in the format: {run_id}_event_{sequence}
+    
+    Args:
+        run_id: The run identifier
+        sequence: The event sequence number
+        
+    Returns:
+        Formatted event ID string
+    """
+    return f"{run_id}_event_{sequence}"
+
+
+def extract_event_sequence(event_id: str) -> int:
+    """Extract numeric sequence from event_id format: {run_id}_event_{sequence}
+    
+    Args:
+        event_id: The event ID string
+        
+    Returns:
+        The sequence number, or 0 if extraction fails
+    """
+    try:
+        return int(event_id.split("_event_")[-1])
+    except (ValueError, IndexError):
+        return 0


### PR DESCRIPTION
## Summary
This PR fixes multiple issues preventing LangSmith Studio from working correctly with Aegra.

## Issues Fixed
Closes #39
Closes #43 - Fix 422 Unprocessable Entity error on `/assistants/search`
Closes #44 - Fix 404 Error when accessing default assistants
Closes #45 - Fix 'No run id' error during streaming
Closes #47 - Fix assistant IDs incompatibility with external tools
Closes #28 - Implement graph endpoints (clarification: `/assistants/{id}/graph` and `/assistants/{id}/subgraphs` are the correct endpoints, not `/graphs`)

## Changes Made

### 1. Double-encoded JSON Middleware (Fixes #43)
- Added `DoubleEncodedJSONMiddleware` to handle `text/plain` payloads from LangSmith Studio
- Automatically detects and decodes double-encoded JSON strings
- Updates Content-Type header to `application/json`

### 2. System Assistants Access (Fixes #44)
- Modified assistant endpoints to allow all users to access assistants with `user_id="system"`
- Applies to: `GET /assistants/{id}`, `/schemas`, `/graph`, `/subgraphs`

### 3. Initial Metadata Event (Fixes #45)
- Added initial `metadata` event to SSE stream containing `run_id` and `attempt`
- Ensures LangSmith Studio can identify and track runs

### 4. Checkpoint Fields in Debug Events (Fixes #46 partially)
- Enhanced debug events to include `checkpoint` and `parent_checkpoint` fields
- Extracted from `config.configurable` for proper execution timeline tracking

### 5. Standard Assistant ID Namespace (Fixes #47)
- Changed UUID namespace from custom to standard (`6ba7b821-9dad-11d1-80b4-00c04fd430c8`)
- Ensures compatibility with external tools
- ⚠️ **Breaking change**: Existing assistant IDs will change

### 6. Graph Endpoints (Fixes #28)
- Implemented `GET /assistants/{id}/graph` - Returns graph structure for visualization
- Implemented `GET /assistants/{id}/subgraphs` - Returns subgraph schemas
- Note: There is no `/graphs` endpoint in LangGraph API - these are the correct endpoints

### 7. Configurable Server Port
- Made server port configurable via `PORT` environment variable (defaults to 8000)

## Testing
- ✅ Verified LangSmith Studio can connect and list assistants
- ✅ Verified system assistants are accessible
- ✅ Verified SSE streaming works with proper metadata
- ✅ Verified graph visualization endpoints work

## Breaking Changes
- Assistant IDs generated from graph IDs will change due to namespace update
- Existing deployments should run a data migration if needed