### PR TITLE
feat: add optional Redis support for streaming buffers

### DIFF
--- a/tests/unit/test_services/test_redis_service.py
+++ b/tests/unit/test_services/test_redis_service.py
@@ -39,13 +39,14 @@ class TestRedisService:
         with (
             patch("src.agent_server.services.redis_service.settings") as mock_settings,
             patch(
-                "src.agent_server.services.redis_service.aioredis.from_url"
-            ) as mock_redis_cls,
+                "src.agent_server.services.redis_service.aioredis"
+            ) as mock_aioredis,
         ):
             mock_settings.redis.REDIS_ENABLED = True
             mock_settings.redis.REDIS_URL = "redis://localhost"
+            
             mock_redis = AsyncMock()
-            mock_redis_cls.return_value = mock_redis
+            mock_aioredis.from_url.return_value = mock_redis
 
             service = RedisService()
             await service.initialize()
@@ -60,14 +61,15 @@ class TestRedisService:
         with (
             patch("src.agent_server.services.redis_service.settings") as mock_settings,
             patch(
-                "src.agent_server.services.redis_service.aioredis.from_url"
-            ) as mock_redis_cls,
+                "src.agent_server.services.redis_service.aioredis"
+            ) as mock_aioredis,
         ):
             mock_settings.redis.REDIS_ENABLED = True
             mock_settings.redis.REDIS_URL = "redis://localhost"
+            
             mock_redis = AsyncMock()
             mock_redis.ping.side_effect = Exception("Connection fail")
-            mock_redis_cls.return_value = mock_redis
+            mock_aioredis.from_url.return_value = mock_redis
 
             service = RedisService()
             await service.initialize()


### PR DESCRIPTION
Implements optional Redis integration for event streaming to improve throughput and enable distributed workflows.

- Adds RedisSettings to configuration
- Implements RedisRunBroker for Redis Stream-backed event queues
- Adds Redis service initialization in main app
- Updates Docker Compose with Redis service
- Adds unit tests for Redis broker

## Description
This PR introduces optional Redis support to Aegra for handling event streaming buffers. By creating a `RedisRunBroker` that uses Redis Streams, the system can decouple event production from consumption, allowing for better scalability and potential distributed agent runners in the future. The system is designed to fall back to the existing in-memory broker if Redis is not configured or disabled via environment variables.

## Type of Change
- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [x] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
Fixes #133

## Changes Made
- Added `redis` to core dependencies in `pyproject.toml`.
- Added `RedisSettings` to `src/agent_server/settings.py` for configuring URL and stream behavior.
- Created `src/agent_server/services/redis_service.py` for managing the Redis connection.
- Created `src/agent_server/services/redis_broker.py` to implement a broker backed by Redis Streams (`XADD`, `XREAD`).
- Updated `src/agent_server/services/broker.py` `BrokerManager` to optionally instantiate `RedisRunBroker` based on settings.
- Updated `src/agent_server/main.py` to initialize and close the Redis connection in the app lifespan.
- Updated `docker-compose.yml` to include a Redis container and service link.
- Added comprehensive unit tests in `tests/unit/test_services/test_redis_broker.py`.

## Testing
- [x] Unit tests added/updated - Added tests for `RedisRunBroker` verifying `put`, `aiter` behavior, and finish signaling.
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed - Verified using `uv run python run_server.py` that the server starts up correctly, updates the environment configuration, and the broker initializes when Redis is enabled. Confirmed `uv run pytest` passes for the new module.

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (README.md includes new env vars and Redis status)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Additional Notes
This feature is "opt-in" by default via `REDIS_ENABLED`. The implementation uses `aioredis` (via the standard `redis` python package asyncio support). The stream keys are managed with a TTL to auto-cleanup, ensuring no memory leaks in long-running instances.