### PR TITLE
fix(streaming): ensure consistent run_id in stream_graph_events

### DIFF
--- a/src/agent_server/services/graph_streaming.py
+++ b/src/agent_server/services/graph_streaming.py
@@ -106,7 +106,7 @@ async def stream_graph_events(
     Yields:
         Tuples of (mode, payload) where mode is the stream mode and payload is the event data
     """
-    run_id = str(config.get("run_id", uuid.uuid4()))
+    run_id = str(config.get("configurable", {}).get("run_id", uuid.uuid4()))
 
     # Prepare stream modes
     stream_modes_set: set[str] = set(stream_mode) - {"events"}


### PR DESCRIPTION
## Description
This PR fixes a bug where the `run_id` returned in the streaming response metadata did not match the actual `run_id` of the execution request.

Previously, `stream_graph_events` attempted to retrieve `run_id` from the root of the `config` object. However, `create_run_config` nests the `run_id` inside the `configurable` dictionary. This caused the stream to generate a new random UUID instead of using the existing one.

## Type of Change
- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
Addresses https://github.com/ibbybuilds/aegra/discussions/141

## Changes Made
- Updated `src/agent_server/services/graph_streaming.py` to correctly retrieve `run_id` from `config.get("configurable")`.
- Added a safety fallback to ensure `run_id` is retrieved even if `configurable` is missing (though unlikely given the upstream logic).

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

*Verified that the `run_id` in the `metadata` event of the stream now matches the `run_id` passed in the request.*

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Additional Notes
This change ensures consistency for clients tracking request/response cycles via `run_id`.