### PR TITLE
feat(api): add threadId and ifExists parameters for idempotent thread creation

### DIFF
--- a/src/agent_server/models/threads.py
+++ b/src/agent_server/models/threads.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ..utils.status_compat import validate_thread_status
 
@@ -11,9 +11,21 @@ from ..utils.status_compat import validate_thread_status
 class ThreadCreate(BaseModel):
     """Request model for creating threads"""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     metadata: dict[str, Any] | None = Field(None, description="Thread metadata")
     initial_state: dict[str, Any] | None = Field(
         None, description="LangGraph initial state"
+    )
+    thread_id: str | None = Field(
+        None,
+        alias="threadId",
+        description="Optional client-provided thread ID for idempotent creation",
+    )
+    if_exists: str | None = Field(
+        "raise",
+        alias="ifExists",
+        description="Behavior when thread exists: 'raise' (default) or 'do_nothing'",
     )
 
 


### PR DESCRIPTION
## Summary

Add LangGraph SDK compatibility for idempotent thread creation:

- **threadId**: Optional client-provided thread ID (auto-generated if not provided)
- **ifExists**: Behavior when thread already exists:
  - `raise` (default): Returns 409 Conflict
  - `do_nothing`: Returns existing thread without modification

This enables idempotent thread creation patterns used by LangGraph clients, matching the existing pattern used for assistant creation.

## Changes

- `src/agent_server/models/threads.py`: Added `thread_id` and `if_exists` fields to `ThreadCreate` model with camelCase aliases for SDK compatibility
- `src/agent_server/api/threads.py`: Updated `create_thread` endpoint with existence check and conflict handling
- `tests/integration/test_api/test_threads_crud.py`: Added 5 new test cases covering all scenarios

## Test Plan

- [x] `test_create_thread_with_custom_id` - Create with client-provided ID
- [x] `test_create_thread_with_custom_id_snake_case` - Verify both camelCase and snake_case work
- [x] `test_create_thread_if_exists_do_nothing` - Return existing thread when duplicate
- [x] `test_create_thread_if_exists_raise` - Return 409 on duplicate (default)
- [x] `test_create_thread_if_exists_raise_explicit` - Explicit `raise` behavior

All tests pass: `pytest tests/integration/test_api/test_threads_crud.py::TestCreateThread -v`

## Backward Compatibility

- Fully backward compatible - existing clients work unchanged (auto-generated IDs)
- Uses camelCase aliases matching LangGraph SDK conventions
- Follows existing `if_exists` pattern from assistant creation