### PR TITLE
fix: release workflow artifact upload for uv workspace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,14 @@ jobs:
 
       - name: Build package
         working-directory: libs/aegra-api
-        run: uv build
+        run: uv build --output-dir dist/
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: dist-aegra-api
           path: libs/aegra-api/dist/
+          if-no-files-found: error
 
   publish-api:
     needs: [build-api]
@@ -114,13 +115,14 @@ jobs:
 
       - name: Build package
         working-directory: libs/aegra-cli
-        run: uv build
+        run: uv build --output-dir dist/
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: dist-aegra-cli
           path: libs/aegra-cli/dist/
+          if-no-files-found: error
 
   publish-cli:
     needs: [build-cli]


### PR DESCRIPTION
## Summary

- Fix `uv build` output directory in release workflow — newer uv versions output to the workspace root `dist/` instead of the package-local `dist/` when building in a uv workspace member directory
- Add `--output-dir dist/` flag to both `build-api` and `build-cli` jobs to explicitly control output location
- Change `if-no-files-found` from `warn` (default) to `error` so empty artifact uploads fail the build instead of silently passing

## Root Cause

`uv build` in `libs/aegra-api/` now outputs to `/home/runner/work/aegra/aegra/dist/` (workspace root) instead of `libs/aegra-api/dist/`. The `upload-artifact` step looked for `libs/aegra-api/dist/` which was empty, issued a warning (not an error), and `publish-api` then failed because the artifact was never uploaded.

**Before (v0.2.0 release - worked):** `Successfully built dist/aegra_api-0.2.0.tar.gz` (relative, local dist/)
**After (v0.3.0 release - failed):** `Successfully built /home/runner/work/aegra/aegra/dist/aegra_api-0.3.0.tar.gz` (absolute, workspace root)

## Test plan

- [ ] Merge and trigger release workflow with `package: both`
- [ ] Verify `build-api` uploads artifacts successfully
- [ ] Verify `publish-api` downloads and publishes to PyPI
- [ ] Verify `build-cli` and `publish-cli` work the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build artifact handling in release workflow with enhanced output directory configuration and error detection for missing build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->