### PR TITLE
fix: relax FastAPI lower bound from >=0.116.1 to >=0.110.1

### DIFF
--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.7.0"
+version = "0.7.1"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,7 +18,7 @@ classifiers = [
 
 dependencies = [
     # Core
-    "fastapi>=0.116.1",
+    "fastapi>=0.110.1",
     "uvicorn>=0.35.0",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.12.0",

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.7.0"
+version = "0.7.1"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -55,7 +55,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.16.4" },
     { name = "asgi-correlation-id", specifier = ">=4.3.4" },
     { name = "asyncpg", specifier = ">=0.30.0" },
-    { name = "fastapi", specifier = ">=0.116.1" },
+    { name = "fastapi", specifier = ">=0.110.1" },
     { name = "langgraph", specifier = ">=1.0.3" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.23" },
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.58" },
@@ -86,7 +86,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary
- Lowers the FastAPI version constraint in `aegra-api` from `>=0.116.1` to `>=0.110.1`
- Bumps version to `0.7.1` in both `aegra-api` and `aegra-cli`
- Unblocks installation alongside packages like CopilotKit that pin `fastapi<0.116.0`

## Context

The `>=0.116.1` lower bound was set to "whatever was current at the time" but no code in aegra-api actually requires features from FastAPI 0.116+. The most modern feature used (`router.lifespan_context` in `core/route_merger.py`) has been stable since FastAPI 0.93.0. The 0.115 → 0.116 release was mostly FastAPI Cloud CLI tooling, not core API changes.

## Testing

Tested against multiple FastAPI versions locally:

| FastAPI Version | Starlette Version | Unit Tests (591) | Result |
|---|---|---|---|
| **0.110.0** | 0.36.3 | 587 passed, 1 failed | FAIL (test infra only) |
| **0.110.1** | 0.37.2 | 591 passed | PASS |
| **0.112.0** | 0.37.2 | 591 passed | PASS |
| **0.115.0** | — | 591 passed | PASS |
| **0.128.6** (current) | 0.52.1 | 591 passed | PASS |

The single failure on 0.110.0 is a `TestClient` keyword argument change in Starlette 0.36.3 → 0.37.2 (test infrastructure, not application code).

## Test plan
- [ ] CI passes (lint + unit tests for both packages)
- [ ] Verify `uv add aegra-cli copilotkit==0.1.78` resolves successfully in a clean environment

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.7.1 for aegra-api and aegra-cli packages.
  * Adjusted FastAPI minimum version requirement to improve compatibility with existing deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->