### PR TITLE
fix: POSTGRES_HOST default, .env parsing, and config simplification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,11 +11,11 @@ AEGRA_CONFIG=
 # DATABASE_URL=postgresql://user:password@host:5432/aegra
 #
 # Option 2: Individual fields (used when DATABASE_URL is not set)
-POSTGRES_USER=user
-POSTGRES_PASSWORD=password
 POSTGRES_DB=aegra
-POSTGRES_HOST=postgres
+POSTGRES_HOST=localhost
+POSTGRES_PASSWORD=password
 POSTGRES_PORT=5432
+POSTGRES_USER=user
 DB_ECHO_LOG=false
 
 # --- Connection Pools ---

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.4.0"
+version = "0.4.1"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -45,7 +45,6 @@ dependencies = [
 
     # Utils
     "structlog>=25.4.0",
-    "python-dotenv>=1.1.1",
     "asgi-correlation-id>=4.3.4",
     "pyjwt>=2.10.1",
 ]

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -1,25 +1,10 @@
 """FastAPI application for Aegra (Agent Protocol Server)"""
 
 import asyncio
-import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from pathlib import Path
 from typing import Any
 
-from dotenv import load_dotenv
-
-# Load environment variables from .env file
-load_dotenv()
-
-# Add graphs directory to Python path so react_agent can be imported
-# This MUST happen before importing any modules that depend on graphs/
-current_dir = Path(__file__).parent.parent.parent  # Go up to aegra root
-graphs_dir = current_dir / "graphs"
-if str(graphs_dir) not in sys.path:
-    sys.path.insert(0, str(graphs_dir))
-
-# ruff: noqa: E402 - imports below require sys.path modification above
 import structlog
 from asgi_correlation_id import CorrelationIdMiddleware
 from fastapi import FastAPI, HTTPException, Request

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -22,8 +22,6 @@ UpperStr = Annotated[str, BeforeValidator(parse_upper)]
 
 class EnvBase(BaseSettings):
     model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
         extra="ignore",
     )
 

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.4.0"
+version = "0.4.1"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -22,6 +22,7 @@ dependencies = [
     "click>=8.1.7",
     "rich>=13.0",
     "jinja2>=3.1",
+    "python-dotenv>=1.1.1",
 
     # Server (always included)
     "aegra-api~=0.4.0",

--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import click
+from dotenv import dotenv_values
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -56,7 +57,9 @@ def version():
 
 
 def load_env_file(env_file: Path | None) -> Path | None:
-    """Load environment variables from a .env file.
+    """Load environment variables from a .env file using python-dotenv.
+
+    Existing environment variables take precedence and are not overwritten.
 
     Args:
         env_file: Path to .env file, or None to use default (.env in cwd)
@@ -73,30 +76,13 @@ def load_env_file(env_file: Path | None) -> Path | None:
         # Default: look for .env in current directory
         target = Path.cwd() / ".env"
 
-    if not target.exists():
+    if not target.is_file():
         return None
 
-    # Load the .env file into environment
-    # Simple parser - handles KEY=value format
-    with open(target, encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            # Skip empty lines and comments
-            if not line or line.startswith("#"):
-                continue
-            # Parse KEY=value (handle = in value)
-            if "=" in line:
-                key, _, value = line.partition("=")
-                key = key.strip()
-                value = value.strip()
-                # Remove surrounding quotes if present
-                if (value.startswith('"') and value.endswith('"')) or (
-                    value.startswith("'") and value.endswith("'")
-                ):
-                    value = value[1:-1]
-                # Only set if not already in environment (env vars take precedence)
-                if key and key not in os.environ:
-                    os.environ[key] = value
+    # Parse .env file and set vars (existing env vars take precedence)
+    for key, value in dotenv_values(target).items():
+        if key not in os.environ and value is not None:
+            os.environ[key] = value
 
     return target
 
@@ -478,13 +464,23 @@ def serve(host: str, port: int, app: str, config_file: Path | None, workers: int
     # Set AEGRA_CONFIG env var
     os.environ["AEGRA_CONFIG"] = str(resolved_config)
 
+    # Load .env file from config directory (same logic as dev command)
+    config_dir_env = resolved_config.parent / ".env"
+    loaded_env = load_env_file(config_dir_env if config_dir_env.exists() else None)
+
+    info_lines = [
+        "[bold green]Starting Aegra production server[/bold green]\n",
+        f"[cyan]Host:[/cyan] {host}",
+        f"[cyan]Port:[/cyan] {port}",
+        f"[cyan]Workers:[/cyan] {workers}",
+        f"[cyan]Config:[/cyan] {resolved_config}",
+    ]
+    if loaded_env:
+        info_lines.append(f"[cyan]Env:[/cyan] {loaded_env}")
+
     console.print(
         Panel(
-            f"[bold green]Starting Aegra production server[/bold green]\n\n"
-            f"[cyan]Host:[/cyan] {host}\n"
-            f"[cyan]Port:[/cyan] {port}\n"
-            f"[cyan]Workers:[/cyan] {workers}\n"
-            f"[cyan]Config:[/cyan] {resolved_config}",
+            "\n".join(info_lines),
             title="[bold]Aegra Server[/bold]",
             border_style="green",
         )

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -11,11 +11,11 @@ AEGRA_CONFIG=
 # DATABASE_URL=postgresql://user:password@host:5432/{slug}
 #
 # Option 2: Individual fields (used when DATABASE_URL is not set)
-POSTGRES_USER={slug}
-POSTGRES_PASSWORD={slug}_secret
 POSTGRES_DB={slug}
-POSTGRES_HOST=postgres
+POSTGRES_HOST=localhost
+POSTGRES_PASSWORD={slug}_secret
 POSTGRES_PORT=5432
+POSTGRES_USER={slug}
 DB_ECHO_LOG=false
 
 # --- Connection Pools ---

--- a/libs/aegra-cli/tests/test_cli.py
+++ b/libs/aegra-cli/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -15,6 +16,7 @@ from aegra_cli.cli import (
     ensure_docker_files_prod,
     find_config_file,
     get_project_slug,
+    load_env_file,
 )
 
 if TYPE_CHECKING:
@@ -846,3 +848,93 @@ class TestDownCommandExtended:
             result = cli_runner.invoke(cli, ["down"])
             assert result.exit_code == 0
             assert "No docker-compose files found" in result.output
+
+
+class TestLoadEnvFile:
+    """Tests for the .env file parser."""
+
+    def test_loads_simple_key_value(self, tmp_path: Path) -> None:
+        """Test basic KEY=value parsing."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_VAR=hello\n")
+        with patch.dict("os.environ", {}, clear=True):
+            load_env_file(env_file)
+
+            assert os.environ["MY_VAR"] == "hello"
+
+    def test_strips_inline_comments_from_unquoted_values(self, tmp_path: Path) -> None:
+        """Test that inline comments are stripped from unquoted values."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("ENV_MODE=LOCAL # this is a comment\n")
+        with patch.dict("os.environ", {}, clear=True):
+            load_env_file(env_file)
+
+            assert os.environ["ENV_MODE"] == "LOCAL"
+
+    def test_preserves_hash_in_quoted_values(self, tmp_path: Path) -> None:
+        """Test that # inside quoted values is preserved."""
+        env_file = tmp_path / ".env"
+        env_file.write_text('PASSWORD="my#secret"\n')
+        with patch.dict("os.environ", {}, clear=True):
+            load_env_file(env_file)
+
+            assert os.environ["PASSWORD"] == "my#secret"
+
+    def test_preserves_hash_in_single_quoted_values(self, tmp_path: Path) -> None:
+        """Test that # inside single-quoted values is preserved."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("PASSWORD='my#secret'\n")
+        with patch.dict("os.environ", {}, clear=True):
+            load_env_file(env_file)
+
+            assert os.environ["PASSWORD"] == "my#secret"
+
+    def test_skips_comment_lines(self, tmp_path: Path) -> None:
+        """Test that full-line comments are skipped."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("# this is a comment\nKEY=value\n")
+        with patch.dict("os.environ", {}, clear=True):
+            load_env_file(env_file)
+
+            assert os.environ.get("KEY") == "value"
+            assert "# this is a comment" not in os.environ
+
+    def test_skips_empty_lines(self, tmp_path: Path) -> None:
+        """Test that empty lines are skipped."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("\n\nKEY=value\n\n")
+        with patch.dict("os.environ", {}, clear=True):
+            load_env_file(env_file)
+
+            assert os.environ["KEY"] == "value"
+
+    def test_does_not_override_existing_env_vars(self, tmp_path: Path) -> None:
+        """Test that existing env vars are not overwritten."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("MY_VAR=from_file\n")
+        with patch.dict("os.environ", {"MY_VAR": "from_env"}, clear=True):
+            load_env_file(env_file)
+
+            assert os.environ["MY_VAR"] == "from_env"
+
+    def test_returns_none_for_nonexistent_file(self, tmp_path: Path) -> None:
+        """Test that None is returned when .env file doesn't exist."""
+        result = load_env_file(tmp_path / "nonexistent.env")
+        assert result is None
+
+    def test_returns_path_on_success(self, tmp_path: Path) -> None:
+        """Test that the file path is returned on success."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("KEY=value\n")
+        with patch.dict("os.environ", {}, clear=True):
+            result = load_env_file(env_file)
+            assert result == env_file
+
+    def test_inline_comment_with_multiple_hashes(self, tmp_path: Path) -> None:
+        """Test stripping inline comment when value itself has no quotes."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("AUTH_TYPE=noop  # noop, custom\n")
+        with patch.dict("os.environ", {}, clear=True):
+            load_env_file(env_file)
+
+            assert os.environ["AUTH_TYPE"] == "noop"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -35,7 +35,6 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
-    { name = "python-dotenv" },
     { name = "sqlalchemy" },
     { name = "structlog" },
     { name = "uvicorn" },
@@ -72,7 +71,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "pyjwt", specifier = ">=2.10.1" },
-    { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
@@ -92,12 +90,13 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },
     { name = "click" },
     { name = "jinja2" },
+    { name = "python-dotenv" },
     { name = "rich" },
 ]
 
@@ -114,6 +113,7 @@ requires-dist = [
     { name = "aegra-api", editable = "libs/aegra-api" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "jinja2", specifier = ">=3.1" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "rich", specifier = ">=13.0" },
 ]
 


### PR DESCRIPTION
## Summary

- **Fix `aegra dev` DNS failure**: Default `POSTGRES_HOST` changed from `postgres` (Docker service name) to `localhost` in `.env.example` files. `aegra dev` runs uvicorn on the host machine where `postgres` doesn't resolve — the Docker container exposes port 5432 to `localhost`. Production compose (`aegra up`) already hardcodes `POSTGRES_HOST=postgres` in the container environment block, so this is safe.
- **Fix JSON logs in LOCAL mode**: Replaced hand-rolled `.env` parser with `python-dotenv` (`dotenv_values`). The old parser didn't strip inline comments, so `ENV_MODE=LOCAL # comment` was parsed as the full string, bypassing the `ConsoleRenderer` and falling through to `JSONRenderer`.
- **Simplify config loading**: Removed 3 redundant `.env` loading mechanisms — CLI is now the single source of truth. Removed broken `sys.path` graphs hack from `main.py` (pointed to wrong location when installed as package; `langgraph_service._setup_dependencies()` handles this via `aegra.json` `dependencies` config).
- **Fix `aegra serve`**: Added `.env` loading that was missing (unlike `aegra dev`).

## Changes

| File | Change |
|------|--------|
| `.env.example` | `POSTGRES_HOST=postgres` → `localhost` |
| `env.example.template` | `POSTGRES_HOST=postgres` → `localhost` |
| `main.py` | Remove `load_dotenv()`, `sys.path` hack, unused imports |
| `settings.py` | Remove `env_file=".env"` from pydantic-settings |
| `cli.py` | Use `dotenv_values()` instead of hand-rolled parser; add `.env` loading to `serve` |
| `aegra-api/pyproject.toml` | Remove `python-dotenv` dep, bump to 0.4.1 |
| `aegra-cli/pyproject.toml` | Add `python-dotenv` dep, bump to 0.4.1 |
| `test_cli.py` | Add 10 tests for `load_env_file()` |

## Config flow (before → after)

**Before:** `.env` loaded 3 times (CLI → `main.py` `load_dotenv()` → pydantic-settings `env_file`)
**After:** `.env` loaded once by CLI → `os.environ` → pydantic-settings reads `os.environ`

## Test plan

- [x] `aegra dev` connects to PostgreSQL without DNS error
- [x] Logs display as colored console output (not JSON) in LOCAL mode
- [x] 795 aegra-api unit tests pass
- [x] 186 aegra-cli tests pass (including 10 new `load_env_file` tests)
- [x] `ruff check` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI startup panels now show loaded environment configuration when available.

* **Chores**
  * Bumped project versions to 0.4.1.
  * Changed default development DB host from "postgres" to "localhost".
  * Reworked environment-loading behavior between API and CLI components and adjusted dependency placement.

* **Tests**
  * Added thorough tests for .env parsing and handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->