### PR TITLE
fix(db): qualify uuid_generate_v4 with public schema

### DIFF
--- a/alembic/versions/20250817172544_initial_schema.py
+++ b/alembic/versions/20250817172544_initial_schema.py
@@ -36,7 +36,7 @@ def upgrade() -> None:
         sa.Column(
             "assistant_id",
             sa.Text(),
-            server_default=sa.text("uuid_generate_v4()::text"),
+            server_default=sa.text("public.uuid_generate_v4()::text"),
             nullable=False,
         ),
         sa.Column("name", sa.Text(), nullable=False),
@@ -116,7 +116,7 @@ def upgrade() -> None:
         sa.Column(
             "run_id",
             sa.Text(),
-            server_default=sa.text("uuid_generate_v4()::text"),
+            server_default=sa.text("public.uuid_generate_v4()::text"),
             nullable=False,
         ),
         sa.Column("thread_id", sa.Text(), nullable=False),

--- a/src/agent_server/core/orm.py
+++ b/src/agent_server/core/orm.py
@@ -36,7 +36,7 @@ class Assistant(Base):
 
     # TEXT PK with DB-side generation using uuid_generate_v4()::text
     assistant_id: Mapped[str] = mapped_column(
-        Text, primary_key=True, server_default=text("uuid_generate_v4()::text")
+        Text, primary_key=True, server_default=text("public.uuid_generate_v4()::text")
     )
     name: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
@@ -117,7 +117,7 @@ class Run(Base):
 
     # TEXT PK with DB-side generation using uuid_generate_v4()::text
     run_id: Mapped[str] = mapped_column(
-        Text, primary_key=True, server_default=text("uuid_generate_v4()::text")
+        Text, primary_key=True, server_default=text("public.uuid_generate_v4()::text")
     )
     thread_id: Mapped[str] = mapped_column(
         Text, ForeignKey("thread.thread_id", ondelete="CASCADE"), nullable=False


### PR DESCRIPTION
## Summary
This PR explicitly adds the `public.` schema prefix to `uuid_generate_v4()` function calls in both Alembic migrations and SQLAlchemy ORM models.

**Changes:**
- Updated `alembic/versions/..._initial_schema.py`
- Updated `src/agent_server/core/orm.py`

## Motivation
1. **Reliability:** Using the fully qualified name (`public.uuid_generate_v4`) prevents potential "function not found" errors if the database `search_path` configuration changes or does not include `public` by default.
2. **Consistency:** Synchronizes the ORM definitions with the actual database schema. This prevents Alembic from incorrectly detecting schema changes (drift) in future `revision --autogenerate` runs.

## Checklist
- [x] Applied `public.` prefix to all occurrences in migrations.
- [x] Applied `public.` prefix to all occurrences in ORM models.
- [x] Verified that the application starts without schema errors.