### PR TITLE
feat(core): add run lifecycle hooks

### DIFF
--- a/aegra.json
+++ b/aegra.json
@@ -9,5 +9,9 @@
   },
   "http": {
     "app": "./examples/custom_routes_example.py:app"
+  },
+  "hooks": {
+    "path": "./examples/hooks_example.py:hooks",
+    "timeout": 10
   }
 }

--- a/examples/hooks_example.py
+++ b/examples/hooks_example.py
@@ -1,0 +1,93 @@
+"""Example run lifecycle hooks for Aegra.
+
+Demonstrates how to use before_run, after_run, and on_run_error hooks
+to observe, gate, and react to run lifecycle events.
+
+Configuration:
+Add this to your aegra.json:
+
+{
+  "hooks": {
+    "path": "./examples/hooks_example.py:hooks",
+    "timeout": 10
+  }
+}
+
+Hook types:
+- before_run:   Fires before graph execution. Can reject runs via RejectRun.
+- after_run:    Fires after successful completion or interrupt. Errors are logged, not propagated.
+- on_run_error: Fires when a run fails or is cancelled. Errors are logged, not propagated.
+"""
+
+import structlog
+
+from aegra_api.hooks import RunHooks
+
+logger = structlog.get_logger("hooks_example")
+
+hooks = RunHooks()
+
+
+# ---------------------------------------------------------------------------
+# before_run — gate and observe incoming runs
+# ---------------------------------------------------------------------------
+
+
+@hooks.before_run
+async def log_run_start(ctx) -> None:
+    """Log every incoming run with key context."""
+    logger.info(
+        "run started",
+        run_id=ctx.run_id,
+        thread_id=ctx.thread_id,
+        assistant_id=ctx.assistant_id,
+        graph_id=ctx.graph_id,
+        user=ctx.user.identity,
+    )
+
+
+# Uncomment to test run rejection:
+#
+# @hooks.before_run
+# async def require_subscription(ctx) -> None:
+#     """Reject runs from users without a subscription tier."""
+#     tier = getattr(ctx.user, "subscription_tier", None)
+#     if not tier:
+#         raise hooks.RejectRun("Subscription required", status_code=402)
+
+
+# ---------------------------------------------------------------------------
+# after_run — react to completed runs
+# ---------------------------------------------------------------------------
+
+
+@hooks.after_run
+async def log_run_complete(ctx) -> None:
+    """Log run completion with status and extras."""
+    logger.info(
+        "run completed",
+        run_id=ctx.run_id,
+        status=ctx.status,
+        graph_id=ctx.graph_id,
+        user=ctx.user.identity,
+        has_output=ctx.output is not None,
+        extras_keys=list(ctx.extras.keys()) if ctx.extras else [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# on_run_error — react to failed runs
+# ---------------------------------------------------------------------------
+
+
+@hooks.on_run_error
+async def log_run_error(ctx) -> None:
+    """Log run failures with error details."""
+    logger.error(
+        "run failed",
+        run_id=ctx.run_id,
+        graph_id=ctx.graph_id,
+        user=ctx.user.identity,
+        error=ctx.error,
+        error_type=ctx.error_type,
+    )

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from aegra_api.core.auth_ctx import with_auth_ctx
 from aegra_api.core.auth_deps import auth_dependency, get_current_user
 from aegra_api.core.auth_handlers import build_auth_context, handle_event
+from aegra_api.core.hooks import RejectRun, RunContext, get_hooks, get_hooks_timeout
 from aegra_api.core.orm import Assistant as AssistantORM
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
@@ -263,6 +264,7 @@ async def create_run(
         execute_run_async(
             run_id,
             thread_id,
+            resolved_assistant_id,
             assistant.graph_id,
             request.input or {},
             user,
@@ -301,6 +303,21 @@ async def create_and_stream_run(
     after the client disconnects (default is `"cancel"`). Use `stream_mode`
     to control which event types are emitted.
     """
+    # Authorization check (create_run action on threads resource)
+    ctx = build_auth_context(user, "threads", "create_run")
+    value = {**request.model_dump(), "thread_id": thread_id}
+    filters = await handle_event(ctx, value)
+
+    # If handler modified config/context, update request
+    if filters:
+        if "config" in filters:
+            request.config = {**(request.config or {}), **filters["config"]}
+        if "context" in filters:
+            request.context = {**(request.context or {}), **filters["context"]}
+    elif value.get("config"):
+        request.config = {**(request.config or {}), **value["config"]}
+    elif value.get("context"):
+        request.context = {**(request.context or {}), **value["context"]}
 
     # Validate resume command requirements early
     await _validate_resume_command(session, thread_id, request.command)
@@ -384,6 +401,7 @@ async def create_and_stream_run(
         execute_run_async(
             run_id,
             thread_id,
+            resolved_assistant_id,
             assistant.graph_id,
             request.input or {},
             user,
@@ -624,6 +642,22 @@ async def wait_for_run(
     Sessions are managed manually (not via Depends) to avoid holding a pool
     connection during the long wait, which would starve background tasks.
     """
+    # Authorization check (create_run action on threads resource)
+    auth_ctx = build_auth_context(user, "threads", "create_run")
+    value = {**request.model_dump(), "thread_id": thread_id}
+    filters = await handle_event(auth_ctx, value)
+
+    # If handler modified config/context, update request
+    if filters:
+        if "config" in filters:
+            request.config = {**(request.config or {}), **filters["config"]}
+        if "context" in filters:
+            request.context = {**(request.context or {}), **filters["context"]}
+    elif value.get("config"):
+        request.config = {**(request.config or {}), **value["config"]}
+    elif value.get("context"):
+        request.context = {**(request.context or {}), **value["context"]}
+
     maker = _get_session_maker()
 
     # Session block 1: all pre-execution DB work (validate, create run, commit)
@@ -707,6 +741,7 @@ async def wait_for_run(
         execute_run_async(
             run_id,
             thread_id,
+            resolved_assistant_id,
             graph_id,
             request.input or {},
             user,
@@ -895,6 +930,7 @@ async def cancel_run_endpoint(
 async def execute_run_async(
     run_id: str,
     thread_id: str,
+    assistant_id: str,
     graph_id: str,
     input_data: dict,
     user: User,
@@ -914,6 +950,10 @@ async def execute_run_async(
     if session is None:
         maker = _get_session_maker()
         session = maker()
+
+    hooks = get_hooks()
+    hooks_timeout = get_hooks_timeout()
+    run_config: dict = {}
 
     try:
         # Update status
@@ -942,6 +982,27 @@ async def execute_run_async(
         else:
             # No command, use regular input
             execution_input = input_data
+
+        # === HOOK POINT 1: before_run ===
+        if hooks:
+            before_ctx = RunContext(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=assistant_id,
+                graph_id=graph_id,
+                user=user,
+                config=run_config,
+                input=input_data,
+            )
+            try:
+                await hooks.fire_before_run(before_ctx, timeout=hooks_timeout)
+            except RejectRun as e:
+                await update_run_status(run_id, "error", output={}, error=e.message, session=session)
+                # Thread goes back to "idle", not "error" — the run was denied
+                # before execution started.  The thread itself is fine.
+                await set_thread_status(session, thread_id, "idle")
+                await streaming_service.signal_run_error(run_id, e.message, "RejectRun")
+                return
 
         # Execute using streaming to capture events for later replay
         event_counter = 0
@@ -1015,11 +1076,29 @@ async def execute_run_async(
                 await streaming_service.signal_run_error(run_id, str(stream_error), error_type)
                 raise
 
+        # Build extras dict with any server-collected data
+        run_extras: dict[str, Any] = {}
+
         if has_interrupt:
             await update_run_status(run_id, "interrupted", output=final_output or {}, session=session)
             if not session:
                 raise RuntimeError(f"No database session available to update thread {thread_id} status")
             await set_thread_status(session, thread_id, "interrupted")
+
+            # === HOOK POINT 2a: after_run (interrupted) ===
+            if hooks:
+                after_ctx = RunContext(
+                    run_id=run_id,
+                    thread_id=thread_id,
+                    assistant_id=assistant_id,
+                    graph_id=graph_id,
+                    user=user,
+                    config=run_config,
+                    output=final_output or {},
+                    status="interrupted",
+                    extras=run_extras,
+                )
+                await hooks.fire_after_run(after_ctx, timeout=hooks_timeout)
 
         else:
             # Update with results - use standard status
@@ -1029,6 +1108,21 @@ async def execute_run_async(
                 raise RuntimeError(f"No database session available to update thread {thread_id} status")
             await set_thread_status(session, thread_id, "idle")
 
+            # === HOOK POINT 2b: after_run (success) ===
+            if hooks:
+                after_ctx = RunContext(
+                    run_id=run_id,
+                    thread_id=thread_id,
+                    assistant_id=assistant_id,
+                    graph_id=graph_id,
+                    user=user,
+                    config=run_config,
+                    output=final_output or {},
+                    status="success",
+                    extras=run_extras,
+                )
+                await hooks.fire_after_run(after_ctx, timeout=hooks_timeout)
+
     except asyncio.CancelledError:
         # Store empty output to avoid JSON serialization issues - use standard status
         await update_run_status(run_id, "interrupted", output={}, session=session)
@@ -1037,7 +1131,31 @@ async def execute_run_async(
         await set_thread_status(session, thread_id, "idle")
         # Signal cancellation to broker
         await streaming_service.signal_run_cancelled(run_id)
+
+        # === HOOK POINT 3a: on_run_error (cancellation) ===
+        if hooks:
+            error_extras: dict[str, Any] = {}
+            error_ctx = RunContext(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=assistant_id,
+                graph_id=graph_id,
+                user=user,
+                config=run_config or {},
+                error="Run was cancelled",
+                error_type="CancelledError",
+                extras=error_extras,
+            )
+            # Shield the hook call from the ongoing cancellation.
+            try:
+                await asyncio.shield(hooks.fire_on_run_error(error_ctx, timeout=hooks_timeout))
+            except asyncio.CancelledError:
+                logger.warning(f"on_run_error hooks cancelled during shutdown for run {run_id}")
         raise
+
+    except RejectRun:
+        pass  # Already handled above in before_run
+
     except Exception as e:
         # Log with full traceback so bugs are visible in logs
         logger.exception(f"[execute_run_async] run failed run_id={run_id}")
@@ -1053,6 +1171,23 @@ async def execute_run_async(
         if broker and not broker.is_finished():
             error_type = type(e).__name__
             await streaming_service.signal_run_error(run_id, str(e), error_type)
+
+        # === HOOK POINT 3b: on_run_error (exception) ===
+        if hooks:
+            error_extras_exc: dict[str, Any] = {}
+            error_ctx = RunContext(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=assistant_id,
+                graph_id=graph_id,
+                user=user,
+                config=run_config or {},
+                error=str(e),
+                error_type=type(e).__name__,
+                extras=error_extras_exc,
+            )
+            await hooks.fire_on_run_error(error_ctx, timeout=hooks_timeout)
+
         # Don't re-raise: this runs as a background task (asyncio.create_task),
         # so re-raising causes "Task exception was never retrieved" warnings.
         # The error is already fully handled (run status, thread status, broker).

--- a/libs/aegra-api/src/aegra_api/config.py
+++ b/libs/aegra-api/src/aegra_api/config.py
@@ -80,6 +80,15 @@ class AuthConfig(TypedDict, total=False):
     """Disable authentication for LangGraph Studio connections"""
 
 
+class HooksConfig(TypedDict, total=False):
+    """Run lifecycle hooks configuration."""
+
+    path: str
+    """Import path for RunHooks instance in format './file.py:variable' or 'module:variable'."""
+    timeout: float
+    """Max seconds a hook can run before being killed (default: 10)."""
+
+
 def _resolve_config_path() -> Path | None:
     """Resolve config file path using standard resolution order.
 
@@ -192,6 +201,27 @@ def load_auth_config() -> AuthConfig | None:
         config_path = _resolve_config_path()
         logger.info(f"Loaded auth config from {config_path}")
         return auth_config
+
+    return None
+
+
+def load_hooks_config() -> HooksConfig | None:
+    """Load hooks config from aegra.json or langgraph.json.
+
+    Uses standard config resolution order.
+
+    Returns:
+        Hooks configuration dict or None if not configured
+    """
+    config = load_config()
+    if config is None:
+        return None
+
+    hooks_config = config.get("hooks")
+    if hooks_config:
+        config_path = _resolve_config_path()
+        logger.info(f"Loaded hooks config from {config_path}")
+        return hooks_config
 
     return None
 

--- a/libs/aegra-api/src/aegra_api/core/hooks.py
+++ b/libs/aegra-api/src/aegra_api/core/hooks.py
@@ -1,0 +1,211 @@
+"""Run lifecycle hooks for aegra-api.
+
+Provides the ``RunHooks`` registry, the immutable ``RunContext`` dataclass,
+and the ``RejectRun`` exception used by ``before_run`` hooks to gate
+execution.  A module-level singleton + loader round out the public API.
+"""
+
+import asyncio
+import importlib
+import importlib.util
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from aegra_api.models.auth import User
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class RunContext:
+    """Immutable context passed to all run hook callbacks.
+
+    All hooks receive the same fields.  Fields that are only meaningful for
+    specific hook points are ``None`` when not applicable.
+
+    The ``extras`` dict is populated by the server with data collected during
+    execution (e.g., token usage metadata).  Hooks should treat it as
+    read-only.
+    """
+
+    run_id: str
+    thread_id: str
+    assistant_id: str
+    graph_id: str
+    user: User
+    config: dict[str, Any] = field(default_factory=dict)
+    input: dict[str, Any] | None = None
+    output: dict[str, Any] | None = None
+    status: str | None = None
+    error: str | None = None
+    error_type: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+class RejectRun(Exception):
+    """Raise inside a ``before_run`` hook to reject execution."""
+
+    def __init__(self, message: str = "Run rejected by hook", status_code: int = 429) -> None:
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+class RunHooks:
+    """Registry for run lifecycle hook callbacks.
+
+    Hooks are purely observational — they can read run context and gate
+    execution (via ``RejectRun``) but cannot modify the run config or
+    graph state.
+    """
+
+    # Class-level reference for user convenience: ``hooks.RejectRun``
+    RejectRun = RejectRun
+
+    def __init__(self) -> None:
+        self._before_run: list[Callable[..., Any]] = []
+        self._after_run: list[Callable[..., Any]] = []
+        self._on_run_error: list[Callable[..., Any]] = []
+
+    def before_run(self, fn: Callable[..., Any]) -> Callable[..., Any]:
+        """Register a ``before_run`` hook."""
+        self._before_run.append(fn)
+        return fn
+
+    def after_run(self, fn: Callable[..., Any]) -> Callable[..., Any]:
+        """Register an ``after_run`` hook."""
+        self._after_run.append(fn)
+        return fn
+
+    def on_run_error(self, fn: Callable[..., Any]) -> Callable[..., Any]:
+        """Register an ``on_run_error`` hook."""
+        self._on_run_error.append(fn)
+        return fn
+
+    async def fire_before_run(self, ctx: RunContext, timeout: float = 10.0) -> None:
+        """Fire all ``before_run`` hooks.
+
+        ``RejectRun`` exceptions propagate up.  ``TimeoutError`` becomes
+        ``RejectRun(504)``.  Hook return values are ignored.
+        """
+        for fn in self._before_run:
+            try:
+                await asyncio.wait_for(fn(ctx), timeout=timeout)
+            except TimeoutError:
+                raise RejectRun(
+                    f"before_run hook '{fn.__name__}' timed out after {timeout}s",
+                    status_code=504,
+                )
+
+    async def fire_after_run(self, ctx: RunContext, timeout: float = 10.0) -> None:
+        """Fire all ``after_run`` hooks.  Errors are logged, not propagated."""
+        for fn in self._after_run:
+            try:
+                await asyncio.wait_for(fn(ctx), timeout=timeout)
+            except TimeoutError:
+                logger.warning(
+                    "after_run hook timed out",
+                    hook=fn.__name__,
+                    timeout=timeout,
+                    run_id=ctx.run_id,
+                )
+            except Exception:
+                logger.exception(
+                    "after_run hook failed",
+                    hook=fn.__name__,
+                    run_id=ctx.run_id,
+                )
+
+    async def fire_on_run_error(self, ctx: RunContext, timeout: float = 10.0) -> None:
+        """Fire all ``on_run_error`` hooks.  Errors are logged, not propagated.
+
+        Catches ``BaseException`` (not just ``Exception``) because this method
+        may be called inside a ``CancelledError`` handler.  If the task is
+        being cancelled, the ``await`` inside could itself raise
+        ``CancelledError`` — we must not let that escape unhandled.
+        """
+        for fn in self._on_run_error:
+            try:
+                await asyncio.wait_for(fn(ctx), timeout=timeout)
+            except TimeoutError:
+                logger.warning(
+                    "on_run_error hook timed out",
+                    hook=fn.__name__,
+                    timeout=timeout,
+                    run_id=ctx.run_id,
+                )
+            except BaseException:
+                logger.exception(
+                    "on_run_error hook failed",
+                    hook=fn.__name__,
+                    run_id=ctx.run_id,
+                )
+
+
+# ---------- Global singleton ----------
+_hooks: RunHooks | None = None
+_hooks_timeout: float = 10.0
+
+
+def get_hooks() -> RunHooks | None:
+    """Return the globally registered ``RunHooks`` instance (or ``None``)."""
+    return _hooks
+
+
+def get_hooks_timeout() -> float:
+    """Return the configured hook timeout in seconds."""
+    return _hooks_timeout
+
+
+def set_hooks(hooks: RunHooks, timeout: float = 10.0) -> None:
+    """Register a ``RunHooks`` instance as the global singleton."""
+    global _hooks, _hooks_timeout
+    _hooks = hooks
+    _hooks_timeout = timeout
+
+
+# ---------- Loader ----------
+def load_hooks(hooks_import: str, base_dir: Path | None = None) -> RunHooks:
+    """Load ``RunHooks`` instance from an import path.
+
+    Supports ``"./hooks.py:hooks"`` or ``"mypackage.hooks:hooks"``.
+    Follows the same pattern as ``core/app_loader.py``.
+    """
+    if ":" not in hooks_import:
+        raise ValueError(
+            f"Invalid hooks import path '{hooks_import}'. "
+            "Expected format: './file.py:variable' or 'module.path:variable'"
+        )
+
+    module_path, attr_name = hooks_import.rsplit(":", 1)
+
+    # Handle relative file paths
+    if module_path.startswith("."):
+        if base_dir is None:
+            base_dir = Path.cwd()
+        file_path = (base_dir / module_path).resolve()
+        if not file_path.exists():
+            raise FileNotFoundError(f"Hooks file not found: {file_path}")
+
+        spec = importlib.util.spec_from_file_location("_user_hooks", file_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load hooks from {file_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    else:
+        module = importlib.import_module(module_path)
+
+    hooks = getattr(module, attr_name, None)
+    if hooks is None:
+        raise AttributeError(f"Module '{module_path}' has no attribute '{attr_name}'")
+    if not isinstance(hooks, RunHooks):
+        raise TypeError(
+            f"Expected RunHooks instance, got {type(hooks).__name__}. "
+            f"Make sure '{attr_name}' is an instance of RunHooks."
+        )
+
+    return hooks

--- a/libs/aegra-api/src/aegra_api/hooks.py
+++ b/libs/aegra-api/src/aegra_api/hooks.py
@@ -1,0 +1,11 @@
+"""Public API for run lifecycle hooks.
+
+Users should import from this module, not from ``aegra_api.core.hooks``
+directly::
+
+    from aegra_api.hooks import RunHooks, RunContext, RejectRun
+"""
+
+from aegra_api.core.hooks import RejectRun, RunContext, RunHooks
+
+__all__: list[str] = ["RunHooks", "RunContext", "RejectRun"]

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -13,6 +13,7 @@ import json
 import sys
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, TypeVar
 from uuid import uuid5
@@ -572,7 +573,7 @@ def inject_user_context(user: Any | None, base_config: dict[str, Any] | None = N
     return config
 
 
-def create_thread_config(thread_id: str, user, additional_config: dict = None) -> dict:
+def create_thread_config(thread_id: str, user: Any, additional_config: dict | None = None) -> dict:
     """Create LangGraph configuration for a specific thread with user context"""
     base_config = {"configurable": {"thread_id": thread_id}}
 
@@ -585,8 +586,8 @@ def create_thread_config(thread_id: str, user, additional_config: dict = None) -
 def create_run_config(
     run_id: str,
     thread_id: str,
-    user,
-    additional_config: dict = None,
+    user: Any,
+    additional_config: dict | None = None,
     checkpoint: dict | None = None,
 ) -> dict:
     """Create LangGraph configuration for a specific run with full context.
@@ -595,8 +596,6 @@ def create_run_config(
     supplied.  We simply ensure a `configurable` dict exists and then merge a
     few server-side keys so graph nodes can rely on them.
     """
-    from copy import deepcopy
-
     cfg: dict = deepcopy(additional_config) if additional_config else {}
 
     # Ensure a configurable section exists

--- a/libs/aegra-api/tests/integration/test_hooks_integration.py
+++ b/libs/aegra-api/tests/integration/test_hooks_integration.py
@@ -1,0 +1,404 @@
+"""Integration tests for run lifecycle hooks wired through execute_run_async.
+
+These tests verify that hooks fire correctly when execute_run_async is called
+with mock graph execution, covering before_run, after_run, on_run_error,
+RejectRun gating, and extras propagation.
+"""
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aegra_api.api.runs import execute_run_async
+from aegra_api.core.hooks import RejectRun, RunContext, RunHooks, set_hooks
+from aegra_api.models.auth import User
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_user() -> User:
+    return User(identity="integration-test-user")
+
+
+@pytest.fixture
+def run_id() -> str:
+    return "integration-run-1"
+
+
+@pytest.fixture
+def thread_id() -> str:
+    return "integration-thread-1"
+
+
+@pytest.fixture
+def assistant_id() -> str:
+    return "integration-assistant-1"
+
+
+@pytest.fixture
+def graph_id() -> str:
+    return "test-graph"
+
+
+@pytest.fixture(autouse=True)
+def reset_hooks_singleton() -> Any:
+    """Reset hooks singleton before and after each test."""
+    from aegra_api.core import hooks as hooks_module
+
+    original_hooks = hooks_module._hooks
+    original_timeout = hooks_module._hooks_timeout
+    hooks_module._hooks = None
+    hooks_module._hooks_timeout = 10.0
+    yield
+    hooks_module._hooks = original_hooks
+    hooks_module._hooks_timeout = original_timeout
+
+
+def _make_success_stream() -> AsyncIterator[tuple[str, Any]]:
+    """Async generator that yields a successful values event."""
+
+    async def gen() -> AsyncIterator[tuple[str, Any]]:
+        yield ("values", {"result": "ok"})
+
+    return gen()
+
+
+def _make_error_stream() -> AsyncIterator[tuple[str, Any]]:
+    """Async generator that raises during streaming."""
+
+    async def gen() -> AsyncIterator[tuple[str, Any]]:
+        raise ValueError("graph exploded")
+        yield  # type: ignore[misc]  # make it a generator
+
+    return gen()
+
+
+def _make_interrupt_stream() -> AsyncIterator[tuple[str, Any]]:
+    """Async generator that yields an interrupt event."""
+
+    async def gen() -> AsyncIterator[tuple[str, Any]]:
+        yield ("values", {"result": "partial"})
+        yield ("values", {"__interrupt__": [{"reason": "human_input"}]})
+
+    return gen()
+
+
+def _standard_patches():
+    """Context manager stack for mocking out DB/LangGraph dependencies."""
+    mock_graph = MagicMock()
+    mock_lg_service = MagicMock()
+    mock_lg_service.return_value.get_graph.return_value.__aenter__ = AsyncMock(return_value=mock_graph)
+    mock_lg_service.return_value.get_graph.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    return (
+        patch("aegra_api.api.runs.get_langgraph_service", return_value=mock_lg_service.return_value),
+        patch("aegra_api.api.runs.update_run_status", new_callable=AsyncMock),
+        patch("aegra_api.api.runs.set_thread_status", new_callable=AsyncMock),
+        patch("aegra_api.api.runs._get_session_maker", return_value=lambda: AsyncMock()),
+        patch(
+            "aegra_api.api.runs.streaming_service",
+            MagicMock(
+                put_to_broker=AsyncMock(),
+                store_event_from_raw=AsyncMock(),
+                signal_run_error=AsyncMock(),
+                signal_run_cancelled=AsyncMock(),
+                cleanup_run=AsyncMock(),
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBeforeRunHookIntegration:
+    """before_run hooks fire before graph execution."""
+
+    async def test_before_run_called(
+        self, mock_user: User, run_id: str, thread_id: str, assistant_id: str, graph_id: str
+    ) -> None:
+        """before_run hook is called with correct context."""
+        received_ctx: list[RunContext] = []
+        hooks = RunHooks()
+
+        @hooks.before_run
+        async def capture(ctx: RunContext) -> None:
+            received_ctx.append(ctx)
+
+        set_hooks(hooks)
+
+        p1, p2, p3, p4, p5 = _standard_patches()
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            patch(
+                "aegra_api.api.runs.stream_graph_events",
+                return_value=_make_success_stream(),
+            ),
+        ):
+            await execute_run_async(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=assistant_id,
+                graph_id=graph_id,
+                input_data={"msg": "hello"},
+                user=mock_user,
+            )
+
+        assert len(received_ctx) == 1
+        ctx = received_ctx[0]
+        assert ctx.run_id == run_id
+        assert ctx.thread_id == thread_id
+        assert ctx.assistant_id == assistant_id
+        assert ctx.graph_id == graph_id
+        assert ctx.user.identity == "integration-test-user"
+        assert ctx.input == {"msg": "hello"}
+
+    async def test_reject_run_stops_execution(
+        self, mock_user: User, run_id: str, thread_id: str, assistant_id: str, graph_id: str
+    ) -> None:
+        """RejectRun in before_run prevents graph execution."""
+        hooks = RunHooks()
+
+        @hooks.before_run
+        async def reject(ctx: RunContext) -> None:
+            raise RejectRun("subscription required", status_code=402)
+
+        set_hooks(hooks)
+
+        graph_was_called = False
+
+        async def stream_that_shouldnt_run(*args: Any, **kwargs: Any) -> AsyncIterator[tuple[str, Any]]:
+            nonlocal graph_was_called
+            graph_was_called = True
+            yield ("values", {})
+
+        p1, p2, p3, p4, p5 = _standard_patches()
+        with (
+            p1,
+            p2 as mock_update,
+            p3,
+            p4,
+            p5,
+            patch(
+                "aegra_api.api.runs.stream_graph_events",
+                side_effect=stream_that_shouldnt_run,
+            ),
+        ):
+            await execute_run_async(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=assistant_id,
+                graph_id=graph_id,
+                input_data={},
+                user=mock_user,
+            )
+
+        assert not graph_was_called
+        # Run should be set to error status — verify the key arguments
+        # (session is a mock so we check positional/keyword args without session identity)
+        error_calls = [
+            c for c in mock_update.call_args_list if len(c.args) >= 2 and c.args[0] == run_id and c.args[1] == "error"
+        ]
+        assert len(error_calls) >= 1, "update_run_status should be called with 'error' status"
+        assert error_calls[0].kwargs.get("error") == "subscription required"
+
+
+class TestAfterRunHookIntegration:
+    """after_run hooks fire after successful graph execution."""
+
+    async def test_after_run_success(
+        self, mock_user: User, run_id: str, thread_id: str, assistant_id: str, graph_id: str
+    ) -> None:
+        """after_run fires with status='success' on normal completion."""
+        received_ctx: list[RunContext] = []
+        hooks = RunHooks()
+
+        @hooks.after_run
+        async def capture(ctx: RunContext) -> None:
+            received_ctx.append(ctx)
+
+        set_hooks(hooks)
+
+        p1, p2, p3, p4, p5 = _standard_patches()
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            patch(
+                "aegra_api.api.runs.stream_graph_events",
+                return_value=_make_success_stream(),
+            ),
+        ):
+            await execute_run_async(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=assistant_id,
+                graph_id=graph_id,
+                input_data={},
+                user=mock_user,
+            )
+
+        assert len(received_ctx) == 1
+        ctx = received_ctx[0]
+        assert ctx.status == "success"
+        assert ctx.output == {"result": "ok"}
+        assert ctx.extras == {}
+
+    async def test_after_run_interrupt(
+        self, mock_user: User, run_id: str, thread_id: str, assistant_id: str, graph_id: str
+    ) -> None:
+        """after_run fires with status='interrupted' when graph hits interrupt."""
+        received_ctx: list[RunContext] = []
+        hooks = RunHooks()
+
+        @hooks.after_run
+        async def capture(ctx: RunContext) -> None:
+            received_ctx.append(ctx)
+
+        set_hooks(hooks)
+
+        p1, p2, p3, p4, p5 = _standard_patches()
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            patch(
+                "aegra_api.api.runs.stream_graph_events",
+                return_value=_make_interrupt_stream(),
+            ),
+        ):
+            await execute_run_async(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=assistant_id,
+                graph_id=graph_id,
+                input_data={},
+                user=mock_user,
+            )
+
+        assert len(received_ctx) == 1
+        assert received_ctx[0].status == "interrupted"
+
+    async def test_after_run_error_does_not_propagate(
+        self, mock_user: User, run_id: str, thread_id: str, assistant_id: str, graph_id: str
+    ) -> None:
+        """If after_run hook raises, the error is logged but doesn't fail the run."""
+        hooks = RunHooks()
+
+        @hooks.after_run
+        async def explode(ctx: RunContext) -> None:
+            raise RuntimeError("hook crashed")
+
+        set_hooks(hooks)
+
+        p1, p2, p3, p4, p5 = _standard_patches()
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            patch(
+                "aegra_api.api.runs.stream_graph_events",
+                return_value=_make_success_stream(),
+            ),
+        ):
+            # Should not raise despite hook error
+            await execute_run_async(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=assistant_id,
+                graph_id=graph_id,
+                input_data={},
+                user=mock_user,
+            )
+
+
+class TestOnRunErrorHookIntegration:
+    """on_run_error hooks fire when graph execution fails."""
+
+    async def test_on_run_error_called(
+        self, mock_user: User, run_id: str, thread_id: str, assistant_id: str, graph_id: str
+    ) -> None:
+        """on_run_error fires with error details when graph raises."""
+        received_ctx: list[RunContext] = []
+        hooks = RunHooks()
+
+        @hooks.on_run_error
+        async def capture(ctx: RunContext) -> None:
+            received_ctx.append(ctx)
+
+        set_hooks(hooks)
+
+        p1, p2, p3, p4, p5 = _standard_patches()
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            patch(
+                "aegra_api.api.runs.stream_graph_events",
+                return_value=_make_error_stream(),
+            ),
+        ):
+            await execute_run_async(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=assistant_id,
+                graph_id=graph_id,
+                input_data={},
+                user=mock_user,
+            )
+
+        assert len(received_ctx) == 1
+        ctx = received_ctx[0]
+        assert ctx.error == "graph exploded"
+        assert ctx.error_type == "ValueError"
+
+
+class TestNoHooksConfigured:
+    """When no hooks are configured, execution works normally."""
+
+    async def test_no_hooks(
+        self, mock_user: User, run_id: str, thread_id: str, assistant_id: str, graph_id: str
+    ) -> None:
+        """execute_run_async works fine with no hooks set."""
+        # hooks singleton is already None from the autouse fixture
+
+        p1, p2, p3, p4, p5 = _standard_patches()
+        with (
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            patch(
+                "aegra_api.api.runs.stream_graph_events",
+                return_value=_make_success_stream(),
+            ),
+        ):
+            await execute_run_async(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=assistant_id,
+                graph_id=graph_id,
+                input_data={},
+                user=mock_user,
+            )
+        # No assertion needed — just verifying no exception

--- a/libs/aegra-api/tests/integration/test_streaming_errors.py
+++ b/libs/aegra-api/tests/integration/test_streaming_errors.py
@@ -76,6 +76,7 @@ class TestStreamingErrorHandling:
             await execute_run_async(
                 run_id=run_id,
                 thread_id=thread_id,
+                assistant_id="test-assistant-id",
                 graph_id=graph_id,
                 input_data={},
                 user=mock_user,
@@ -158,6 +159,7 @@ class TestStreamingErrorHandling:
             await execute_run_async(
                 run_id=run_id,
                 thread_id=thread_id,
+                assistant_id="test-assistant-id",
                 graph_id=graph_id,
                 input_data={},
                 user=mock_user,
@@ -216,6 +218,7 @@ class TestStreamingErrorHandling:
             await execute_run_async(
                 run_id=run_id,
                 thread_id=thread_id,
+                assistant_id="test-assistant-id",
                 graph_id=graph_id,
                 input_data={},
                 user=mock_user,
@@ -278,6 +281,7 @@ class TestStreamingErrorHandling:
             await execute_run_async(
                 run_id=run_id,
                 thread_id=thread_id,
+                assistant_id="test-assistant-id",
                 graph_id=graph_id,
                 input_data={},
                 user=mock_user,

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -189,6 +189,7 @@ class TestRunsStreamingEndpoints:
             await execute_run_async(
                 run_id=run_id,
                 thread_id=thread_id,
+                assistant_id="test-assistant-id",
                 graph_id=graph_id,
                 input_data={},
                 user=mock_user,

--- a/libs/aegra-api/tests/unit/test_core/test_hooks.py
+++ b/libs/aegra-api/tests/unit/test_core/test_hooks.py
@@ -1,0 +1,493 @@
+"""Unit tests for run lifecycle hooks (core/hooks.py)."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aegra_api.core.hooks import (
+    RejectRun,
+    RunContext,
+    RunHooks,
+    get_hooks,
+    get_hooks_timeout,
+    load_hooks,
+    set_hooks,
+)
+from aegra_api.models.auth import User
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hooks() -> RunHooks:
+    """Fresh RunHooks instance for each test."""
+    return RunHooks()
+
+
+@pytest.fixture
+def user() -> User:
+    """Minimal User for RunContext construction."""
+    return User(identity="test-user")
+
+
+@pytest.fixture
+def base_ctx(user: User) -> RunContext:
+    """Base RunContext with required fields filled in."""
+    return RunContext(
+        run_id="run-1",
+        thread_id="thread-1",
+        assistant_id="asst-1",
+        graph_id="agent",
+        user=user,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RunContext
+# ---------------------------------------------------------------------------
+
+
+class TestRunContext:
+    """Tests for RunContext dataclass."""
+
+    def test_frozen(self, base_ctx: RunContext) -> None:
+        """RunContext is immutable."""
+        with pytest.raises(AttributeError):
+            base_ctx.run_id = "changed"  # type: ignore[misc]
+
+    def test_defaults(self, user: User) -> None:
+        """Optional fields default to None / empty dict."""
+        ctx = RunContext(
+            run_id="r",
+            thread_id="t",
+            assistant_id="a",
+            graph_id="g",
+            user=user,
+        )
+        assert ctx.config == {}
+        assert ctx.input is None
+        assert ctx.output is None
+        assert ctx.status is None
+        assert ctx.error is None
+        assert ctx.error_type is None
+        assert ctx.extras == {}
+
+    def test_extras_populated(self, user: User) -> None:
+        """extras dict can be populated at construction time."""
+        extras = {"usage_metadata": {"gpt-4o": {"total_tokens": 100}}}
+        ctx = RunContext(
+            run_id="r",
+            thread_id="t",
+            assistant_id="a",
+            graph_id="g",
+            user=user,
+            extras=extras,
+        )
+        assert ctx.extras["usage_metadata"]["gpt-4o"]["total_tokens"] == 100
+
+    def test_extras_default_factory_isolation(self, user: User) -> None:
+        """Each RunContext gets its own extras dict (no shared mutable default)."""
+        ctx1 = RunContext(run_id="r1", thread_id="t", assistant_id="a", graph_id="g", user=user)
+        ctx2 = RunContext(run_id="r2", thread_id="t", assistant_id="a", graph_id="g", user=user)
+        assert ctx1.extras is not ctx2.extras
+
+
+# ---------------------------------------------------------------------------
+# RejectRun
+# ---------------------------------------------------------------------------
+
+
+class TestRejectRun:
+    """Tests for RejectRun exception."""
+
+    def test_defaults(self) -> None:
+        exc = RejectRun()
+        assert exc.message == "Run rejected by hook"
+        assert exc.status_code == 429
+
+    def test_custom(self) -> None:
+        exc = RejectRun("No credits", status_code=402)
+        assert exc.message == "No credits"
+        assert exc.status_code == 402
+
+    def test_is_exception(self) -> None:
+        assert issubclass(RejectRun, Exception)
+
+    def test_class_level_access(self) -> None:
+        """RejectRun accessible via RunHooks.RejectRun for user convenience."""
+        assert RunHooks.RejectRun is RejectRun
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    """Tests for hook registration via decorators."""
+
+    def test_register_before_run(self, hooks: RunHooks) -> None:
+        @hooks.before_run
+        async def my_hook(ctx: RunContext) -> None:
+            pass
+
+        assert len(hooks._before_run) == 1
+        assert hooks._before_run[0] is my_hook
+
+    def test_register_after_run(self, hooks: RunHooks) -> None:
+        @hooks.after_run
+        async def my_hook(ctx: RunContext) -> None:
+            pass
+
+        assert len(hooks._after_run) == 1
+
+    def test_register_on_run_error(self, hooks: RunHooks) -> None:
+        @hooks.on_run_error
+        async def my_hook(ctx: RunContext) -> None:
+            pass
+
+        assert len(hooks._on_run_error) == 1
+
+    def test_multiple_hooks_per_event(self, hooks: RunHooks) -> None:
+        @hooks.before_run
+        async def hook1(ctx: RunContext) -> None:
+            pass
+
+        @hooks.before_run
+        async def hook2(ctx: RunContext) -> None:
+            pass
+
+        assert len(hooks._before_run) == 2
+        assert hooks._before_run[0] is hook1
+        assert hooks._before_run[1] is hook2
+
+    def test_decorator_returns_original_function(self, hooks: RunHooks) -> None:
+        async def original(ctx: RunContext) -> None:
+            pass
+
+        result = hooks.before_run(original)
+        assert result is original
+
+
+# ---------------------------------------------------------------------------
+# fire_before_run
+# ---------------------------------------------------------------------------
+
+
+class TestFireBeforeRun:
+    """Tests for fire_before_run behavior."""
+
+    async def test_calls_hooks_in_order(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        call_order: list[str] = []
+
+        @hooks.before_run
+        async def first(ctx: RunContext) -> None:
+            call_order.append("first")
+
+        @hooks.before_run
+        async def second(ctx: RunContext) -> None:
+            call_order.append("second")
+
+        await hooks.fire_before_run(base_ctx)
+        assert call_order == ["first", "second"]
+
+    async def test_reject_run_propagates(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        @hooks.before_run
+        async def reject(ctx: RunContext) -> None:
+            raise RejectRun("denied", status_code=402)
+
+        with pytest.raises(RejectRun) as exc_info:
+            await hooks.fire_before_run(base_ctx)
+
+        assert exc_info.value.message == "denied"
+        assert exc_info.value.status_code == 402
+
+    async def test_reject_stops_subsequent_hooks(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        reached_second = False
+
+        @hooks.before_run
+        async def reject(ctx: RunContext) -> None:
+            raise RejectRun("stop")
+
+        @hooks.before_run
+        async def should_not_run(ctx: RunContext) -> None:
+            nonlocal reached_second
+            reached_second = True
+
+        with pytest.raises(RejectRun):
+            await hooks.fire_before_run(base_ctx)
+
+        assert not reached_second
+
+    async def test_timeout_becomes_reject_run(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        @hooks.before_run
+        async def slow(ctx: RunContext) -> None:
+            await asyncio.sleep(10)
+
+        with pytest.raises(RejectRun) as exc_info:
+            await hooks.fire_before_run(base_ctx, timeout=0.01)
+
+        assert exc_info.value.status_code == 504
+        assert "timed out" in exc_info.value.message
+
+    async def test_return_values_ignored(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        @hooks.before_run
+        async def returns_stuff(ctx: RunContext) -> dict:
+            return {"should": "be ignored"}
+
+        # Should not raise
+        await hooks.fire_before_run(base_ctx)
+
+    async def test_no_hooks_is_noop(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        """Empty hook list doesn't error."""
+        await hooks.fire_before_run(base_ctx)
+
+
+# ---------------------------------------------------------------------------
+# fire_after_run
+# ---------------------------------------------------------------------------
+
+
+class TestFireAfterRun:
+    """Tests for fire_after_run behavior."""
+
+    async def test_calls_hooks(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        called = AsyncMock()
+
+        @hooks.after_run
+        async def my_hook(ctx: RunContext) -> None:
+            await called()
+
+        await hooks.fire_after_run(base_ctx)
+        called.assert_awaited_once()
+
+    async def test_errors_logged_not_propagated(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        @hooks.after_run
+        async def fails(ctx: RunContext) -> None:
+            raise ValueError("boom")
+
+        # Should not raise
+        await hooks.fire_after_run(base_ctx)
+
+    async def test_error_does_not_stop_subsequent_hooks(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        second_called = False
+
+        @hooks.after_run
+        async def fails(ctx: RunContext) -> None:
+            raise ValueError("first hook fails")
+
+        @hooks.after_run
+        async def succeeds(ctx: RunContext) -> None:
+            nonlocal second_called
+            second_called = True
+
+        await hooks.fire_after_run(base_ctx)
+        assert second_called
+
+    async def test_timeout_logged_not_propagated(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        @hooks.after_run
+        async def slow(ctx: RunContext) -> None:
+            await asyncio.sleep(10)
+
+        # Should not raise
+        await hooks.fire_after_run(base_ctx, timeout=0.01)
+
+
+# ---------------------------------------------------------------------------
+# fire_on_run_error
+# ---------------------------------------------------------------------------
+
+
+class TestFireOnRunError:
+    """Tests for fire_on_run_error behavior."""
+
+    async def test_calls_hooks(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        called = AsyncMock()
+
+        @hooks.on_run_error
+        async def my_hook(ctx: RunContext) -> None:
+            await called()
+
+        await hooks.fire_on_run_error(base_ctx)
+        called.assert_awaited_once()
+
+    async def test_errors_logged_not_propagated(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        @hooks.on_run_error
+        async def fails(ctx: RunContext) -> None:
+            raise RuntimeError("hook failed")
+
+        # Should not raise
+        await hooks.fire_on_run_error(base_ctx)
+
+    async def test_catches_base_exception(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        """on_run_error catches BaseException (including CancelledError)."""
+
+        @hooks.on_run_error
+        async def raises_cancelled(ctx: RunContext) -> None:
+            raise asyncio.CancelledError()
+
+        # Should not propagate
+        await hooks.fire_on_run_error(base_ctx)
+
+    async def test_timeout_logged_not_propagated(self, hooks: RunHooks, base_ctx: RunContext) -> None:
+        @hooks.on_run_error
+        async def slow(ctx: RunContext) -> None:
+            await asyncio.sleep(10)
+
+        # Should not raise
+        await hooks.fire_on_run_error(base_ctx, timeout=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+
+class TestSingleton:
+    """Tests for global singleton management."""
+
+    def test_default_is_none(self) -> None:
+        """Before set_hooks, get_hooks returns None."""
+        # Reset to clean state
+        from aegra_api.core import hooks as hooks_module
+
+        original = hooks_module._hooks
+        hooks_module._hooks = None
+        try:
+            assert get_hooks() is None
+        finally:
+            hooks_module._hooks = original
+
+    def test_set_and_get(self) -> None:
+        from aegra_api.core import hooks as hooks_module
+
+        original_hooks = hooks_module._hooks
+        original_timeout = hooks_module._hooks_timeout
+        try:
+            h = RunHooks()
+            set_hooks(h, timeout=5.0)
+            assert get_hooks() is h
+            assert get_hooks_timeout() == 5.0
+        finally:
+            hooks_module._hooks = original_hooks
+            hooks_module._hooks_timeout = original_timeout
+
+    def test_default_timeout(self) -> None:
+        from aegra_api.core import hooks as hooks_module
+
+        original_hooks = hooks_module._hooks
+        original_timeout = hooks_module._hooks_timeout
+        try:
+            set_hooks(RunHooks())
+            assert get_hooks_timeout() == 10.0
+        finally:
+            hooks_module._hooks = original_hooks
+            hooks_module._hooks_timeout = original_timeout
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+class TestLoadHooks:
+    """Tests for load_hooks()."""
+
+    def test_invalid_format_no_colon(self) -> None:
+        with pytest.raises(ValueError, match="Invalid hooks import path"):
+            load_hooks("no_colon_here")
+
+    def test_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError, match="not found"):
+            load_hooks("./nonexistent.py:hooks", base_dir=tmp_path)
+
+    def test_missing_attribute(self, tmp_path: Path) -> None:
+        f = tmp_path / "empty.py"
+        f.write_text("x = 1\n")
+        with pytest.raises(AttributeError, match="no attribute"):
+            load_hooks("./empty.py:hooks", base_dir=tmp_path)
+
+    def test_wrong_type(self, tmp_path: Path) -> None:
+        f = tmp_path / "wrong.py"
+        f.write_text("hooks = 'not a RunHooks'\n")
+        with pytest.raises(TypeError, match="Expected RunHooks"):
+            load_hooks("./wrong.py:hooks", base_dir=tmp_path)
+
+    def test_load_from_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "my_hooks.py"
+        f.write_text(
+            "from aegra_api.core.hooks import RunHooks\n"
+            "hooks = RunHooks()\n"
+            "@hooks.before_run\n"
+            "async def my_hook(ctx):\n"
+            "    pass\n"
+        )
+        loaded = load_hooks("./my_hooks.py:hooks", base_dir=tmp_path)
+        assert isinstance(loaded, RunHooks)
+        assert len(loaded._before_run) == 1
+
+    def test_load_from_module(self) -> None:
+        """Loading from an installed module path (aegra_api.core.hooks itself)."""
+        # This tests the module-import branch. We ask it to load the
+        # RejectRun class which is *not* a RunHooks, so it should raise
+        # TypeError — proving the module-import path works.
+        with pytest.raises(TypeError, match="Expected RunHooks"):
+            load_hooks("aegra_api.core.hooks:RejectRun")
+
+    def test_load_nonexistent_module(self) -> None:
+        with pytest.raises(ModuleNotFoundError):
+            load_hooks("nonexistent.module:hooks")
+
+
+# ---------------------------------------------------------------------------
+# HooksConfig (config.py additions)
+# ---------------------------------------------------------------------------
+
+
+class TestHooksConfig:
+    """Tests for load_hooks_config in config.py."""
+
+    def test_returns_none_when_no_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from aegra_api.config import load_hooks_config
+
+        monkeypatch.setattr("aegra_api.config.load_config", lambda: None)
+        assert load_hooks_config() is None
+
+    def test_returns_none_when_no_hooks_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from aegra_api.config import load_hooks_config
+
+        monkeypatch.setattr("aegra_api.config.load_config", lambda: {"graphs": {}})
+        assert load_hooks_config() is None
+
+    def test_returns_hooks_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from aegra_api.config import load_hooks_config
+
+        config = {"hooks": {"path": "./hooks.py:hooks", "timeout": 5}}
+        monkeypatch.setattr("aegra_api.config.load_config", lambda: config)
+        monkeypatch.setattr("aegra_api.config._resolve_config_path", lambda: Path("aegra.json"))
+        result = load_hooks_config()
+        assert result is not None
+        assert result["path"] == "./hooks.py:hooks"
+        assert result["timeout"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Public re-export module
+# ---------------------------------------------------------------------------
+
+
+class TestPublicReexport:
+    """Tests that aegra_api.hooks re-exports correctly."""
+
+    def test_imports(self) -> None:
+        from aegra_api.hooks import RejectRun as RR
+        from aegra_api.hooks import RunContext as RC
+        from aegra_api.hooks import RunHooks as RH
+
+        assert RR is RejectRun
+        assert RC is RunContext
+        assert RH is RunHooks


### PR DESCRIPTION
## Description

Adds a run lifecycle hooks system that lets users register async callbacks for three run lifecycle events: `before_run`, `after_run`, and `on_run_error`. Hooks are configured via `aegra.json` and fire inside `execute_run_async`, covering all run creation paths (`/runs`, `/runs/stream`, `/runs/wait`, and stateless endpoints).

`before_run` hooks can gate execution by raising `RejectRun`. `after_run` and `on_run_error` hooks are observational -- errors are logged, not propagated. All hooks receive an immutable `RunContext` with full server-level context (user, thread, assistant, graph, input/output, error details).

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [x] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues

Closes #XXX <!-- Replace with your feature request issue number -->

## Changes Made

- Added `RunHooks` registry with decorator-based registration (`@hooks.before_run`, `@hooks.after_run`, `@hooks.on_run_error`)
- Added frozen `RunContext` dataclass passed to all hooks with run/thread/assistant/graph/user context
- Added `RejectRun` exception for gating runs in `before_run` hooks
- Added `HooksConfig` TypedDict and `load_hooks_config()` to `config.py`
- Added dynamic loader (`load_hooks()`) supporting file paths and module paths, matching existing `core/app_loader.py` pattern
- Wired 4 hook points into `execute_run_async` in `runs.py`: before execution, after success, after interrupt, and on error/cancellation
- Added `assistant_id` parameter to `execute_run_async` and threaded it from all 3 call sites
- Added `asyncio.shield()` on `on_run_error` in `CancelledError` handler to prevent re-cancellation
- Added hooks loading during FastAPI lifespan startup in `main.py`
- Added public re-export module (`aegra_api.hooks`) for stable user-facing imports
- Fixed type annotations in `langgraph_service.py` (`user: Any`, `additional_config: dict | None`)
- Moved inline `from copy import deepcopy` to top of file in `langgraph_service.py`

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

**Unit tests** (493 lines): `RunContext` immutability/defaults, `RejectRun` behavior, hook registration, fire ordering, `RejectRun` propagation, timeout handling (`before_run` -> `RejectRun(504)`, `after_run`/`on_run_error` -> logged), error isolation, `BaseException` catch in `on_run_error`, singleton management, loader edge cases (missing file, wrong type, missing attribute, module import), config loading, public re-exports.

**Integration tests** (404 lines): Full `execute_run_async` with mocked DB/LangGraph verifying `before_run` fires with correct context, `RejectRun` prevents graph execution, `after_run` fires on success and interrupt with correct status, `on_run_error` fires on exception with error details, and no-hooks-configured works normally.

## Checklist

- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [ ] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Screenshots (if applicable)

N/A -- no UI changes.

## Additional Notes

- All hook calls are wrapped in `asyncio.wait_for()` with a configurable timeout (default 10s) to prevent hanging external calls from blocking the server
- On `RejectRun`, the thread status resets to `"idle"` (not `"error"`) since the run was denied before execution -- the thread itself is fine
- `fire_on_run_error` catches `BaseException` (not just `Exception`) to handle `CancelledError` propagation in Python 3.12+
- Hooks do not receive the shared DB session -- hooks needing DB access must create their own session
- The `extras` dict on `RunContext` provides an extensibility point for server-collected data (e.g., token usage) without requiring schema changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added run lifecycle hooks enabling custom logic at key execution points: before run (with rejection capability), after run (on success or interruption), and on run error
  * Hook handlers are configurable via `aegra.json` with path and timeout settings
  * Included example demonstrating lifecycle hook registration and usage for run observability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->