### PR TITLE
fix(api): decode literal \uXXXX sequences in SSE output

### DIFF
--- a/libs/aegra-api/src/aegra_api/core/sse.py
+++ b/libs/aegra-api/src/aegra_api/core/sse.py
@@ -12,6 +12,33 @@ from aegra_api.core.serializers import GeneralSerializer
 # Global serializer instance
 _serializer = GeneralSerializer()
 
+# Some LLMs stream tool_call_chunks.args with literal \uXXXX sequences
+# instead of actual Unicode characters. After json.dumps these become \\uXXXX (double-escaped).
+# We decode them back in two passes: surrogate pairs first to avoid lone surrogates that
+# cannot be encoded to UTF-8, then remaining non-ASCII, non-surrogate code points.
+# ASCII control characters (< 0x80) are left intact to preserve JSON validity.
+_SURROGATE_PAIR_RE = re.compile(
+    r"\\\\u(D[89AB][0-9a-fA-F]{2})\\\\u(D[C-F][0-9a-fA-F]{2})",
+    re.IGNORECASE,
+)
+_NONASCII_ESCAPE_RE = re.compile(r"\\\\u([0-9a-fA-F]{4})")
+
+
+def _decode_literal_unicode_escapes(data_str: str) -> str:
+    """Decode double-escaped \\uXXXX sequences in an already-JSON-encoded string."""
+    if "\\u" not in data_str:
+        return data_str
+    # First pass: combine surrogate pairs (e.g. \\uD83D\\uDE00 → 😀)
+    data_str = _SURROGATE_PAIR_RE.sub(
+        lambda m: chr(((int(m.group(1), 16) - 0xD800) << 10) + (int(m.group(2), 16) - 0xDC00) + 0x10000),
+        data_str,
+    )
+    # Second pass: decode remaining non-ASCII, non-surrogate escapes
+    return _NONASCII_ESCAPE_RE.sub(
+        lambda m: chr(cp) if (cp := int(m.group(1), 16)) >= 0x80 and not (0xD800 <= cp <= 0xDFFF) else m.group(0),
+        data_str,
+    )
+
 
 def get_sse_headers() -> dict[str, str]:
     """Get standard SSE headers"""
@@ -49,16 +76,7 @@ def format_sse_message(
         # Use our general serializer by default to handle complex objects
         default_serializer = serializer or _serializer.serialize
         data_str = json.dumps(data, default=default_serializer, separators=(",", ":"), ensure_ascii=False)
-        # Some LLMs stream tool_call_chunks.args with literal \uXXXX escape
-        # sequences. json.dumps double-escapes the backslash (\\uXXXX), so we
-        # decode non-ASCII code points (>= 0x80) back to characters. ASCII
-        # control characters are left intact to preserve JSON validity.
-        if "\\u" in data_str:
-            data_str = re.sub(
-                r"\\\\u([0-9a-fA-F]{4})",
-                lambda m: chr(cp) if (cp := int(m.group(1), 16)) >= 0x80 else m.group(0),
-                data_str,
-            )
+        data_str = _decode_literal_unicode_escapes(data_str)
 
     lines.append(f"data: {data_str}")
 

--- a/libs/aegra-api/tests/unit/test_core/test_sse.py
+++ b/libs/aegra-api/tests/unit/test_core/test_sse.py
@@ -91,6 +91,26 @@ class TestFormatSSEMessage:
         parsed_data = json.loads(data_line.replace("data: ", ""))
         assert parsed_data == data
 
+    def test_format_message_decodes_surrogate_pairs(self):
+        """Surrogate pairs from LLM streaming are decoded to the actual character.
+
+        Some LLMs encode emoji as surrogate pairs (\\uD83D\\uDE00 → 😀).
+        Decoding each half independently produces a lone surrogate that cannot
+        be encoded to UTF-8 and would crash the stream. Verify they are combined.
+        """
+        data = {"tool_call_chunks": [{"args": '{"emoji": "\\uD83D\\uDE00"}'}]}
+        result = format_sse_message("messages", data)
+        data_line = next(line for line in result.split("\n") if line.startswith("data: "))
+        assert "😀" in data_line
+        assert "\\uD83D" not in data_line
+
+    def test_format_message_preserves_lone_surrogates(self):
+        """A lone surrogate without its pair is left intact rather than decoded."""
+        data = {"tool_call_chunks": [{"args": '{"x": "\\uD83D"}'}]}
+        result = format_sse_message("messages", data)
+        data_line = next(line for line in result.split("\n") if line.startswith("data: "))
+        assert "\\uD83D" in data_line
+
     def test_format_message_with_custom_serializer(self):
         """Test SSE message with custom serializer"""
 


### PR DESCRIPTION
## Description

  Follows up on #212 which fixed Cyrillic characters in SSE output by adding `ensure_ascii=False` to `json.dumps`. That fix handled Python-native Unicode strings
  correctly, but one case remained broken: some LLMs (confirmed with GigaChat) stream `tool_call_chunks.args` as raw JSON text where non-ASCII characters are
  pre-encoded as literal `\uXXXX` escape sequences (e.g. `\u041f` as 6 characters, not the actual character `П`).

  `ensure_ascii=False` only prevents the JSON encoder from *adding* escapes — it cannot decode escapes that already exist in the source string. As a result, Cyrillic
   text in streaming tool calls was still appearing escaped in the SSE output even after #212.

  **Root cause:** `json.dumps` sees a backslash in the source string and double-escapes it (`\u041f` → `\\u041f`), so the client receives `\\u041f` and after
  `json.loads` still gets a literal 6-char sequence instead of `П`.

  **Fix:** After `json.dumps`, post-process the serialized string with `re.sub` to decode `\\uXXXX` sequences for non-ASCII code points (`>= 0x80`) back to their
  Unicode characters. ASCII control characters (`\u0000`–`\u007f`) are intentionally left intact because decoding them (e.g. `\u0022` → `"`, `\u005c` → `\`) would
  break JSON validity.

  ## Type of Change

  - [ ] `feat`: New feature
  - [x] `fix`: Bug fix
  - [ ] `docs`: Documentation changes
  - [ ] `style`: Code style/formatting
  - [ ] `refactor`: Code refactoring
  - [ ] `perf`: Performance improvement
  - [ ] `test`: Tests added/updated
  - [ ] `chore`: Maintenance (dependencies, build, etc.)
  - [ ] `ci`: CI/CD changes

  ## Related Issues

  Follows up on #212 (fix: return non-ASCII characters as-is in SSE stream)

  ## Changes Made

  - `libs/aegra-api/src/aegra_api/core/sse.py`: added `import re` and a post-processing step in `format_sse_message` that decodes double-escaped `\\uXXXX` sequences
  for non-ASCII code points after `json.dumps`
  - `libs/aegra-api/tests/unit/test_core/test_sse.py`: added two regression tests — one verifying that `\uXXXX` Cyrillic sequences are decoded in SSE output, one
  verifying that ASCII control escapes are preserved

  ## Testing

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] E2E tests added/updated
  - [x] Manual testing performed

  Manual test: streamed a GigaChat response containing a `Think` tool call with Cyrillic text in `args`. Before the fix, the SSE `messages` event contained
  `\\u041f\\u043e\\u043b...` in `tool_call_chunks[0].args`. After the fix, the same field shows `Пользователь` as expected. Fields already working in #212
  (`content`, `tool_calls[0].args`) remain unaffected.

  ## Checklist

  - [x] Code follows project style (Ruff formatting)
  - [x] All linting checks pass (`make lint`)
  - [x] Type checking passes (`make type-check`)
  - [x] All tests pass (`make test`)
  - [ ] Documentation updated (if needed)
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] PR title follows Conventional Commits format

  ## Additional Notes

  The fix is intentionally minimal: 8 lines in `format_sse_message`, no changes to `GeneralSerializer` or any other layer. The `"\\u" in data_str` guard ensures the
  regex runs only when the output actually contains a backslash-u substring, keeping the hot path allocation-free for the common case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode handling in real-time message streams so literal Unicode escape sequences (e.g., \uXXXX) are decoded to display non‑ASCII characters correctly.
  * Correctly decodes surrogate-pair escapes (e.g., emoji) while preserving lone surrogates and ASCII/control escapes required for valid JSON, avoiding parsing issues.
  * No changes to public interfaces; behavior affects message rendering only.

* **Tests**
  * Added unit tests validating decoded escapes, surrogate handling, and preservation of JSON control escapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->