### PR TITLE
fix: fix the langsmith studio issue

### DIFF
--- a/src/agent_server/utils/run_utils.py
+++ b/src/agent_server/utils/run_utils.py
@@ -1,6 +1,10 @@
 import copy
 from typing import Any
 
+import structlog
+
+logger = structlog.getLogger(__name__)
+
 
 def _should_skip_event(raw_event: Any) -> bool:
     """Check if an event should be skipped based on langsmith:nostream tag"""
@@ -29,3 +33,30 @@ def _merge_jsonb(*objects: dict) -> dict:
         if obj is not None:
             result.update(copy.deepcopy(obj))
     return result
+
+
+async def _filter_context_by_schema(
+    context: dict[str, Any], context_schema: dict | None
+) -> dict[str, Any]:
+    """Filter context parameters based on the context schema."""
+    if not context_schema or not context:
+        return context
+
+    # Extract valid properties from the schema
+    properties = context_schema.get("properties", {})
+    if not properties:
+        return context
+
+    # Filter context to only include parameters defined in the schema
+    filtered_context = {}
+    for key, value in context.items():
+        if key in properties:
+            filtered_context[key] = value
+        else:
+            await logger.adebug(
+                f"Filtering out context parameter '{key}' not found in context schema",
+                context_key=key,
+                available_keys=list(properties.keys()),
+            )
+
+    return filtered_context

--- a/tests/integration/test_services/test_langgraph_service_integration.py
+++ b/tests/integration/test_services/test_langgraph_service_integration.py
@@ -6,8 +6,15 @@ from tempfile import TemporaryDirectory
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from langgraph.graph import StateGraph
 
 from agent_server.services.langgraph_service import LangGraphService
+
+
+class DummyStateGraph(StateGraph):
+    def __init__(self):
+        # avoid heavy init
+        pass
 
 
 class TestLangGraphServiceRealFiles:
@@ -116,7 +123,7 @@ class TestLangGraphServiceDatabase:
             "db_graph": {"file_path": "./graphs/db.py", "export_name": "graph"}
         }
 
-        mock_graph = Mock()
+        mock_graph = DummyStateGraph()
         mock_compiled_graph = Mock()
 
         with (
@@ -297,7 +304,7 @@ class TestLangGraphServiceErrorHandling:
             }
         }
 
-        mock_graph = Mock()
+        mock_graph = DummyStateGraph()
         mock_graph.compile = Mock(side_effect=Exception("Compilation error"))
 
         with (
@@ -352,7 +359,7 @@ class TestLangGraphServiceConcurrency:
             }
         }
 
-        mock_graph = Mock()
+        mock_graph = DummyStateGraph()
         mock_compiled_graph = Mock()
 
         with (


### PR DESCRIPTION
Changed return type of langgraph_service.get_graph to Pregal and added filtering for context based on context schema

## Description
<!-- Provide a clear description of your changes -->
Changed the return type of langgraph_service.get_graph to Pregal, which will improve intellisense which using graphs.
Added filtering to the context before running/invoking the graph, since langsmith studio provides thread_id to the context which needs to be removed from context.

## Type of Change
<!-- Check the relevant option -->
- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [x] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->

## Changes Made
<!-- List the main changes -->
- Replaced return type of LanggraphService.get_graph() from StateGraph to Pregal.
- Replaced `if hasattr(base_graph, "compile"):` with `if isinstance(base_graph, StateGraph):`
- Implemented context filtering based on context schema to remove unnecessary keys from context before invoking the agent. 

## Testing
<!-- Describe how you tested your changes -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist
<!-- Ensure all items are checked before requesting review -->
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Notes
<!-- Any additional information for reviewers -->
