### PR TITLE
hotfix: fix runs.list API to return list[Run] instead of RunList

### DIFF
--- a/tests/e2e/test_assistants/test_assistant_deletion.py
+++ b/tests/e2e/test_assistants/test_assistant_deletion.py
@@ -46,7 +46,7 @@ async def test_assistant_deletion_with_active_runs():
 
     # 5. Verify run is also deleted/cancelled
     runs_list = await client.runs.list(thread_id)
-    assert all(r["assistant_id"] != assistant_id for r in runs_list["runs"]), \
+    assert all(r["assistant_id"] != assistant_id for r in runs_list), \
         "Run should have been deleted/cancelled when assistant was deleted"
 
 
@@ -95,7 +95,7 @@ async def test_assistant_deletion_with_completed_runs():
 
     # 5. Verify run is also deleted
     runs_list = await client.runs.list(thread_id)
-    assert all(r["assistant_id"] != assistant_id for r in runs_list["runs"])
+    assert all(r["assistant_id"] != assistant_id for r in runs_list)
 
 
 @pytest.mark.e2e
@@ -177,4 +177,4 @@ async def test_assistant_deletion_multiple_runs():
 
     # 5. Verify all runs tied to assistant are deleted
     runs_list = await client.runs.list(thread_id)
-    assert all(r["assistant_id"] != assistant_id for r in runs_list["runs"])
+    assert all(r["assistant_id"] != assistant_id for r in runs_list)

--- a/tests/e2e/test_runs/test_runs.py
+++ b/tests/e2e/test_runs/test_runs.py
@@ -61,8 +61,8 @@ async def test_runs_crud_and_join_e2e():
     # 6) List runs for the thread and ensure our run is present
     runs_list = await client.runs.list(thread_id)
     elog("Runs.list", runs_list)
-    assert isinstance(runs_list, dict) and "runs" in runs_list
-    assert any(r["run_id"] == run_id for r in runs_list["runs"])
+    assert isinstance(runs_list, list)
+    assert any(r["run_id"] == run_id for r in runs_list)
 
     # 7) Stream endpoint after completion: should yield an end event quickly.
     # Reuse the SDK join_stream to align with current helper patterns.
@@ -121,8 +121,8 @@ async def test_runs_cancel_e2e():
 
     # Find the most recent run id
     runs_list = await client.runs.list(thread_id)
-    assert "runs" in runs_list and runs_list["runs"], "Expected at least one run for cancellation test"
-    run_id = runs_list["runs"][0]["run_id"]
+    assert len(runs_list) > 0, "Expected at least one run for cancellation test"
+    run_id = runs_list[0]["run_id"]
 
     # Cancel the run
     patched = await client.runs.cancel(thread_id, run_id)

--- a/tests/e2e/test_threads/test_thread_deletion.py
+++ b/tests/e2e/test_threads/test_thread_deletion.py
@@ -42,8 +42,8 @@ async def test_thread_deletion_with_active_runs():
     
     # 3. Verify run exists and is active
     runs_list = await client.runs.list(thread_id)
-    assert len(runs_list["runs"]) >= 1
-    active_run = next(r for r in runs_list["runs"] if r["run_id"] == run_id)
+    assert len(runs_list) >= 1
+    active_run = next(r for r in runs_list if r["run_id"] == run_id)
     assert active_run["status"] in ["pending", "running", "streaming"]
     
     # 4. Delete thread via SDK - should work seamlessly
@@ -127,7 +127,7 @@ async def test_thread_deletion_empty_thread():
     
     # 2. Verify no runs exist
     runs_list = await client.runs.list(thread_id)
-    assert len(runs_list["runs"]) == 0
+    assert len(runs_list) == 0
     
     # 3. Delete thread via SDK
     await client.threads.delete(thread_id)
@@ -182,7 +182,7 @@ async def test_thread_deletion_multiple_runs():
     
     # 3. Verify multiple runs exist
     runs_list = await client.runs.list(thread_id)
-    assert len(runs_list["runs"]) >= 2
+    assert len(runs_list) >= 2
     
     # 4. Delete thread via SDK - should cancel all runs and delete thread
     await client.threads.delete(thread_id)


### PR DESCRIPTION
## Hotfix: Fix runs.list API Response Format

**Problem:**
Tests failing with `TypeError: list indices must be integers or slices, not str` because API returns `RunList` dict but tests expect `list[Run]`.

**Solution:**
- Remove `RunList` model from `models/runs.py`
- Remove `RunList` import from `models/__init__.py`
- Change API return type from `RunList` to `list[Run]`
- Update all tests to expect list instead of dict with 'runs' key

**Files Changed:**
- `src/agent_server/models/runs.py` - Removed RunList model
- `src/agent_server/models/__init__.py` - Removed RunList export
- `src/agent_server/api/runs.py` - Changed return type to list[Run]
- `tests/e2e/test_assistants/test_assistant_deletion.py` - Updated assertions
- `tests/e2e/test_runs/test_runs.py` - Updated assertions  
- `tests/e2e/test_threads/test_thread_deletion.py` - Updated assertions

**Testing:**
- All tests should now pass with the corrected API response format
- Maintains compatibility with LangGraph SDK expectations