### PR TITLE
feat(tasks): implement startup tasks

### DIFF
--- a/aegra.json
+++ b/aegra.json
@@ -7,5 +7,19 @@
   },
   "http": {
     "app": "./custom_routes_example.py:app"
+  },
+  "startup": {
+    "warm_cache": {
+      "path": "./startup_tasks_example.py:warmup_cache",
+      "blocking": true
+    },
+    "webhook": {
+      "path": "./startup_tasks_example.py:call_webhook",
+      "blocking": false
+    },
+    "periodic": {
+      "path": "./startup_tasks_example.py:periodic_task",
+      "blocking": false
+    }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - ./alembic:/app/alembic:ro # for migrations
       # Mount custom route files dynamically (add your custom routes file here)
       - ./custom_routes_example.py:/app/custom_routes_example.py:ro
+      # Mount startup tasks files here
+      - ./startup_tasks_example.py:/app/startup_tasks_example.py:ro
     command: >
       sh -c "
         echo 'Running database migrations...' &&

--- a/src/agent_server/main.py
+++ b/src/agent_server/main.py
@@ -86,6 +86,11 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # Stop event store cleanup task
     await event_store.stop_cleanup_task()
 
+    # Cancel tasks that might still be running from startup launch
+    for task in langgraph_service.get_running_tasks().values():
+        if not task.done():
+            task.cancel()
+
     await db_manager.close()
 
 

--- a/startup_tasks_example.py
+++ b/startup_tasks_example.py
@@ -1,0 +1,53 @@
+import asyncio
+import textwrap
+
+import httpx
+import structlog
+
+
+async def warmup_cache():
+    """
+    Blocking Task Example Usage
+
+    These tasks should be used to perform actions which need to be completed before deploying other langgraph services (e.g. sql cache warming, building lookup indices, fetching configurations, ...)
+    """
+    logger = structlog.get_logger(__name__)
+    logger.info(
+        "🕑 Simulating cache warming for a few seconds... Server won't start until this is done"
+    )
+    await asyncio.sleep(5)
+    logger.info("✅ Cache warming simulation done !")
+
+
+async def call_webhook():
+    """
+    Non-blocking Task Example Usage
+
+    These tasks should be used to perform actions whose completion isn't required to provide proper services (e.g. setup additional features, webhook calls, periodic tasks, ...)
+    """
+    logger = structlog.get_logger(__name__)
+    endpoint = "https://example.com/"
+    logger.info(f"🌐 Requesting webpage at {endpoint}")
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(endpoint)
+        logger.info(
+            f"➡️ Data received from {endpoint}...",
+            data=textwrap.shorten(text=resp.text, width=50),
+        )
+
+    except httpx.RequestError as e:
+        logger.error("❌ Request error in startup hook: " + str(e))
+
+
+async def periodic_task():
+    """
+    Another Non-blocking Task Example : Periodic tasks
+    """
+    logger = structlog.get_logger(__name__)
+    loops, max_loops = 0, 10
+
+    while loops < max_loops:
+        loops += 1
+        logger.info(f"🔄️ Periodic Task Loop Count : {loops}/{max_loops}")
+        await asyncio.sleep(3)


### PR DESCRIPTION
## Description
Added new features : startup tasks.
These can be defined inside a `startup` configuration field as follows:

```json
{
  "graphs": {
    "agent": "./graphs/react_agent/graph.py:graph"
  },
  "http": {
    "app": "./custom_routes_example.py:app"
  },
  "startup": {
    "warm_cache": {
      "path": "./startup_tasks_example.py:warmup_cache",
      "blocking": true
    },
    "webhook": {
      "path": "./startup_tasks_example.py:call_webhook",
      "blocking": false
    },
    "periodic": {
      "path": "./startup_tasks_example.py:periodic_task",
      "blocking": false
    }
  }
}
```

_fire_startup_tasks and _fire_task_from_file follow existing project styles.
Blocking tasks are awaited in _fire_task_from_file. Non-blocking tasks are ran as coroutines in spawn tasks.

## Type of Change
<!-- Check the relevant option -->
- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->
Closes #116 

## Changes Made
<!-- List the main changes -->
- New configuration field: `startup`
- Additional step in LangGraphService's ``intialize()`` to fire tasks
- Additional step in FastAPI's lifespan to cleanup non-blocking tasks that may still be running
- New unit tests to ensure individual features work as expected
- New integration tests to validate the expected behaviour under different setting files conditions

## Testing
<!-- Describe how you tested your changes -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist
<!-- Ensure all items are checked before requesting review -->
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Notes for reviewers

Pydantic models could be used to automatically validate config elements and clean up manual boilerplate checks