### PR TITLE
fix(api): add missing updated_at field to Thread response model

### DIFF
--- a/src/agent_server/api/threads.py
+++ b/src/agent_server/api/threads.py
@@ -147,12 +147,17 @@ async def create_thread(
     if not isinstance(coerced_created_at, datetime):
         coerced_created_at = datetime.now(UTC)
 
+    coerced_updated_at = getattr(thread_orm, "updated_at", None)
+    if not isinstance(coerced_updated_at, datetime):
+        coerced_updated_at = datetime.now(UTC)
+
     thread_dict: dict[str, Any] = {
         "thread_id": coerced_thread_id,
         "status": coerced_status,
         "metadata": coerced_metadata,
         "user_id": coerced_user_id,
         "created_at": coerced_created_at,
+        "updated_at": coerced_updated_at,
     }
 
     return Thread.model_validate(thread_dict)

--- a/src/agent_server/models/threads.py
+++ b/src/agent_server/models/threads.py
@@ -48,6 +48,7 @@ class Thread(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     user_id: str
     created_at: datetime
+    updated_at: datetime
 
     @field_validator("status", mode="before")
     @classmethod

--- a/tests/unit/test_models/test_thread_status_validation.py
+++ b/tests/unit/test_models/test_thread_status_validation.py
@@ -20,6 +20,7 @@ class TestThreadStatusValidation:
                 metadata={},
                 user_id="test-user",
                 created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
             )
             assert thread.status == status
 
@@ -32,6 +33,7 @@ class TestThreadStatusValidation:
                 metadata={},
                 user_id="test-user",
                 created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
             )
 
     def test_thread_rejects_non_string_status(self):
@@ -43,6 +45,7 @@ class TestThreadStatusValidation:
                 metadata={},
                 user_id="test-user",
                 created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
             )
 
     def test_thread_from_orm_with_standard_status(self):
@@ -55,6 +58,7 @@ class TestThreadStatusValidation:
             metadata_json = {}
             user_id = "test-user"
             created_at = datetime.now(UTC)
+            updated_at = datetime.now(UTC)
 
         thread = Thread.model_validate(MockORM())
         assert thread.status == "busy"


### PR DESCRIPTION
## Problem

The `Thread` Pydantic response model is missing the `updated_at` field, even though:
- The ORM model has it (`core/orm.py:107-109`)
- The database stores it with a default value
- The LangGraph SDK expects it in thread responses

This causes downstream consumers to receive `null` for `updated_at`, breaking integrations that require this timestamp.

**Error observed:**
```
Cannot return null for non-nullable field AnalysisStatus.updatedAt
```

## Solution

Add `updated_at: datetime` to the `Thread` Pydantic model in `models/threads.py`.

## Testing

- Verified ORM has the field
- Verified model imports correctly with new field
- Thread GET responses will now include `updated_at`