### PR TITLE
fix: update Codecov configuration for proper project coverage reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,22 +1,16 @@
 coverage:
   status:
+    # Fail PRs that reduce total coverage by more than 2%
     project:
       default:
         target: auto
-        threshold: 0%
-        base: auto
+        threshold: 2%
+    # Treat patch coverage as informational only
     patch:
       default:
-        target: auto
-        threshold: 0%
-        base: auto
+        informational: true
 
 comment:
-  layout: "diff, flags, files"
-  behavior: default
-  require_changes: false
-  require_base: false
-  require_head: true
   hide_project_coverage: false
 
 # When modifying this file, please validate using


### PR DESCRIPTION
## Changes
- Set project coverage threshold to 2% (fail PRs that reduce coverage by more than 2%)
- Make patch coverage informational only
- Simplify configuration to focus on project coverage reporting

## Expected Outcome
After merging this PR, future PRs should show:
- ✅ Project coverage percentage and comparison
- ✅ Patch coverage as informational
- ✅ File-by-file breakdown with missing lines
- ✅ Coverage deltas (improvements/regressions)

This replaces the basic 'All modified and coverable lines are covered by tests' message with detailed analysis.