### PR TITLE
test: add comprehensive tests for /api/runs and streaming_service

### DIFF
--- a/tests/unit/test_api/test_runs.py
+++ b/tests/unit/test_api/test_runs.py
@@ -17,18 +17,18 @@ class TestRunsEndpoints:
     """Test standard run endpoints."""
 
     @pytest.fixture
-    def mock_user(self):
+    def mock_user(self) -> User:
         return User(identity="test-user", scopes=[])
 
     @pytest.fixture
-    def mock_session(self):
+    def mock_session(self) -> AsyncMock:
         session = AsyncMock()
         session.refresh = AsyncMock()
         session.add = MagicMock()  # session.add is synchronous
         return session
 
     @pytest.fixture
-    def sample_assistant(self):
+    def sample_assistant(self) -> AssistantORM:
         return AssistantORM(
             assistant_id="test-assistant",
             graph_id="test-graph",
@@ -39,7 +39,9 @@ class TestRunsEndpoints:
         )
 
     @pytest.mark.asyncio
-    async def test_create_run_success(self, mock_user, mock_session, sample_assistant):
+    async def test_create_run_success(
+        self, mock_user: User, mock_session: AsyncMock, sample_assistant: AssistantORM
+    ) -> None:
         """Test successful run creation."""
         thread_id = "test-thread-123"
         run_id = str(uuid4())
@@ -67,9 +69,7 @@ class TestRunsEndpoints:
             patch("agent_server.api.runs.uuid4", return_value=run_id),
             patch("agent_server.api.runs.asyncio.create_task") as mock_create_task,
             patch("agent_server.api.runs.active_runs", {}),
-            patch(
-                "agent_server.api.runs.execute_run_async", new_callable=MagicMock
-            ),
+            patch("agent_server.api.runs.execute_run_async", new_callable=MagicMock),
         ):
             mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
 
@@ -93,7 +93,9 @@ class TestRunsEndpoints:
             mock_create_task.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_create_run_assistant_not_found(self, mock_user, mock_session):
+    async def test_create_run_assistant_not_found(
+        self, mock_user: User, mock_session: AsyncMock
+    ) -> None:
         """Test creation with non-existent assistant."""
         thread_id = "test-thread-123"
         request = RunCreate(assistant_id="nonexistent", input={})
@@ -122,8 +124,8 @@ class TestRunsEndpoints:
 
     @pytest.mark.asyncio
     async def test_create_run_graph_not_found(
-        self, mock_user, mock_session, sample_assistant
-    ):
+        self, mock_user: User, mock_session: AsyncMock, sample_assistant: AssistantORM
+    ) -> None:
         """Test creation where assistant's graph is missing."""
         thread_id = "test-thread-123"
         request = RunCreate(assistant_id="test-assistant", input={})
@@ -150,7 +152,9 @@ class TestRunsEndpoints:
             assert "Graph" in str(exc.value.detail)
 
     @pytest.mark.asyncio
-    async def test_create_run_config_context_conflict(self, mock_user, mock_session):
+    async def test_create_run_config_context_conflict(
+        self, mock_user: User, mock_session: AsyncMock
+    ) -> None:
         """Test validation error when both configurable and context are provided."""
         thread_id = "test-thread-123"
         request = RunCreate(
@@ -181,7 +185,9 @@ class TestRunsEndpoints:
             )
 
     @pytest.mark.asyncio
-    async def test_get_run_success(self, mock_user, mock_session):
+    async def test_get_run_success(
+        self, mock_user: User, mock_session: AsyncMock
+    ) -> None:
         """Test retrieving an existing run."""
         thread_id = "test-thread"
         run_id = "run-123"
@@ -206,7 +212,9 @@ class TestRunsEndpoints:
         mock_session.refresh.assert_called_once_with(run_orm)
 
     @pytest.mark.asyncio
-    async def test_get_run_not_found(self, mock_user, mock_session):
+    async def test_get_run_not_found(
+        self, mock_user: User, mock_session: AsyncMock
+    ) -> None:
         """Test retrieving non-existent run."""
         mock_session.scalar.return_value = None
 
@@ -217,7 +225,9 @@ class TestRunsEndpoints:
         assert "Run" in str(exc.value.detail)
 
     @pytest.mark.asyncio
-    async def test_list_runs_success(self, mock_user, mock_session):
+    async def test_list_runs_success(
+        self, mock_user: User, mock_session: AsyncMock
+    ) -> None:
         """Test listing runs."""
         thread_id = "test-thread"
 
@@ -252,7 +262,9 @@ class TestRunsEndpoints:
         assert result[0].run_id == "run-0"
 
     @pytest.mark.asyncio
-    async def test_update_run_cancel(self, mock_user, mock_session):
+    async def test_update_run_cancel(
+        self, mock_user: User, mock_session: AsyncMock
+    ) -> None:
         """Test cancelling a run."""
         thread_id = "test-thread"
         run_id = "run-123"
@@ -289,7 +301,9 @@ class TestRunsEndpoints:
             assert result.run_id == run_id
 
     @pytest.mark.asyncio
-    async def test_update_run_not_found(self, mock_user, mock_session):
+    async def test_update_run_not_found(
+        self, mock_user: User, mock_session: AsyncMock
+    ) -> None:
         """Test updating non-existent run."""
         mock_session.scalar.return_value = None
 
@@ -305,7 +319,9 @@ class TestRunsEndpoints:
         assert exc.value.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_join_run_terminal_state(self, mock_user, mock_session):
+    async def test_join_run_terminal_state(
+        self, mock_user: User, mock_session: AsyncMock
+    ) -> None:
         """Test joining a completed run returns output immediately."""
         run_orm = RunORM(
             run_id="run-1",
@@ -324,7 +340,9 @@ class TestRunsEndpoints:
         assert result == {"result": "done"}
 
     @pytest.mark.asyncio
-    async def test_join_run_active_state(self, mock_user, mock_session):
+    async def test_join_run_active_state(
+        self, mock_user: User, mock_session: AsyncMock
+    ) -> None:
         """Test joining an active run waits for completion."""
         # Setup run initially in running state
         run_orm_running = RunORM(

--- a/tests/unit/test_api/test_runs_wait.py
+++ b/tests/unit/test_api/test_runs_wait.py
@@ -18,7 +18,7 @@ class TestWaitForRunExceptionPaths:
     """Test exception handling and edge cases in wait_for_run endpoint."""
 
     @pytest.mark.asyncio
-    async def test_wait_for_run_timeout(self):
+    async def test_wait_for_run_timeout(self) -> None:
         """Test that TimeoutError is handled gracefully and returns current state."""
         # Setup mocks
         thread_id = "test-thread-123"
@@ -110,7 +110,7 @@ class TestWaitForRunExceptionPaths:
             assert mock_wait_for.called
 
     @pytest.mark.asyncio
-    async def test_wait_for_run_cancelled(self):
+    async def test_wait_for_run_cancelled(self) -> None:
         """Test that CancelledError is handled gracefully."""
         thread_id = "test-thread-123"
         run_id = str(uuid4())
@@ -189,7 +189,7 @@ class TestWaitForRunExceptionPaths:
             assert mock_wait_for.called
 
     @pytest.mark.asyncio
-    async def test_wait_for_run_generic_exception(self):
+    async def test_wait_for_run_generic_exception(self) -> None:
         """Test that generic Exception is handled gracefully."""
         thread_id = "test-thread-123"
         run_id = str(uuid4())
@@ -268,7 +268,7 @@ class TestWaitForRunExceptionPaths:
             assert mock_wait_for.called
 
     @pytest.mark.asyncio
-    async def test_wait_for_run_disappeared(self):
+    async def test_wait_for_run_disappeared(self) -> None:
         """Test that HTTPException 500 is raised if run disappears during execution."""
         thread_id = "test-thread-123"
         run_id = str(uuid4())
@@ -334,7 +334,7 @@ class TestWaitForRunExceptionPaths:
             assert "disappeared during execution" in exc_info.value.detail
 
     @pytest.mark.asyncio
-    async def test_wait_for_run_failed_status(self):
+    async def test_wait_for_run_failed_status(self) -> None:
         """Test that failed runs return output and log error."""
         thread_id = "test-thread-123"
         run_id = str(uuid4())
@@ -415,7 +415,7 @@ class TestWaitForRunExceptionPaths:
             mock_logger.error.assert_called()
 
     @pytest.mark.asyncio
-    async def test_wait_for_run_interrupted_status(self):
+    async def test_wait_for_run_interrupted_status(self) -> None:
         """Test that interrupted runs return partial output."""
         thread_id = "test-thread-123"
         run_id = str(uuid4())
@@ -493,7 +493,7 @@ class TestWaitForRunExceptionPaths:
             assert result == {"partial": "result", "__interrupt__": [{"value": "test"}]}
 
     @pytest.mark.asyncio
-    async def test_wait_for_run_cancelled_status(self):
+    async def test_wait_for_run_cancelled_status(self) -> None:
         """Test that cancelled runs return empty output."""
         thread_id = "test-thread-123"
         run_id = str(uuid4())
@@ -571,7 +571,7 @@ class TestWaitForRunExceptionPaths:
             assert result == {}
 
     @pytest.mark.asyncio
-    async def test_wait_for_run_graph_not_found(self):
+    async def test_wait_for_run_graph_not_found(self) -> None:
         """Test that HTTPException 404 is raised if assistant's graph doesn't exist."""
         thread_id = "test-thread-123"
         user = User(identity="test-user", scopes=[])
@@ -628,7 +628,7 @@ class TestWaitForRunExceptionPaths:
             assert "not found" in exc_info.value.detail
 
     @pytest.mark.asyncio
-    async def test_wait_for_run_with_context_branch(self):
+    async def test_wait_for_run_with_context_branch(self) -> None:
         """Test the context branch where context is provided."""
         thread_id = "test-thread-123"
         run_id = str(uuid4())
@@ -706,7 +706,7 @@ class TestWaitForRunExceptionPaths:
             assert result == {"result": "success"}
 
     @pytest.mark.asyncio
-    async def test_wait_for_run_without_context_branch(self):
+    async def test_wait_for_run_without_context_branch(self) -> None:
         """Test the else branch where context is not provided."""
         thread_id = "test-thread-123"
         run_id = str(uuid4())

--- a/tests/unit/test_services/test_assistant_service.py
+++ b/tests/unit/test_services/test_assistant_service.py
@@ -5,7 +5,9 @@ All external dependencies (database, LangGraph) are mocked.
 """
 
 import uuid
+from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -16,7 +18,7 @@ from agent_server.services.assistant_service import AssistantService, to_pydanti
 
 
 @pytest.fixture
-def mock_session():
+def mock_session() -> AsyncMock:
     """Mock AsyncSession for testing"""
     session = AsyncMock()
     session.add = Mock()  # session.add is synchronous
@@ -24,7 +26,7 @@ def mock_session():
 
 
 @pytest.fixture
-def mock_langgraph_service():
+def mock_langgraph_service() -> Mock:
     """Mock LangGraphService for testing"""
     mock_service = Mock()
     mock_service.list_graphs.return_value = {"test-graph": {}}
@@ -33,13 +35,15 @@ def mock_langgraph_service():
 
 
 @pytest.fixture
-def assistant_service(mock_session, mock_langgraph_service):
+def assistant_service(
+    mock_session: AsyncMock, mock_langgraph_service: Mock
+) -> AssistantService:
     """AssistantService instance with mocked dependencies"""
     return AssistantService(mock_session, mock_langgraph_service)
 
 
 @pytest.fixture
-def sample_assistant_create():
+def sample_assistant_create() -> AssistantCreate:
     """Sample AssistantCreate request for testing"""
     return AssistantCreate(
         name="Test Assistant",
@@ -52,7 +56,7 @@ def sample_assistant_create():
 
 
 @pytest.fixture
-def sample_assistant_update():
+def sample_assistant_update() -> AssistantUpdate:
     """Sample AssistantUpdate request for testing"""
     return AssistantUpdate(
         name="Updated Assistant",
@@ -65,7 +69,7 @@ def sample_assistant_update():
 class TestToPydantic:
     """Test ORM to Pydantic conversion logic"""
 
-    def test_to_pydantic_basic_conversion(self):
+    def test_to_pydantic_basic_conversion(self) -> None:
         """Test basic ORM to Pydantic conversion"""
         # Create mock ORM object
         mock_orm = Mock()
@@ -126,7 +130,7 @@ class TestToPydantic:
         assert isinstance(result.assistant_id, str)
         assert isinstance(result.user_id, str)
 
-    def test_to_pydantic_uuid_conversion(self):
+    def test_to_pydantic_uuid_conversion(self) -> None:
         """Test UUID to string conversion"""
         mock_orm = Mock()
         mock_table = Mock()
@@ -181,7 +185,7 @@ class TestToPydantic:
         assert result.assistant_id == str(test_uuid)
         assert result.user_id == str(test_uuid)
 
-    def test_to_pydantic_none_values(self):
+    def test_to_pydantic_none_values(self) -> None:
         """Test handling of None values"""
         mock_orm = Mock()
         mock_table = Mock()
@@ -241,8 +245,10 @@ class TestAssistantServiceCreate:
 
     @pytest.mark.asyncio
     async def test_create_assistant_graph_validation_success(
-        self, assistant_service, sample_assistant_create
-    ):
+        self,
+        assistant_service: AssistantService,
+        sample_assistant_create: AssistantCreate,
+    ) -> None:
         """Test successful graph validation"""
         # Setup mocks
         assistant_service.langgraph_service.list_graphs.return_value = {
@@ -269,7 +275,7 @@ class TestAssistantServiceCreate:
         assistant_service.session.commit = AsyncMock()
 
         # Mock refresh to populate the mock object with attributes
-        def mock_refresh(obj):
+        def mock_refresh(obj: Mock) -> None:
             obj.assistant_id = "test-id"
             obj.name = "Test Assistant"
             obj.description = "Test description"
@@ -296,8 +302,10 @@ class TestAssistantServiceCreate:
 
     @pytest.mark.asyncio
     async def test_create_assistant_graph_not_found(
-        self, assistant_service, sample_assistant_create
-    ):
+        self,
+        assistant_service: AssistantService,
+        sample_assistant_create: AssistantCreate,
+    ) -> None:
         """Test graph not found error"""
         assistant_service.langgraph_service.list_graphs.return_value = {
             "other-graph": {}
@@ -313,8 +321,10 @@ class TestAssistantServiceCreate:
 
     @pytest.mark.asyncio
     async def test_create_assistant_graph_load_failure(
-        self, assistant_service, sample_assistant_create
-    ):
+        self,
+        assistant_service: AssistantService,
+        sample_assistant_create: AssistantCreate,
+    ) -> None:
         """Test graph loading failure"""
         assistant_service.langgraph_service.list_graphs.return_value = {
             "test-graph": {}
@@ -332,7 +342,9 @@ class TestAssistantServiceCreate:
         assert "Failed to load graph" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    async def test_create_assistant_config_context_conflict(self, assistant_service):
+    async def test_create_assistant_config_context_conflict(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test config and context conflict validation"""
         request = AssistantCreate(
             graph_id="test-graph",
@@ -355,8 +367,8 @@ class TestAssistantServiceCreate:
 
     @pytest.mark.asyncio
     async def test_create_assistant_config_context_sync_from_config(
-        self, assistant_service
-    ):
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test config to context synchronization"""
         request = AssistantCreate(
             graph_id="test-graph",
@@ -373,7 +385,7 @@ class TestAssistantServiceCreate:
         assistant_service.session.commit = AsyncMock()
 
         # Mock refresh to populate the mock object with attributes
-        def mock_refresh(obj):
+        def mock_refresh(obj: Mock) -> None:
             obj.assistant_id = "test-id"
             obj.name = "Test Assistant"
             obj.description = "Test description"
@@ -395,8 +407,8 @@ class TestAssistantServiceCreate:
 
     @pytest.mark.asyncio
     async def test_create_assistant_config_context_sync_from_context(
-        self, assistant_service
-    ):
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test context to config synchronization"""
         request = AssistantCreate(
             graph_id="test-graph",
@@ -413,7 +425,7 @@ class TestAssistantServiceCreate:
         assistant_service.session.commit = AsyncMock()
 
         # Mock refresh to populate the mock object with attributes
-        def mock_refresh(obj):
+        def mock_refresh(obj: Mock) -> None:
             obj.assistant_id = "test-id"
             obj.name = "Test Assistant"
             obj.description = "Test description"
@@ -435,8 +447,10 @@ class TestAssistantServiceCreate:
 
     @pytest.mark.asyncio
     async def test_create_assistant_duplicate_handling_do_nothing(
-        self, assistant_service, sample_assistant_create
-    ):
+        self,
+        assistant_service: AssistantService,
+        sample_assistant_create: AssistantCreate,
+    ) -> None:
         """Test duplicate assistant handling with do_nothing policy"""
         request = AssistantCreate(
             graph_id="test-graph",
@@ -476,8 +490,10 @@ class TestAssistantServiceCreate:
 
     @pytest.mark.asyncio
     async def test_create_assistant_duplicate_handling_error(
-        self, assistant_service, sample_assistant_create
-    ):
+        self,
+        assistant_service: AssistantService,
+        sample_assistant_create: AssistantCreate,
+    ) -> None:
         """Test duplicate assistant handling with error policy"""
         request = AssistantCreate(
             graph_id="test-graph",
@@ -505,7 +521,9 @@ class TestAssistantServiceGet:
     """Test assistant retrieval business logic"""
 
     @pytest.mark.asyncio
-    async def test_get_assistant_success(self, assistant_service):
+    async def test_get_assistant_success(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test successful assistant retrieval"""
         # Mock assistant from database
         mock_assistant = Mock()
@@ -540,7 +558,9 @@ class TestAssistantServiceGet:
         assert result.name == "Test Assistant"
 
     @pytest.mark.asyncio
-    async def test_get_assistant_not_found(self, assistant_service):
+    async def test_get_assistant_not_found(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test assistant not found error"""
         assistant_service.session.scalar.return_value = None
 
@@ -551,7 +571,9 @@ class TestAssistantServiceGet:
         assert "not found" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    async def test_get_assistant_system_access(self, assistant_service):
+    async def test_get_assistant_system_access(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test system assistant access"""
         # Mock system assistant
         mock_assistant = Mock()
@@ -590,8 +612,10 @@ class TestAssistantServiceUpdate:
 
     @pytest.mark.asyncio
     async def test_update_assistant_success(
-        self, assistant_service, sample_assistant_update
-    ):
+        self,
+        assistant_service: AssistantService,
+        sample_assistant_update: AssistantUpdate,
+    ) -> None:
         """Test successful assistant update"""
         # Mock existing assistant
         mock_assistant = Mock()
@@ -638,8 +662,10 @@ class TestAssistantServiceUpdate:
 
     @pytest.mark.asyncio
     async def test_update_assistant_not_found(
-        self, assistant_service, sample_assistant_update
-    ):
+        self,
+        assistant_service: AssistantService,
+        sample_assistant_update: AssistantUpdate,
+    ) -> None:
         """Test update of non-existent assistant"""
         assistant_service.session.scalar.return_value = None
 
@@ -652,7 +678,9 @@ class TestAssistantServiceUpdate:
         assert "not found" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    async def test_update_assistant_config_context_conflict(self, assistant_service):
+    async def test_update_assistant_config_context_conflict(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test update with config and context conflict"""
         request = AssistantUpdate(
             config={"configurable": {"key": "value"}},
@@ -672,7 +700,9 @@ class TestAssistantServiceDelete:
     """Test assistant deletion business logic"""
 
     @pytest.mark.asyncio
-    async def test_delete_assistant_success(self, assistant_service):
+    async def test_delete_assistant_success(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test successful assistant deletion"""
         # Mock existing assistant
         mock_assistant = Mock()
@@ -689,7 +719,9 @@ class TestAssistantServiceDelete:
         assistant_service.session.commit.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_delete_assistant_not_found(self, assistant_service):
+    async def test_delete_assistant_not_found(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test deletion of non-existent assistant"""
         assistant_service.session.scalar.return_value = None
 
@@ -704,7 +736,9 @@ class TestAssistantServiceVersionManagement:
     """Test assistant version management logic"""
 
     @pytest.mark.asyncio
-    async def test_set_assistant_latest_success(self, assistant_service):
+    async def test_set_assistant_latest_success(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test setting assistant latest version"""
         # Mock existing assistant
         mock_assistant = Mock()
@@ -743,7 +777,9 @@ class TestAssistantServiceVersionManagement:
         assistant_service.session.commit.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_set_assistant_latest_assistant_not_found(self, assistant_service):
+    async def test_set_assistant_latest_assistant_not_found(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test setting latest version for non-existent assistant"""
         assistant_service.session.scalar.return_value = None
 
@@ -754,7 +790,9 @@ class TestAssistantServiceVersionManagement:
         assert "not found" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    async def test_set_assistant_latest_version_not_found(self, assistant_service):
+    async def test_set_assistant_latest_version_not_found(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test setting non-existent version as latest"""
         # Mock existing assistant
         mock_assistant = Mock()
@@ -775,7 +813,9 @@ class TestAssistantServiceSearch:
     """Test assistant search business logic"""
 
     @pytest.mark.asyncio
-    async def test_search_assistants_with_filters(self, assistant_service):
+    async def test_search_assistants_with_filters(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test assistant search with various filters"""
         # Mock search request
         mock_request = Mock()
@@ -798,7 +838,9 @@ class TestAssistantServiceSearch:
         assistant_service.session.scalars.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_count_assistants_with_filters(self, assistant_service):
+    async def test_count_assistants_with_filters(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test assistant counting with filters"""
         # Mock search request
         mock_request = Mock()
@@ -813,7 +855,9 @@ class TestAssistantServiceSearch:
         assistant_service.session.scalar.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_count_assistants_none_result(self, assistant_service):
+    async def test_count_assistants_none_result(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test assistant counting with None result"""
         mock_request = Mock()
         assistant_service.session.scalar.return_value = None
@@ -827,7 +871,9 @@ class TestAssistantServiceSchemas:
     """Test assistant schema extraction logic"""
 
     @pytest.mark.asyncio
-    async def test_get_assistant_schemas_success(self, assistant_service):
+    async def test_get_assistant_schemas_success(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test successful schema extraction"""
         # Mock assistant
         mock_assistant = Mock()
@@ -860,7 +906,9 @@ class TestAssistantServiceSchemas:
         assert result["graph_id"] == "test-graph"
 
     @pytest.mark.asyncio
-    async def test_get_assistant_schemas_assistant_not_found(self, assistant_service):
+    async def test_get_assistant_schemas_assistant_not_found(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test schema extraction for non-existent assistant"""
         assistant_service.session.scalar.return_value = None
 
@@ -871,7 +919,9 @@ class TestAssistantServiceSchemas:
         assert "not found" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    async def test_get_assistant_schemas_graph_failure(self, assistant_service):
+    async def test_get_assistant_schemas_graph_failure(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test schema extraction with graph loading failure"""
         # Mock assistant
         mock_assistant = Mock()
@@ -899,7 +949,9 @@ class TestAssistantServiceGraph:
     """Test assistant graph operations"""
 
     @pytest.mark.asyncio
-    async def test_get_assistant_graph_success(self, assistant_service):
+    async def test_get_assistant_graph_success(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test successful graph retrieval"""
         # Mock assistant
         mock_assistant = Mock()
@@ -932,7 +984,9 @@ class TestAssistantServiceGraph:
         assert "id" not in result["nodes"][0]["data"]
 
     @pytest.mark.asyncio
-    async def test_get_assistant_graph_invalid_xray(self, assistant_service):
+    async def test_get_assistant_graph_invalid_xray(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test graph retrieval with invalid xray parameter"""
         # Mock assistant
         mock_assistant = Mock()
@@ -958,7 +1012,9 @@ class TestAssistantServiceGraph:
         assert "Invalid xray value" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
-    async def test_get_assistant_graph_not_implemented(self, assistant_service):
+    async def test_get_assistant_graph_not_implemented(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test graph retrieval with unsupported visualization"""
         # Mock assistant
         mock_assistant = Mock()
@@ -988,7 +1044,9 @@ class TestAssistantServiceSubgraphs:
     """Test assistant subgraph operations"""
 
     @pytest.mark.asyncio
-    async def test_get_assistant_subgraphs_success(self, assistant_service):
+    async def test_get_assistant_subgraphs_success(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test successful subgraph retrieval"""
         # Mock assistant
         mock_assistant = Mock()
@@ -1011,7 +1069,9 @@ class TestAssistantServiceSubgraphs:
         mock_subgraph.config_schema.return_value = Mock()
         mock_subgraph.get_context_jsonschema.return_value = {"type": "object"}
 
-        async def mock_aget_subgraphs(namespace=None, recurse=False):
+        async def mock_aget_subgraphs(
+            namespace: str | None = None, recurse: bool = False
+        ) -> AsyncGenerator[Any, None]:
             yield "subgraph1", mock_subgraph
 
         mock_graph.aget_subgraphs = mock_aget_subgraphs
@@ -1027,7 +1087,9 @@ class TestAssistantServiceSubgraphs:
         assert "input_schema" in result["subgraph1"]
 
     @pytest.mark.asyncio
-    async def test_get_assistant_subgraphs_not_implemented(self, assistant_service):
+    async def test_get_assistant_subgraphs_not_implemented(
+        self, assistant_service: AssistantService
+    ) -> None:
         """Test subgraph retrieval with unsupported feature"""
         # Mock assistant
         mock_assistant = Mock()

--- a/tests/unit/test_services/test_streaming_service.py
+++ b/tests/unit/test_services/test_streaming_service.py
@@ -1,5 +1,6 @@
 """Unit tests for streaming_service module"""
 
+from collections.abc import AsyncGenerator
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,7 +14,7 @@ from agent_server.services.streaming_service import StreamingService
 class TestStreamingService:
     """Test StreamingService class"""
 
-    async def test_next_event_counter(self):
+    async def test_next_event_counter(self) -> None:
         """Test event counter update logic"""
         service = StreamingService()
         run_id = "run-123"
@@ -37,7 +38,7 @@ class TestStreamingService:
         count = service._next_event_counter(run_id, "invalid")
         assert count == 10  # Should remain unchanged
 
-    async def test_put_to_broker(self):
+    async def test_put_to_broker(self) -> None:
         """Test putting event to broker"""
         service = StreamingService()
         run_id = "run-123"
@@ -57,7 +58,7 @@ class TestStreamingService:
             mock_broker.put.assert_awaited_with(event_id, raw_event)
             assert service.event_counters[run_id] == 1
 
-    async def test_store_event_from_raw_messages(self):
+    async def test_store_event_from_raw_messages(self) -> None:
         """Test storing message events"""
         service = StreamingService()
         run_id = "run-123"
@@ -65,7 +66,8 @@ class TestStreamingService:
 
         # Test messages (tuple with 2 items)
         with patch(
-            "agent_server.services.streaming_service.store_sse_event"
+            "agent_server.services.streaming_service.store_sse_event",
+            new_callable=AsyncMock,
         ) as mock_store:
             raw_event = ("messages", {"content": "hello"})
             await service.store_event_from_raw(run_id, event_id, raw_event)
@@ -82,14 +84,15 @@ class TestStreamingService:
                 },
             )
 
-    async def test_store_event_from_raw_partial(self):
+    async def test_store_event_from_raw_partial(self) -> None:
         """Test storing partial message events"""
         service = StreamingService()
         run_id = "run-123"
         event_id = "evt-1"
 
         with patch(
-            "agent_server.services.streaming_service.store_sse_event"
+            "agent_server.services.streaming_service.store_sse_event",
+            new_callable=AsyncMock,
         ) as mock_store:
             raw_event = ("messages/partial", ["chunk"])
             await service.store_event_from_raw(run_id, event_id, raw_event)
@@ -101,14 +104,15 @@ class TestStreamingService:
                 {"type": "messages_partial", "messages": ["chunk"], "node_path": None},
             )
 
-    async def test_store_event_from_raw_complete(self):
+    async def test_store_event_from_raw_complete(self) -> None:
         """Test storing complete message events"""
         service = StreamingService()
         run_id = "run-123"
         event_id = "evt-1"
 
         with patch(
-            "agent_server.services.streaming_service.store_sse_event"
+            "agent_server.services.streaming_service.store_sse_event",
+            new_callable=AsyncMock,
         ) as mock_store:
             raw_event = ("messages/complete", ["msg"])
             await service.store_event_from_raw(run_id, event_id, raw_event)
@@ -120,14 +124,15 @@ class TestStreamingService:
                 {"type": "messages_complete", "messages": ["msg"], "node_path": None},
             )
 
-    async def test_store_event_from_raw_metadata(self):
+    async def test_store_event_from_raw_metadata(self) -> None:
         """Test storing metadata events"""
         service = StreamingService()
         run_id = "run-123"
         event_id = "evt-1"
 
         with patch(
-            "agent_server.services.streaming_service.store_sse_event"
+            "agent_server.services.streaming_service.store_sse_event",
+            new_callable=AsyncMock,
         ) as mock_store:
             raw_event = ("messages/metadata", {"meta": "data"})
             await service.store_event_from_raw(run_id, event_id, raw_event)
@@ -143,14 +148,15 @@ class TestStreamingService:
                 },
             )
 
-    async def test_store_event_from_raw_events(self):
+    async def test_store_event_from_raw_events(self) -> None:
         """Test storing langchain events"""
         service = StreamingService()
         run_id = "run-123"
         event_id = "evt-1"
 
         with patch(
-            "agent_server.services.streaming_service.store_sse_event"
+            "agent_server.services.streaming_service.store_sse_event",
+            new_callable=AsyncMock,
         ) as mock_store:
             raw_event = ("events", {"event": "data"})
             await service.store_event_from_raw(run_id, event_id, raw_event)
@@ -162,14 +168,15 @@ class TestStreamingService:
                 {"type": "langchain_event", "event": {"event": "data"}},
             )
 
-    async def test_store_event_from_raw_values(self):
+    async def test_store_event_from_raw_values(self) -> None:
         """Test storing values events"""
         service = StreamingService()
         run_id = "run-123"
         event_id = "evt-1"
 
         with patch(
-            "agent_server.services.streaming_service.store_sse_event"
+            "agent_server.services.streaming_service.store_sse_event",
+            new_callable=AsyncMock,
         ) as mock_store:
             raw_event = ("values", {"val": 1})
             await service.store_event_from_raw(run_id, event_id, raw_event)
@@ -181,14 +188,15 @@ class TestStreamingService:
                 {"type": "execution_values", "chunk": {"val": 1}},
             )
 
-    async def test_store_event_from_raw_end(self):
+    async def test_store_event_from_raw_end(self) -> None:
         """Test storing end events"""
         service = StreamingService()
         run_id = "run-123"
         event_id = "evt-1"
 
         with patch(
-            "agent_server.services.streaming_service.store_sse_event"
+            "agent_server.services.streaming_service.store_sse_event",
+            new_callable=AsyncMock,
         ) as mock_store:
             raw_event = ("end", {"status": "success", "final_output": "done"})
             await service.store_event_from_raw(run_id, event_id, raw_event)
@@ -200,7 +208,7 @@ class TestStreamingService:
                 {"type": "run_complete", "status": "success", "final_output": "done"},
             )
 
-    async def test_signal_run_cancelled(self):
+    async def test_signal_run_cancelled(self) -> None:
         """Test signalling run cancellation"""
         service = StreamingService()
         run_id = "run-123"
@@ -222,7 +230,7 @@ class TestStreamingService:
             # Should cleanup broker
             mock_manager.cleanup_broker.assert_called_with(run_id)
 
-    async def test_signal_run_error(self):
+    async def test_signal_run_error(self) -> None:
         """Test signalling run error"""
         service = StreamingService()
         run_id = "run-123"
@@ -245,7 +253,7 @@ class TestStreamingService:
             # Should cleanup broker
             mock_manager.cleanup_broker.assert_called_with(run_id)
 
-    async def test_stream_run_execution(self):
+    async def test_stream_run_execution(self) -> None:
         """Test overall streaming execution"""
         service = StreamingService()
         run = Run(
@@ -263,7 +271,7 @@ class TestStreamingService:
         mock_broker = MagicMock()
         mock_broker.is_finished.return_value = False
 
-        async def mock_aiter():
+        async def mock_aiter() -> AsyncGenerator:
             yield "run-123_event_3", "raw3"
             yield "run-123_event_4", "raw4"
 
@@ -295,7 +303,7 @@ class TestStreamingService:
             # Should have fetched stored events
             mock_store.get_all_events.assert_awaited_with("run-123")
 
-    async def test_stream_run_execution_with_last_id(self):
+    async def test_stream_run_execution_with_last_id(self) -> None:
         """Test streaming with last_event_id resume"""
         service = StreamingService()
         run = Run(
@@ -320,7 +328,7 @@ class TestStreamingService:
 
             mock_broker = MagicMock()
 
-            async def mock_aiter():
+            async def mock_aiter() -> AsyncGenerator:
                 if False:
                     yield  # Force async generator
 
@@ -335,7 +343,7 @@ class TestStreamingService:
             # Should fetch events since last_id
             mock_store.get_events_since.assert_awaited_with("run-123", last_id)
 
-    async def test_cancel_background_task(self):
+    async def test_cancel_background_task(self) -> None:
         """Test cancelling background task"""
         service = StreamingService()
         run_id = "run-123"
@@ -350,7 +358,7 @@ class TestStreamingService:
             service._cancel_background_task(run_id)
             mock_task.cancel.assert_called_once()
 
-    async def test_interrupt_run(self):
+    async def test_interrupt_run(self) -> None:
         """Test run interruption"""
         service = StreamingService()
         run_id = "run-123"
@@ -365,7 +373,7 @@ class TestStreamingService:
             mock_signal.assert_awaited_with(run_id, "Run was interrupted")
             mock_update.assert_awaited_with(run_id, "interrupted")
 
-    async def test_cancel_run(self):
+    async def test_cancel_run(self) -> None:
         """Test run cancellation"""
         service = StreamingService()
         run_id = "run-123"
@@ -380,7 +388,7 @@ class TestStreamingService:
             mock_signal.assert_awaited_with(run_id)
             mock_update.assert_awaited_with(run_id, "interrupted")
 
-    async def test_is_run_streaming(self):
+    async def test_is_run_streaming(self) -> None:
         """Test fetching if run is streaming"""
         service = StreamingService()
 
@@ -400,7 +408,7 @@ class TestStreamingService:
             assert service.is_run_streaming("run-1") is False
 
     @pytest.mark.asyncio
-    async def test_cleanup_run(self):
+    async def test_cleanup_run(self) -> None:
         """Test run cleanup"""
         service = StreamingService()
         run_id = "run-123"


### PR DESCRIPTION
## Description
Add comprehensive unit tests for `/api/runs` endpoints and `streaming_service` module, addressing test coverage gaps identified in Issues #60 and #63. Also improves mock configurations in existing tests to eliminate RuntimeWarnings.

## Type of Change
- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [x] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
Closes #60
Closes #63

## Changes Made
- Add `tests/unit/test_api/test_runs.py` - 11 tests covering CRUD endpoints (create, get, list, update, join)
- Add `tests/unit/test_api/test_runs_streaming.py` - 3 tests covering streaming endpoints
- Add `tests/unit/test_services/test_streaming_service.py` - 18 tests covering StreamingService
- Improve `tests/unit/test_api/test_runs_wait.py` - Add proper mocking for `session.add` and `execute_run_async` to eliminate RuntimeWarnings
- Improve `tests/unit/test_services/test_assistant_service.py` - Update `mock_session` fixture to properly mock synchronous `add()` method

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

**Test Results:**
```
526 passed, 18 warnings in 1.37s
```

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`) - Pre-existing errors in src/ files, unrelated to this PR
- [x] All tests pass (`make test`) - Unit tests pass; E2E tests require running server
- [ ] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Screenshots (if applicable)
N/A - Test-only changes

## Additional Notes
- The 160 type-check errors are pre-existing in `src/` files (missing return type annotations) and unrelated to this PR.
- The remaining 18 warnings are pre-existing Pydantic V2 deprecation warnings and unrelated mock schema warnings.
