### PR TITLE
docs: add Hacktoberfest 2025 section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ Replace LangGraph Platform with your own infrastructure. Built with FastAPI + Po
 - **🤝 Human-in-the-Loop Support**: Interactive agent workflows with approval gates and user intervention points
 - **📊 [Langfuse Integration](docs/langfuse-usage.md)**: Complete observability and tracing for your agent runs with automatic metadata capture
 
+## 🎃 Hacktoberfest 2025
+
+Aegra is participating in Hacktoberfest! We welcome **meaningful contributions**.
+
+**What we're looking for:**
+- Feature development and enhancements
+- Bug fixes that improve stability  
+- Substantial documentation improvements
+- Testing and feedback on real use cases
+
+**What we're NOT looking for:**
+- Single typo fixes
+- Whitespace changes  
+- Low-effort PRs for swag hunting
+
+Quality over quantity. If you're here to build something real, we'd love your help.
+
+Check out our [Contributing Guidelines](CONTRIBUTING.md) and [open issues](https://github.com/ibbybuilds/aegra/issues) to get started.
+
 ---
 
 ## 🔥 Why Aegra vs LangGraph Platform?


### PR DESCRIPTION
## 🎃 Hacktoberfest 2025 Setup

This PR adds a dedicated Hacktoberfest section to the README to encourage meaningful contributions.

### Changes
- Added Hacktoberfest 2025 section with contribution guidelines
- Clear expectations for what we're looking for vs. not looking for
- Links to contributing guidelines and open issues

### Purpose
- Prepare the repository for Hacktoberfest participation
- Set clear expectations for contributors
- Encourage quality over quantity contributions

### Checklist
- [x] README updated with Hacktoberfest section
- [x] Clear contribution guidelines added
- [x] Links to relevant resources included