### PR TITLE
refactor(services): use context manager pattern for thread-safe graph loading

### DIFF
--- a/src/agent_server/api/runs.py
+++ b/src/agent_server/api/runs.py
@@ -948,7 +948,6 @@ async def execute_run_async(
 
         # Get graph and execute
         langgraph_service = get_langgraph_service()
-        graph = await langgraph_service.get_graph(graph_id)
 
         run_config = create_run_config(
             run_id, thread_id, user, config or {}, checkpoint
@@ -992,7 +991,10 @@ async def execute_run_async(
         else:
             stream_mode_list = stream_mode.copy()
 
-        async with with_auth_ctx(user, []):
+        async with (
+            langgraph_service.get_graph(graph_id) as graph,
+            with_auth_ctx(user, []),
+        ):
             # Stream events using the graph_streaming service
             async for event_type, event_data in stream_graph_events(
                 graph=graph,

--- a/src/agent_server/api/threads.py
+++ b/src/agent_server/api/threads.py
@@ -307,23 +307,38 @@ async def get_thread_state(
         )
 
         langgraph_service = get_langgraph_service()
-        try:
-            agent = await langgraph_service.get_graph(graph_id)
-        except Exception as e:
-            logger.exception("Failed to load graph '%s' for state retrieval", graph_id)
-            raise HTTPException(
-                500, f"Failed to load graph '{graph_id}': {str(e)}"
-            ) from e
-
         config: dict[str, Any] = create_thread_config(thread_id, user, {})
         if checkpoint_ns:
             config["configurable"]["checkpoint_ns"] = checkpoint_ns
 
         try:
-            agent = agent.with_config(config)
-            # NOTE: LangGraph only exposes subgraph checkpoints while the run is
-            # interrupted. See https://docs.langchain.com/oss/python/langgraph/use-subgraphs#view-subgraph-state
-            state_snapshot = await agent.aget_state(config, subgraphs=subgraphs)
+            async with langgraph_service.get_graph(graph_id) as agent:
+                agent = agent.with_config(config)
+                # NOTE: LangGraph only exposes subgraph checkpoints while the run is
+                # interrupted. See https://docs.langchain.com/oss/python/langgraph/use-subgraphs#view-subgraph-state
+                state_snapshot = await agent.aget_state(config, subgraphs=subgraphs)
+
+                if not state_snapshot:
+                    logger.info(
+                        "state GET: no checkpoint found for thread %s (checkpoint_ns=%s)",
+                        thread_id,
+                        checkpoint_ns,
+                    )
+                    raise HTTPException(404, f"No state found for thread '{thread_id}'")
+
+                thread_state = thread_state_service.convert_snapshot_to_thread_state(
+                    state_snapshot, thread_id, subgraphs=subgraphs
+                )
+
+                logger.debug(
+                    "state GET: thread_id=%s checkpoint_id=%s subgraphs=%s checkpoint_ns=%s",
+                    thread_id,
+                    thread_state.checkpoint.checkpoint_id,
+                    subgraphs,
+                    checkpoint_ns,
+                )
+
+                return thread_state
         except HTTPException:
             raise
         except Exception as e:
@@ -333,34 +348,6 @@ async def get_thread_state(
             raise HTTPException(
                 500, f"Failed to retrieve thread state: {str(e)}"
             ) from e
-
-        if not state_snapshot:
-            logger.info(
-                "state GET: no checkpoint found for thread %s (checkpoint_ns=%s)",
-                thread_id,
-                checkpoint_ns,
-            )
-            raise HTTPException(404, f"No state found for thread '{thread_id}'")
-
-        try:
-            thread_state = thread_state_service.convert_snapshot_to_thread_state(
-                state_snapshot, thread_id, subgraphs=subgraphs
-            )
-        except Exception as e:
-            logger.exception(
-                "Failed to convert latest state for thread '%s'", thread_id
-            )
-            raise HTTPException(500, f"Failed to convert thread state: {str(e)}") from e
-
-        logger.debug(
-            "state GET: thread_id=%s checkpoint_id=%s subgraphs=%s checkpoint_ns=%s",
-            thread_id,
-            thread_state.checkpoint.checkpoint_id,
-            subgraphs,
-            checkpoint_ns,
-        )
-
-        return thread_state
 
     except HTTPException:
         raise
@@ -418,14 +405,6 @@ async def update_thread_state(
         )
 
         langgraph_service = get_langgraph_service()
-        try:
-            agent = await langgraph_service.get_graph(graph_id)
-        except Exception as e:
-            logger.exception("Failed to load graph '%s' for state update", graph_id)
-            raise HTTPException(
-                500, f"Failed to load graph '{graph_id}': {str(e)}"
-            ) from e
-
         config: dict[str, Any] = create_thread_config(thread_id, user, {})
 
         # Apply checkpoint configuration
@@ -437,75 +416,76 @@ async def update_thread_state(
             config["configurable"]["checkpoint_ns"] = request.checkpoint_ns
 
         try:
-            # Update state using aupdate_state method
-            # This creates a new checkpoint with the updated values
-            agent = agent.with_config(config)
+            async with langgraph_service.get_graph(graph_id) as agent:
+                # Update state using aupdate_state method
+                # This creates a new checkpoint with the updated values
+                agent = agent.with_config(config)
 
-            # Handle values - can be dict or list of dicts
-            update_values = request.values
-            if isinstance(update_values, list):
-                # If it's a list, use the first dict or convert to dict
-                if update_values and isinstance(update_values[0], dict):
-                    # Merge all dicts in the list
-                    merged = {}
-                    for item in update_values:
-                        if isinstance(item, dict):
-                            merged.update(item)
-                    update_values = merged
-                else:
-                    update_values = update_values[0] if update_values else None
+                # Handle values - can be dict or list of dicts
+                update_values = request.values
+                if isinstance(update_values, list):
+                    # If it's a list, use the first dict or convert to dict
+                    if update_values and isinstance(update_values[0], dict):
+                        # Merge all dicts in the list
+                        merged = {}
+                        for item in update_values:
+                            if isinstance(item, dict):
+                                merged.update(item)
+                        update_values = merged
+                    else:
+                        update_values = update_values[0] if update_values else None
 
-            # Update the state using aupdate_state
-            # aupdate_state signature: aupdate_state(config, values, as_node=None)
-            # When as_node is not specified, the graph may try to continue execution,
-            # which can fail if the state doesn't match expected graph flow.
-            # We should always use as_node to prevent unwanted execution.
-            try:
-                # If as_node is not provided, we need to determine a safe node to use
-                # For state updates without as_node, we'll use None which should just update state
-                # without triggering execution, but the graph may still validate the state
-                updated_config = await agent.aupdate_state(
-                    config, update_values, as_node=request.as_node
-                )
-            except Exception as update_error:
-                logger.exception(
-                    "aupdate_state failed for thread %s: %s",
+                # Update the state using aupdate_state
+                # aupdate_state signature: aupdate_state(config, values, as_node=None)
+                # When as_node is not specified, the graph may try to continue execution,
+                # which can fail if the state doesn't match expected graph flow.
+                # We should always use as_node to prevent unwanted execution.
+                try:
+                    # If as_node is not provided, we need to determine a safe node to use
+                    # For state updates without as_node, we'll use None which should just update state
+                    # without triggering execution, but the graph may still validate the state
+                    updated_config = await agent.aupdate_state(
+                        config, update_values, as_node=request.as_node
+                    )
+                except Exception as update_error:
+                    logger.exception(
+                        "aupdate_state failed for thread %s: %s",
+                        thread_id,
+                        update_error,
+                        exc_info=True,
+                    )
+                    raise
+
+                # Extract checkpoint info from the updated config
+                # aupdate_state returns the updated config dict
+                if not isinstance(updated_config, dict):
+                    logger.error(
+                        "aupdate_state returned non-dict: %s (type: %s)",
+                        updated_config,
+                        type(updated_config),
+                    )
+                    raise HTTPException(
+                        500,
+                        f"Unexpected return type from aupdate_state: {type(updated_config)}",
+                    )
+
+                checkpoint_info = {
+                    "checkpoint_id": updated_config.get("configurable", {}).get(
+                        "checkpoint_id"
+                    ),
+                    "thread_id": thread_id,
+                    "checkpoint_ns": updated_config.get("configurable", {}).get(
+                        "checkpoint_ns", ""
+                    ),
+                }
+
+                logger.info(
+                    "state POST: updated state for thread %s checkpoint_id=%s",
                     thread_id,
-                    update_error,
-                    exc_info=True,
-                )
-                raise
-
-            # Extract checkpoint info from the updated config
-            # aupdate_state returns the updated config dict
-            if not isinstance(updated_config, dict):
-                logger.error(
-                    "aupdate_state returned non-dict: %s (type: %s)",
-                    updated_config,
-                    type(updated_config),
-                )
-                raise HTTPException(
-                    500,
-                    f"Unexpected return type from aupdate_state: {type(updated_config)}",
+                    checkpoint_info.get("checkpoint_id"),
                 )
 
-            checkpoint_info = {
-                "checkpoint_id": updated_config.get("configurable", {}).get(
-                    "checkpoint_id"
-                ),
-                "thread_id": thread_id,
-                "checkpoint_ns": updated_config.get("configurable", {}).get(
-                    "checkpoint_ns", ""
-                ),
-            }
-
-            logger.info(
-                "state POST: updated state for thread %s checkpoint_id=%s",
-                thread_id,
-                checkpoint_info.get("checkpoint_id"),
-            )
-
-            return ThreadStateUpdateResponse(checkpoint=checkpoint_info)
+                return ThreadStateUpdateResponse(checkpoint=checkpoint_info)
 
         except HTTPException:
             raise
@@ -554,15 +534,6 @@ async def get_thread_state_at_checkpoint(
         )
 
         langgraph_service = get_langgraph_service()
-        try:
-            agent = await langgraph_service.get_graph(graph_id)
-        except Exception as e:
-            logger.exception(
-                "Failed to load graph '%s' for checkpoint retrieval", graph_id
-            )
-            raise HTTPException(
-                500, f"Failed to load graph '{graph_id}': {str(e)}"
-            ) from e
 
         # Build config with user context and thread_id
         config: dict[str, Any] = create_thread_config(thread_id, user, {})
@@ -572,10 +543,30 @@ async def get_thread_state_at_checkpoint(
 
         # Fetch state at checkpoint
         try:
-            agent = agent.with_config(config)
-            state_snapshot = await agent.aget_state(
-                config, subgraphs=subgraphs or False
-            )
+            async with langgraph_service.get_graph(graph_id) as agent:
+                agent = agent.with_config(config)
+                state_snapshot = await agent.aget_state(
+                    config, subgraphs=subgraphs or False
+                )
+
+                if not state_snapshot:
+                    raise HTTPException(
+                        404,
+                        f"No state found at checkpoint '{checkpoint_id}' for thread '{thread_id}'",
+                    )
+
+                # Convert snapshot to ThreadCheckpoint using service
+                thread_checkpoint = (
+                    thread_state_service.convert_snapshot_to_thread_state(
+                        state_snapshot,
+                        thread_id,
+                        subgraphs=subgraphs or False,
+                    )
+                )
+
+                return thread_checkpoint
+        except HTTPException:
+            raise
         except Exception as e:
             logger.exception(
                 "Failed to retrieve state at checkpoint '%s' for thread '%s'",
@@ -586,21 +577,6 @@ async def get_thread_state_at_checkpoint(
                 500,
                 f"Failed to retrieve state at checkpoint '{checkpoint_id}': {str(e)}",
             ) from e
-
-        if not state_snapshot:
-            raise HTTPException(
-                404,
-                f"No state found at checkpoint '{checkpoint_id}' for thread '{thread_id}'",
-            )
-
-        # Convert snapshot to ThreadCheckpoint using service
-        thread_checkpoint = thread_state_service.convert_snapshot_to_thread_state(
-            state_snapshot,
-            thread_id,
-            subgraphs=subgraphs or False,
-        )
-
-        return thread_checkpoint
 
     except HTTPException:
         raise
@@ -715,13 +691,6 @@ async def get_thread_history_post(
         )
 
         langgraph_service = get_langgraph_service()
-        try:
-            agent = await langgraph_service.get_graph(graph_id)
-        except Exception as e:
-            logger.exception("Failed to load graph '%s' for history", graph_id)
-            raise HTTPException(
-                500, f"Failed to load graph '{graph_id}': {str(e)}"
-            ) from e
 
         # Build config with user context and thread_id
         config: dict[str, Any] = create_thread_config(thread_id, user, {})
@@ -744,23 +713,24 @@ async def get_thread_history_post(
         if metadata is not None:
             kwargs["metadata"] = metadata  # type: ignore[index]
 
-        # Some LangGraph versions support subgraphs flag; pass if available
-        try:
-            async for snapshot in agent.aget_state_history(
-                config, subgraphs=subgraphs, **kwargs
-            ):
-                state_snapshots.append(snapshot)
-        except TypeError:
-            # Fallback if subgraphs not supported in this version
-            async for snapshot in agent.aget_state_history(config, **kwargs):
-                state_snapshots.append(snapshot)
+        async with langgraph_service.get_graph(graph_id) as agent:
+            # Some LangGraph versions support subgraphs flag; pass if available
+            try:
+                async for snapshot in agent.aget_state_history(
+                    config, subgraphs=subgraphs, **kwargs
+                ):
+                    state_snapshots.append(snapshot)
+            except TypeError:
+                # Fallback if subgraphs not supported in this version
+                async for snapshot in agent.aget_state_history(config, **kwargs):
+                    state_snapshots.append(snapshot)
 
-        # Convert snapshots to ThreadState using service
-        thread_states = thread_state_service.convert_snapshots_to_thread_states(
-            state_snapshots, thread_id
-        )
+            # Convert snapshots to ThreadState using service
+            thread_states = thread_state_service.convert_snapshots_to_thread_states(
+                state_snapshots, thread_id
+            )
 
-        return thread_states
+            return thread_states
 
     except HTTPException:
         raise

--- a/src/agent_server/services/assistant_service.py
+++ b/src/agent_server/services/assistant_service.py
@@ -155,7 +155,7 @@ class AssistantService:
 
         # Validate graph can be loaded
         try:
-            await self.langgraph_service.get_graph(graph_id)
+            await self.langgraph_service.get_graph_for_validation(graph_id)
         except Exception as e:
             raise HTTPException(400, f"Failed to load graph: {str(e)}") from e
 
@@ -513,7 +513,11 @@ class AssistantService:
             raise HTTPException(404, f"Assistant '{assistant_id}' not found")
 
         try:
-            graph = await self.langgraph_service.get_graph(assistant.graph_id)
+            # Use get_graph_for_validation since we only need schema extraction,
+            # not checkpointer/store for execution
+            graph = await self.langgraph_service.get_graph_for_validation(
+                assistant.graph_id
+            )
             schemas = _extract_graph_schemas(graph)
 
             return {"graph_id": assistant.graph_id, **schemas}
@@ -537,7 +541,11 @@ class AssistantService:
             raise HTTPException(404, f"Assistant '{assistant_id}' not found")
 
         try:
-            graph = await self.langgraph_service.get_graph(assistant.graph_id)
+            # Use get_graph_for_validation since we only need graph structure,
+            # not checkpointer/store for execution
+            graph = await self.langgraph_service.get_graph_for_validation(
+                assistant.graph_id
+            )
 
             # Validate xray if it's an integer (not a boolean)
             if isinstance(xray, int) and not isinstance(xray, bool) and xray <= 0:
@@ -582,7 +590,11 @@ class AssistantService:
             raise HTTPException(404, f"Assistant '{assistant_id}' not found")
 
         try:
-            graph = await self.langgraph_service.get_graph(assistant.graph_id)
+            # Use get_graph_for_validation since we only need schema extraction,
+            # not checkpointer/store for execution
+            graph = await self.langgraph_service.get_graph_for_validation(
+                assistant.graph_id
+            )
 
             try:
                 subgraphs = {

--- a/src/agent_server/services/langgraph_service.py
+++ b/src/agent_server/services/langgraph_service.py
@@ -1,8 +1,16 @@
-"""LangGraph integration service with official patterns"""
+"""LangGraph integration service.
+
+Architecture:
+- Base graph definitions are cached (safe, immutable)
+- Each request gets a fresh graph copy with checkpointer/store injected
+- Thread-safe by design without locks
+"""
 
 import importlib.util
 import json
 import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, TypeVar
 from uuid import uuid5
@@ -21,14 +29,21 @@ logger = structlog.get_logger(__name__)
 
 
 class LangGraphService:
-    """Service to work with LangGraph CLI configuration and graphs"""
+    """Service to work with LangGraph CLI configuration and graphs.
+
+    Architecture:
+    - Caches base graph definitions (raw StateGraph/Pregel before checkpointer)
+    - Yields fresh copies per-request with checkpointer/store injected
+    - Thread-safe without locks via immutable cached state
+    """
 
     def __init__(self, config_path: str = "aegra.json"):
         # Default path can be overridden via AEGRA_CONFIG or by placing aegra.json
         self.config_path = Path(config_path)
         self.config: dict[str, Any] | None = None
         self._graph_registry: dict[str, Any] = {}
-        self._graph_cache: dict[str, Any] = {}
+        # Cache for base graph definitions (without checkpointer/store)
+        self._base_graph_cache: dict[str, Pregel] = {}
 
     async def initialize(self):
         """Load configuration file and setup graph registry.
@@ -177,53 +192,89 @@ class LangGraphService:
         finally:
             await session.close()
 
-    async def get_graph(self, graph_id: str, force_reload: bool = False) -> Pregel:
-        """Get a compiled graph by ID with caching and LangGraph integration"""
+    async def _get_base_graph(self, graph_id: str) -> Pregel:
+        """Get the base compiled graph without checkpointer/store.
+
+        Caches the compiled graph structure for reuse. This is safe because
+        the base graph is immutable - we create copies with checkpointer/store
+        injected per-request.
+
+        @param graph_id: The graph identifier from aegra.json
+        @returns: Compiled Pregel graph (without checkpointer/store)
+        @raises ValueError: If graph_id not found or loading fails
+        """
         if graph_id not in self._graph_registry:
             raise ValueError(f"Graph not found: {graph_id}")
 
-        # Return cached graph if available and not forcing reload
-        if not force_reload and graph_id in self._graph_cache:
-            return self._graph_cache[graph_id]
+        # Return cached base graph if available
+        if graph_id in self._base_graph_cache:
+            return self._base_graph_cache[graph_id]
 
         graph_info = self._graph_registry[graph_id]
 
         # Load graph from file
-        base_graph = await self._load_graph_from_file(graph_id, graph_info)
+        raw_graph = await self._load_graph_from_file(graph_id, graph_info)
 
-        # Always ensure graphs are compiled with our Postgres checkpointer for persistence
+        # Compile if it's a StateGraph
+        if isinstance(raw_graph, StateGraph):
+            logger.info(f"🔧 Compiling graph '{graph_id}'")
+            compiled_graph = raw_graph.compile()
+        else:
+            compiled_graph = raw_graph
+
+        # Cache the base compiled graph (without checkpointer/store)
+        self._base_graph_cache[graph_id] = compiled_graph
+        return compiled_graph
+
+    @asynccontextmanager
+    async def get_graph(self, graph_id: str) -> AsyncIterator[Pregel]:
+        """Get a graph instance for execution with checkpointer/store injected.
+
+        This is a context manager that yields a fresh graph copy per-request.
+        Thread-safe without locks since each request gets its own instance.
+
+        Usage:
+            async with langgraph_service.get_graph("react_agent") as graph:
+                async for event in graph.astream(input, config):
+                    ...
+
+        @param graph_id: The graph identifier from aegra.json
+        @yields: Compiled Pregel graph with Postgres checkpointer/store attached
+        @raises ValueError: If graph_id not found or loading fails
+        """
+        # Get the cached base graph
+        base_graph = await self._get_base_graph(graph_id)
+
+        # Get checkpointer and store for this request
         from ..core.database import db_manager
 
-        checkpointer_cm = db_manager.get_checkpointer()
-        store_cm = db_manager.get_store()
+        checkpointer = db_manager.get_checkpointer()
+        store = db_manager.get_store()
 
-        if isinstance(base_graph, StateGraph):
-            # The module exported an *uncompiled* StateGraph – compile it now with
-            # a Postgres checkpointer for durable state.
-
-            logger.info(f"🔧 Compiling graph '{graph_id}' with Postgres persistence")
-            compiled_graph = base_graph.compile(
-                checkpointer=checkpointer_cm, store=store_cm
+        # Yield a fresh copy with checkpointer/store injected
+        try:
+            yield base_graph.copy(update={"checkpointer": checkpointer, "store": store})
+        except Exception:
+            # Fallback: property may be immutably set
+            logger.warning(
+                f"⚠️  Graph '{graph_id}' does not support checkpointer injection; "
+                "running without persistence"
             )
-        else:
-            # Graph was already compiled by the module.  Create a shallow copy
-            # that injects our Postgres checkpointer *unless* the author already
-            # set one.
-            try:
-                compiled_graph = base_graph.copy(
-                    update={"checkpointer": checkpointer_cm, "store": store_cm}
-                )
-            except Exception:
-                # Fallback: property may be immutably set; run as-is with warning
-                logger.warning(
-                    f"⚠️  Pre-compiled graph '{graph_id}' does not support checkpointer injection; running without persistence"
-                )
-                compiled_graph = base_graph
+            yield base_graph
 
-        # Cache the compiled graph
-        self._graph_cache[graph_id] = compiled_graph
+    async def get_graph_for_validation(self, graph_id: str) -> Pregel:
+        """Get a graph instance for validation/schema extraction only.
 
-        return compiled_graph
+        Use this when you only need to validate that a graph exists and can be
+        loaded, or to extract schemas. Does NOT include checkpointer/store.
+
+        For actual execution, use the `get_graph()` context manager instead.
+
+        @param graph_id: The graph identifier from aegra.json
+        @returns: Compiled Pregel graph (without checkpointer/store)
+        @raises ValueError: If graph_id not found or loading fails
+        """
+        return await self._get_base_graph(graph_id)
 
     async def _load_graph_from_file(self, graph_id: str, graph_info: dict[str, str]):
         """Load graph from filesystem"""
@@ -264,11 +315,14 @@ class LangGraphService:
         }
 
     def invalidate_cache(self, graph_id: str = None):
-        """Invalidate graph cache for hot-reload"""
+        """Invalidate graph cache for hot-reload.
+
+        @param graph_id: Specific graph to invalidate, or None to clear all
+        """
         if graph_id:
-            self._graph_cache.pop(graph_id, None)
+            self._base_graph_cache.pop(graph_id, None)
         else:
-            self._graph_cache.clear()
+            self._base_graph_cache.clear()
 
     def get_config(self) -> dict[str, Any] | None:
         """Get loaded configuration"""

--- a/tests/integration/test_services/test_assistant_service_db.py
+++ b/tests/integration/test_services/test_assistant_service_db.py
@@ -26,7 +26,7 @@ class TestAssistantServiceDatabase:
 
         mock_service = Mock()
         mock_service.list_graphs.return_value = {"test-graph": "test-graph.py"}
-        mock_service.get_graph = AsyncMock(return_value=Mock())
+        mock_service.get_graph_for_validation = AsyncMock(return_value=Mock())
         return mock_service
 
     @pytest.fixture
@@ -429,8 +429,8 @@ class TestAssistantServiceDatabase:
         )
 
         # Mock LangGraph service failure
-        assistant_service.langgraph_service.get_graph.side_effect = Exception(
-            "Graph load failed"
+        assistant_service.langgraph_service.get_graph_for_validation.side_effect = (
+            Exception("Graph load failed")
         )
 
         with pytest.raises(

--- a/tests/unit/test_services/test_assistant_service.py
+++ b/tests/unit/test_services/test_assistant_service.py
@@ -30,7 +30,7 @@ def mock_langgraph_service() -> Mock:
     """Mock LangGraphService for testing"""
     mock_service = Mock()
     mock_service.list_graphs.return_value = {"test-graph": {}}
-    mock_service.get_graph = AsyncMock(return_value=Mock())
+    mock_service.get_graph_for_validation = AsyncMock(return_value=Mock())
     return mock_service
 
 
@@ -254,7 +254,9 @@ class TestAssistantServiceCreate:
         assistant_service.langgraph_service.list_graphs.return_value = {
             "test-graph": {}
         }
-        assistant_service.langgraph_service.get_graph.return_value = Mock()
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            Mock()
+        )
 
         # Mock database operations
         assistant_service.session.scalar.return_value = None  # No existing assistant
@@ -296,7 +298,7 @@ class TestAssistantServiceCreate:
 
         assert isinstance(result, Assistant)
         assistant_service.langgraph_service.list_graphs.assert_called_once()
-        assistant_service.langgraph_service.get_graph.assert_called_once_with(
+        assistant_service.langgraph_service.get_graph_for_validation.assert_called_once_with(
             "test-graph"
         )
 
@@ -329,8 +331,8 @@ class TestAssistantServiceCreate:
         assistant_service.langgraph_service.list_graphs.return_value = {
             "test-graph": {}
         }
-        assistant_service.langgraph_service.get_graph.side_effect = Exception(
-            "Graph load failed"
+        assistant_service.langgraph_service.get_graph_for_validation.side_effect = (
+            Exception("Graph load failed")
         )
 
         with pytest.raises(HTTPException) as exc_info:
@@ -355,7 +357,9 @@ class TestAssistantServiceCreate:
         assistant_service.langgraph_service.list_graphs.return_value = {
             "test-graph": {}
         }
-        assistant_service.langgraph_service.get_graph.return_value = Mock()
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            Mock()
+        )
 
         with pytest.raises(HTTPException) as exc_info:
             await assistant_service.create_assistant(request, "user-123")
@@ -379,7 +383,9 @@ class TestAssistantServiceCreate:
         assistant_service.langgraph_service.list_graphs.return_value = {
             "test-graph": {}
         }
-        assistant_service.langgraph_service.get_graph.return_value = Mock()
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            Mock()
+        )
         assistant_service.session.scalar.return_value = None
         assistant_service.session.add = Mock()
         assistant_service.session.commit = AsyncMock()
@@ -419,7 +425,9 @@ class TestAssistantServiceCreate:
         assistant_service.langgraph_service.list_graphs.return_value = {
             "test-graph": {}
         }
-        assistant_service.langgraph_service.get_graph.return_value = Mock()
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            Mock()
+        )
         assistant_service.session.scalar.return_value = None
         assistant_service.session.add = Mock()
         assistant_service.session.commit = AsyncMock()
@@ -480,7 +488,9 @@ class TestAssistantServiceCreate:
         assistant_service.langgraph_service.list_graphs.return_value = {
             "test-graph": {}
         }
-        assistant_service.langgraph_service.get_graph.return_value = Mock()
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            Mock()
+        )
         assistant_service.session.scalar.return_value = existing_assistant
 
         result = await assistant_service.create_assistant(request, "user-123")
@@ -507,7 +517,9 @@ class TestAssistantServiceCreate:
         assistant_service.langgraph_service.list_graphs.return_value = {
             "test-graph": {}
         }
-        assistant_service.langgraph_service.get_graph.return_value = Mock()
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            Mock()
+        )
         assistant_service.session.scalar.return_value = existing_assistant
 
         with pytest.raises(HTTPException) as exc_info:
@@ -896,7 +908,9 @@ class TestAssistantServiceSchemas:
         mock_graph.get_context_jsonschema.return_value = {"type": "object"}
 
         assistant_service.session.scalar.return_value = mock_assistant
-        assistant_service.langgraph_service.get_graph.return_value = mock_graph
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            mock_graph
+        )
 
         result = await assistant_service.get_assistant_schemas("test-id", "user-123")
 
@@ -934,8 +948,8 @@ class TestAssistantServiceSchemas:
         mock_assistant.__table__ = mock_table
 
         assistant_service.session.scalar.return_value = mock_assistant
-        assistant_service.langgraph_service.get_graph.side_effect = Exception(
-            "Graph load failed"
+        assistant_service.langgraph_service.get_graph_for_validation.side_effect = (
+            Exception("Graph load failed")
         )
 
         with pytest.raises(HTTPException) as exc_info:
@@ -973,7 +987,9 @@ class TestAssistantServiceGraph:
         mock_graph.aget_graph = AsyncMock(return_value=mock_drawable_graph)
 
         assistant_service.session.scalar.return_value = mock_assistant
-        assistant_service.langgraph_service.get_graph.return_value = mock_graph
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            mock_graph
+        )
 
         result = await assistant_service.get_assistant_graph(
             "test-id", False, "user-123"
@@ -1003,7 +1019,9 @@ class TestAssistantServiceGraph:
         mock_graph.aget_graph.return_value = Mock()
 
         assistant_service.session.scalar.return_value = mock_assistant
-        assistant_service.langgraph_service.get_graph.return_value = mock_graph
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            mock_graph
+        )
 
         with pytest.raises(HTTPException) as exc_info:
             await assistant_service.get_assistant_graph("test-id", -1, "user-123")
@@ -1031,7 +1049,9 @@ class TestAssistantServiceGraph:
         mock_graph.aget_graph.side_effect = NotImplementedError("Not supported")
 
         assistant_service.session.scalar.return_value = mock_assistant
-        assistant_service.langgraph_service.get_graph.return_value = mock_graph
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            mock_graph
+        )
 
         with pytest.raises(HTTPException) as exc_info:
             await assistant_service.get_assistant_graph("test-id", False, "user-123")
@@ -1077,7 +1097,9 @@ class TestAssistantServiceSubgraphs:
         mock_graph.aget_subgraphs = mock_aget_subgraphs
 
         assistant_service.session.scalar.return_value = mock_assistant
-        assistant_service.langgraph_service.get_graph.return_value = mock_graph
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            mock_graph
+        )
 
         result = await assistant_service.get_assistant_subgraphs(
             "test-id", "namespace1", True, "user-123"
@@ -1106,7 +1128,9 @@ class TestAssistantServiceSubgraphs:
         mock_graph.aget_subgraphs.side_effect = NotImplementedError("Not supported")
 
         assistant_service.session.scalar.return_value = mock_assistant
-        assistant_service.langgraph_service.get_graph.return_value = mock_graph
+        assistant_service.langgraph_service.get_graph_for_validation.return_value = (
+            mock_graph
+        )
 
         with pytest.raises(HTTPException) as exc_info:
             await assistant_service.get_assistant_subgraphs(

--- a/tests/unit/test_threads/test_state_checkpoint.py
+++ b/tests/unit/test_threads/test_state_checkpoint.py
@@ -1,5 +1,6 @@
 """Unit tests for thread state at checkpoint endpoint."""
 
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,6 +11,21 @@ from agent_server.api.threads import (
     get_thread_state_at_checkpoint_post,
 )
 from agent_server.models import ThreadCheckpoint, ThreadCheckpointPostRequest, User
+
+
+def create_get_graph_mock(return_value=None, side_effect=None):
+    """Create a mock for get_graph that works as an async context manager."""
+
+    @asynccontextmanager
+    async def async_cm(*args, **kwargs):
+        if side_effect:
+            raise side_effect
+        yield return_value
+
+    def get_graph(*args, **kwargs):
+        return async_cm(*args, **kwargs)
+
+    return get_graph
 
 
 class TestGetThreadStateAtCheckpoint:
@@ -46,7 +62,9 @@ class TestGetThreadStateAtCheckpoint:
                 return_value=mock_thread_state,
             ) as mock_convert,
         ):
-            mock_service.return_value.get_graph = AsyncMock(return_value=mock_agent)
+            mock_service.return_value.get_graph = create_get_graph_mock(
+                return_value=mock_agent
+            )
 
             result = await get_thread_state_at_checkpoint(
                 "thread-123",
@@ -94,7 +112,9 @@ class TestGetThreadStateAtCheckpoint:
                 return_value=mock_thread_state,
             ),
         ):
-            mock_service.return_value.get_graph = AsyncMock(return_value=mock_agent)
+            mock_service.return_value.get_graph = create_get_graph_mock(
+                return_value=mock_agent
+            )
 
             await get_thread_state_at_checkpoint(
                 "thread-123",
@@ -139,7 +159,9 @@ class TestGetThreadStateAtCheckpoint:
                 return_value=mock_thread_state,
             ),
         ):
-            mock_service.return_value.get_graph = AsyncMock(return_value=mock_agent)
+            mock_service.return_value.get_graph = create_get_graph_mock(
+                return_value=mock_agent
+            )
 
             await get_thread_state_at_checkpoint(
                 "thread-123",


### PR DESCRIPTION
## Summary

This PR provides an alternative solution to the race condition issue addressed in #122, using a simpler architectural pattern that eliminates the need for explicit async locks.

### Changes Made
- **Cache only base graph definitions** (without checkpointer/store) in `_base_graph_cache`
- **Use `asynccontextmanager`** to yield fresh graph copies per-request with injected checkpointer/store
- **Add `get_graph_for_validation()`** for schema extraction without state management
- **Update all callers** in `threads.py`, `runs.py`, and `assistant_service.py` to use the new context manager pattern

### Why This Approach?

Instead of adding async locks to protect shared graph instances, this refactor ensures each request gets its own isolated graph copy:

| Aspect | Async Locks (#122) | Context Manager (This PR) |
|--------|-------------------|---------------------------|
| Thread Safety | Explicit lock management | Inherent via isolation |
| Code Complexity | More complex | Simpler |
| Connection Pool | Shared, risk of exhaustion | Per-request, isolated |
| Memory | Single cached instance | Fresh copies per request |
| Error Handling | Lock cleanup needed | Automatic via context manager |

### Test Plan

- [x] All 494 unit tests pass
- [x] All 171 integration tests pass (11 skipped - no DB)
- [x] All 57 e2e tests pass (1 skipped - known issue)

Supersedes #122