### PR TITLE
fix(middleware): implement strict buffering and safety limits for chunked requests (#100, #146)

### DIFF
--- a/src/agent_server/middleware/double_encoded_json.py
+++ b/src/agent_server/middleware/double_encoded_json.py
@@ -1,79 +1,221 @@
+"""Middleware to handle double-encoded JSON payloads from frontend.
+
+Some frontend clients may send JSON that's been stringified twice,
+resulting in payloads like '"{\\"key\\":\\"value\\"}"' instead of '{"key":"value"}'.
+This middleware detects and corrects such cases.
+"""
+
 import json
 
 import structlog
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 logger = structlog.getLogger(__name__)
 
+# Skip processing for payloads larger than this (likely contain base64 images)
+MAX_BODY_SIZE = 5 * 1024 * 1024  # 5MB
+
 
 class DoubleEncodedJSONMiddleware:
-    """Middleware to handle double-encoded JSON payloads from frontend.
-
-    Some frontend clients may send JSON that's been stringified twice,
-    resulting in payloads like '"{\"key\":\"value\"}"' instead of '{"key":"value"}'.
-    This middleware detects and corrects such cases.
-    """
+    """Detects and unwraps double-encoded JSON payloads."""
 
     def __init__(self, app: ASGIApp):
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Only process HTTP requests
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
 
-        method = scope["method"]
-        headers = dict(scope.get("headers", []))
-        content_type = headers.get(b"content-type", b"").decode("latin1")
-
-        if method in ["POST", "PUT", "PATCH"] and content_type:
-            body_parts = []
-
-            async def receive_wrapper() -> dict:
-                message = await receive()
-                if message["type"] == "http.request":
-                    body_parts.append(message.get("body", b""))
-
-                    if not message.get("more_body", False):
-                        body = b"".join(body_parts)
-
-                        if body:
-                            try:
-                                decoded = body.decode("utf-8")
-                                parsed = json.loads(decoded)
-
-                                if isinstance(parsed, str):
-                                    parsed = json.loads(parsed)
-
-                                new_body = json.dumps(parsed).encode("utf-8")
-
-                                if (
-                                    b"content-type" in headers
-                                    and content_type != "application/json"
-                                ):
-                                    new_headers = []
-                                    for name, value in scope.get("headers", []):
-                                        if name != b"content-type":
-                                            new_headers.append((name, value))
-                                    new_headers.append(
-                                        (b"content-type", b"application/json")
-                                    )
-                                    scope["headers"] = new_headers
-
-                                return {
-                                    "type": "http.request",
-                                    "body": new_body,
-                                    "more_body": False,
-                                }
-                            except (
-                                json.JSONDecodeError,
-                                ValueError,
-                                UnicodeDecodeError,
-                            ):
-                                pass
-
-                return message
-
-            await self.app(scope, receive_wrapper, send)
-        else:
+        method = scope.get("method", "")
+        # Only process requests that might have JSON bodies
+        if method not in ("POST", "PUT", "PATCH"):
             await self.app(scope, receive, send)
+            return
+
+        # Check content type
+        headers = dict(scope.get("headers", []))
+        content_type = headers.get(b"content-type", b"").decode(
+            "latin1", errors="ignore"
+        )
+
+        # Only process JSON-like content types (or text/plain which might be mislabeled JSON)
+        # But generally we want to be permissive here if we are fixing broken clients
+        if (
+            "json" not in content_type.lower()
+            and "text/plain" not in content_type.lower()
+        ):
+            # If it's not JSON or Text, it's probably not double-encoded JSON string
+            await self.app(scope, receive, send)
+            return
+
+        # Buffer the entire request body
+        body_chunks: list[bytes] = []
+        body_received = False
+        total_size = 0
+
+        async def buffering_receive() -> Message:
+            nonlocal body_received, total_size
+            message = await receive()
+            if message["type"] == "http.request":
+                chunk = message.get("body", b"")
+                if chunk:
+                    body_chunks.append(chunk)
+                    total_size += len(chunk)
+
+                # Check if this is the last chunk
+                if not message.get("more_body", False):
+                    body_received = True
+
+            return message
+
+        # Consume the body by calling receive until we have it all or hit the limit
+        while not body_received:
+            msg = await buffering_receive()
+            if msg["type"] == "http.disconnect":
+                # Client disconnected
+                await self.app(scope, receive, send)  # Pass the disconnect through?
+                # Actually, standard is to likely just return?
+                # But let's just break and let the app handle it via our wrapped receive
+                break
+
+            if total_size > MAX_BODY_SIZE:
+                # Too big, stop buffering and pass through what we have + the rest
+                logger.debug(
+                    f"Payload too large ({total_size}+ bytes), skipping double-encoding check"
+                )
+
+                # We need to construct a receive callable that returns:
+                # 1. The chunks we already buffered
+                # 2. The rest of the stream (which we need to fetch from original receive)
+
+                chunks_to_send = list(body_chunks)  # copy
+
+                async def streaming_receive(
+                    chunks: list[bytes] = chunks_to_send,
+                ) -> Message:
+                    if chunks:
+                        chunk = chunks.pop(0)
+
+                        # Determine if there is more body after this chunk
+                        has_more_in_buffer = bool(chunks)
+
+                        # If more in buffer, explicitly True.
+                        # If buffer empty, it depends on whether we had already received the full body from upstream.
+                        # If body_received is True, then this is the final chunk -> False.
+                        # If body_received is False, then upstream has more -> True.
+                        more_body = has_more_in_buffer or not body_received
+
+                        return {
+                            "type": "http.request",
+                            "body": chunk,
+                            "more_body": more_body,
+                        }
+
+                    # If we are here, buffer is empty.
+                    # If body_received was True, we theoretically shouldn't reach here if logic above is correct,
+                    # or receive() might return disconnect. But we should just delegate safely.
+                    return await receive()
+
+                await self.app(scope, streaming_receive, send)
+                return
+
+        if not body_received:
+            # We must have gotten a disconnect or something odd, just bail
+            return
+
+        # Now we have the complete body
+        complete_body = b"".join(body_chunks)
+
+        # Process the body
+        processed_body = self._process_body(complete_body, total_size, headers, scope)
+
+        # Create a new receive function that returns our processed body
+        body_sent = False
+
+        async def body_receive() -> Message:
+            nonlocal body_sent
+            if not body_sent:
+                body_sent = True
+                return {
+                    "type": "http.request",
+                    "body": processed_body,
+                    "more_body": False,
+                }
+            # After body is sent, next call usually expects disconnect or empty/more_body=False
+            # But the app loop typically ends when more_body=False.
+            # If it calls again, let's just return disconnect to be safe/standard conformant.
+            return {"type": "http.disconnect"}
+
+        await self.app(scope, body_receive, send)
+
+    def _process_body(
+        self, body: bytes, size: int, headers: dict, scope: Scope
+    ) -> bytes:
+        """Process the body, unwrapping double-encoded JSON if detected.
+
+        Args:
+            body: The complete request body
+            size: Size of the body in bytes
+            headers: Request headers (for updating Content-Type)
+            scope: ASGI scope
+
+        Returns:
+            Processed body (unwrapped if double-encoded, original otherwise)
+        """
+        # Empty body - nothing to process
+        if not body:
+            return body
+
+        try:
+            decoded = body.decode("utf-8")
+        except UnicodeDecodeError:
+            # Not valid UTF-8, pass through
+            return body
+
+        # Quick heuristic: double-encoded JSON starts with a quote character
+        stripped = decoded.strip()
+        if not stripped.startswith('"'):
+            return body
+
+        # Might be double-encoded, try to parse
+        try:
+            parsed = json.loads(decoded)
+        except json.JSONDecodeError:
+            return body
+
+        # Check if the result is a string (which would indicate double-encoding)
+        if not isinstance(parsed, str):
+            # It's valid JSON but not a string - e.g. normal JSON object/list
+            return body
+
+        # It's a string - check if that string is valid JSON (the inner payload)
+        try:
+            inner = json.loads(parsed)
+            # Successfully parsed inner JSON - this was double-encoded
+
+            # Re-serialize to ensure clean JSON
+            result = json.dumps(inner, ensure_ascii=False).encode("utf-8")
+
+            logger.debug(
+                f"Unwrapped double-encoded JSON payload ({size} -> {len(result)} bytes)"
+            )
+
+            # Fix content type if it was text/plain
+            content_type = headers.get(b"content-type", b"").decode(
+                "latin1", errors="ignore"
+            )
+            if "application/json" not in content_type:
+                new_headers = []
+                for name, value in scope.get("headers", []):
+                    if name.lower() != b"content-type":
+                        new_headers.append((name, value))
+                new_headers.append((b"content-type", b"application/json"))
+                scope["headers"] = new_headers
+
+            return result
+
+        except json.JSONDecodeError:
+            # The inner string is not JSON - it's just a string value, not double-encoded
+            return body

--- a/tests/unit/test_middleware/test_double_encoded_json.py
+++ b/tests/unit/test_middleware/test_double_encoded_json.py
@@ -5,9 +5,11 @@ without requiring database or full application integration.
 """
 
 import json
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from starlette.requests import Request
+from starlette.types import Message
 
 from agent_server.middleware.double_encoded_json import DoubleEncodedJSONMiddleware
 
@@ -387,3 +389,216 @@ async def test_middleware_handles_json_array():
     await middleware(scope, receive, send)
 
     assert app.called
+
+
+@pytest.mark.asyncio
+async def test_middleware_skips_large_payloads():
+    """Test that payloads exceeding MAX_BODY_SIZE are skipped and passed through."""
+    app = AsyncMock()
+
+    # Set a small limit for testing (10 bytes)
+    with patch("agent_server.middleware.double_encoded_json.MAX_BODY_SIZE", 10):
+        middleware = DoubleEncodedJSONMiddleware(app)
+
+        # Payload larger than 10 bytes that LOOKS like double-encoded JSON
+        # If processed, it would be unwrapped. If skipped, it remains as is.
+        inner = {"key": "val"}
+        # Length of this is > 10
+        body = json.dumps(json.dumps(inner)).encode("utf-8")
+        assert len(body) > 10
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "headers": [(b"content-type", b"application/json")],
+        }
+
+        # Simulate receiving in one go (or multiple, doesn't matter for size check trigger)
+        receive_iter = iter(
+            [
+                {"type": "http.request", "body": body, "more_body": False},
+                {"type": "http.disconnect"},
+            ]
+        )
+
+        async def receive():
+            return next(receive_iter)
+
+        async def mock_app(scope, receive, send):
+            # Read the body passed to the app
+            message = await receive()
+            assert message["type"] == "http.request"
+            received_body = message.get("body", b"")
+            while message.get("more_body", False):
+                message = await receive()
+                received_body += message.get("body", b"")
+
+            # Since size > MAX_BODY_SIZE, it should SKIP decoding.
+            # So we expect the ORIGINAL double-encoded body.
+            assert received_body == body
+
+        middleware.app = mock_app
+
+        send = AsyncMock()
+        await middleware(scope, receive, send)
+
+
+@pytest.mark.asyncio
+async def test_middleware_handles_fragmented_chunks():
+    """Test reassembly of highly fragmented chunks."""
+    app = AsyncMock()
+    middleware = DoubleEncodedJSONMiddleware(app)
+
+    inner = {"key": "value"}
+    # Double encoded: '"{\\"key\\": \\"value\\"}"'
+    full_body = json.dumps(json.dumps(inner)).encode("utf-8")
+
+    # Split into 1-byte chunks to stress the buffering logic
+    chunks = [bytes([b]) for b in full_body]
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": [(b"content-type", b"application/json")],
+    }
+
+    async def receive():
+        if chunks:
+            chunk = chunks.pop(0)
+            return {"type": "http.request", "body": chunk, "more_body": bool(chunks)}
+        return {"type": "http.disconnect"}
+
+    async def mock_app(scope, receive, send):
+        message = await receive()
+        received_body = message.get("body", b"")
+        # Middleware should present fully buffered body (or stream decoded one)
+        # Our implementation buffers fully, then decodes, then sends as one chunk
+        # (or standard ASGI stream if we wanted, but we send as one chunk in the fix).
+
+        # The fix sends: {"type": "http.request", "body": processed_body, "more_body": False}
+        assert message["more_body"] is False
+
+        # Should be DECODED
+        expected = json.dumps(inner, ensure_ascii=False).encode("utf-8")
+        assert received_body == expected
+
+    middleware.app = mock_app
+    send = AsyncMock()
+
+    await middleware(scope, receive, send)
+
+
+@pytest.mark.asyncio
+async def test_streaming_handoff_correctness():
+    """
+    Verify that when the middleware hits the size limit, it correctly hands off
+    the buffered chunks AND the remaining stream to the app, preserving the
+    original data sequence and streaming behavior.
+    """
+    app = AsyncMock()
+
+    # Set limit to 5 bytes
+    with patch("agent_server.middleware.double_encoded_json.MAX_BODY_SIZE", 5):
+        middleware = DoubleEncodedJSONMiddleware(app)
+
+        # Total body: "12345" (buffer) + "67890" (stream)
+        # Chunks: "1", "2", "3", "4", "5", "6", "7", "8", "9", "0"
+        full_payload = b"1234567890"
+        chunks = [bytes([b]) for b in full_payload]
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "headers": [(b"content-type", b"application/json")],
+        }
+
+        # Create a receiver that yields one byte at a time
+        async def receive():
+            if chunks:
+                chunk = chunks.pop(0)
+                return {
+                    "type": "http.request",
+                    "body": chunk,
+                    "more_body": bool(chunks),
+                }
+            return {"type": "http.disconnect"}
+
+        async def mock_app(scope, receive, send):
+            # The app should be able to consume the FULL stream
+            received = b""
+            more_body = True
+            while more_body:
+                msg = await receive()
+                if msg["type"] == "http.request":
+                    received += msg.get("body", b"")
+                    more_body = msg.get("more_body", False)
+
+            assert received == full_payload
+
+        middleware.app = mock_app
+        send = AsyncMock()
+
+        await middleware(scope, receive, send)
+
+
+@pytest.mark.asyncio
+async def test_streaming_handoff_at_limit_boundary():
+    """
+    Verify behavior when the payload exceeds the limit exactly at the last chunk.
+    This tests if 'more_body=True' is incorrectly sent when no more body exists.
+    """
+    app = AsyncMock()
+
+    # Limit 5. Payload 6. One chunk.
+    # Logic: Buffer reads 6. limit hit.
+    # streaming_receive yields 6 with more_body=True.
+    # Application reads 6. expecting more.
+    # Application calls receive().
+    # Underlying receive yields disconnect (or whatever comes after).
+    # If using Starlette Request.stream(), this triggers ClientDisconnect!
+
+    with patch("agent_server.middleware.double_encoded_json.MAX_BODY_SIZE", 5):
+        middleware = DoubleEncodedJSONMiddleware(app)
+
+        body = b"123456"
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "headers": [(b"content-type", b"application/json")],
+        }
+
+        # Iterator for the receive mock
+        # 1. The chunk (more_body=False)
+        # 2. Disconnect
+        receive_iter = iter(
+            [
+                {"type": "http.request", "body": body, "more_body": False},
+                {"type": "http.disconnect"},
+            ]
+        )
+
+        async def receive() -> Message:
+            try:
+                return next(receive_iter)
+            except StopIteration:
+                # Should not happen in typical loop if logic is correct
+                return {"type": "http.disconnect"}
+
+        async def mock_app(scope, receive, send):
+            # Simulate strict Starlette-like stream consumption
+            request = Request(scope, receive)
+            try:
+                content = b""
+                async for chunk in request.stream():
+                    content += chunk
+                assert content == body
+            except Exception as e:
+                # If ClientDisconnect happens, this will catch it
+                pytest.fail(
+                    f"App raised exception during streaming: {type(e).__name__}: {e}"
+                )
+
+        middleware.app = mock_app
+        send = AsyncMock()
+
+        await middleware(scope, receive, send)


### PR DESCRIPTION
## Description
Rewrote the [DoubleEncodedJSONMiddleware](cci:2://file:///home/max/PythonProjects/aegra/src/agent_server/middleware/double_encoded_json.py:18:0-220:23) to robustly handle chunked requests and large payloads. This fixes critical bugs where the middleware would attempt to decode partial JSON chunks or fail on large bodies (like base64 images).
  - Added [test_middleware_handles_fragmented_chunks](cci:1://file:///home/max/PythonProjects/aegra/tests/unit/test_middleware/test_double_encoded_json.py:445:0-487:42): Verifies that the middleware correctly reassembles highly fragmented (1-byte chunk) streams.
  - Added [test_streaming_handoff_correctness](cci:1://file:///home/max/PythonProjects/aegra/tests/unit/test_middleware/test_double_encoded_json.py:490:0-540:46): explicitly verifies that when `MAX_BODY_SIZE` is hit, the middleware correctly stitches the buffered chunks and remaining stream back together.
  - Added [test_streaming_handoff_at_limit_boundary](cci:1://file:///home/max/PythonProjects/aegra/tests/unit/test_middleware/test_double_encoded_json.py:543:0-603:46): explicitly verifies correct [more_body](cci:1://file:///home/max/PythonProjects/aegra/tests/unit/test_middleware/test_double_encoded_json.py:265:0-295:21) handling when the limit is hit exactly at the end of the stream, preventing `ClientDisconnect` errors (validating the fix for the Owner's "ASGI Error" concern).
This prevents `JSON decode error` (Issue #100) and potential memory issues (Issue #146).

## Type of Change
- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [x] [test](cci:1://file:///home/max/PythonProjects/aegra/tests/unit/test_middleware/test_double_encoded_json.py:490:0-540:46): Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
Fixes #100, Closes #146

## Changes Made
- Implemented strict request body buffering to prevent partial JSON parsing.
- Added `MAX_BODY_SIZE` (5MB) limit to skip processing for large payloads (e.g. base64 images).
- Rewrote middleware [__call__](cci:1://file:///home/max/PythonProjects/aegra/src/agent_server/middleware/double_encoded_json.py:24:4-150:49) for correct ASGI lifecycle handling and stream proxing.
- Added robust unit tests for large payloads and fragmented chunks.

## Testing
- [x] Unit tests added/updated ([tests/unit/test_middleware/test_double_encoded_json.py](cci:7://file:///home/max/PythonProjects/aegra/tests/unit/test_middleware/test_double_encoded_json.py:0:0-0:0): 16 tests passed)
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed (Verified with custom reproduction script simulating chunked payloads)

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`) (Passed for modified files; ignored unrelated legacy errors)
- [x] All tests pass (`make test`) (Passed relevant unit tests; ignored unrelated environment/DB failures)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Screenshots (if applicable)
N/A

## Additional Notes
The `make type-check` and `make test` commands fail on unrelated files/tests due to existing technical debt and missing local database configuration. I verified my changes specifically with `uv run mypy src/agent_server/middleware/double_encoded_json.py` (success) and `uv run pytest tests/unit/test_middleware/test_double_encoded_json.py` (success).