### PR TITLE
fix(db): strip null bytes from SSE event data before JSONB insert

### DIFF
--- a/libs/aegra-api/src/aegra_api/services/event_store.py
+++ b/libs/aegra-api/src/aegra_api/services/event_store.py
@@ -185,9 +185,12 @@ async def store_sse_event(run_id: str, event_id: str, event_type: str, data: dic
     """Store SSE event with proper serialization"""
     serializer = GeneralSerializer()
 
-    # Ensure JSONB-safe data by serializing complex objects
+    # Ensure JSONB-safe data by serializing complex objects.
+    # Also strip \u0000 (null bytes) — PostgreSQL JSONB rejects them.
     try:
-        safe_data = json.loads(json.dumps(data, default=serializer.serialize))
+        json_str = json.dumps(data, default=serializer.serialize)
+        json_str = json_str.replace("\\u0000", "")
+        safe_data = json.loads(json_str)
     except Exception:
         # Fallback to stringifying as a last resort to avoid crashing the run
         safe_data = {"raw": str(data)}

--- a/libs/aegra-api/tests/integration/test_services/test_event_store_integration.py
+++ b/libs/aegra-api/tests/integration/test_services/test_event_store_integration.py
@@ -1,13 +1,14 @@
 """Integration tests for EventStore service with real database"""
 
 import asyncio
+import json
 import sys
 from datetime import UTC, datetime
 
 import pytest
 
 from aegra_api.core.sse import SSEEvent
-from aegra_api.services.event_store import EventStore
+from aegra_api.services.event_store import EventStore, store_sse_event
 from aegra_api.settings import settings
 
 # Fix Windows event loop policy for psycopg3 compatibility
@@ -441,3 +442,44 @@ class TestEventStoreIntegration:
         assert retrieved_data["nested"]["null"] is None
         assert retrieved_data["nested"]["number"] == 42.5
         assert retrieved_data["metadata"]["tags"] == ["test", "complex", "json"]
+
+    @pytest.mark.asyncio
+    async def test_store_sse_event_with_null_bytes_does_not_crash(self, event_store: EventStore) -> None:
+        """Regression test: store_sse_event must strip \\u0000 null bytes before
+        inserting into PostgreSQL JSONB — PostgreSQL raises UntranslatableCharacter
+        otherwise (issue #226, reproduced with Tavily and other external tool output).
+
+        The event_store fixture already patches db_manager.lg_pool with a test pool,
+        so both store_sse_event (uses module-level singleton) and event_store.get_all_events
+        (uses fixture instance) go through the same test database connection.
+        """
+        run_id = "null-byte-regression-run"
+
+        # Simulate data from an external tool (e.g. Tavily) containing null bytes
+        data_with_nulls = {
+            "content": "search result\u0000with null byte",
+            "nested": {
+                "title": "article\u0000title",
+                "body": "text\u0000\u0000more text",
+            },
+            "clean_field": "this value has no nulls",
+            "score": 0.95,
+        }
+
+        # Must not raise psycopg.errors.UntranslatableCharacter
+        result = await store_sse_event(run_id, f"{run_id}_event_1", "messages", data_with_nulls)
+
+        assert result is not None
+        assert result.id == f"{run_id}_event_1"
+
+        # Verify stored data has null bytes stripped
+        events = await event_store.get_all_events(run_id)
+        assert len(events) == 1
+
+        stored_json = json.dumps(events[0].data)
+        assert "\\u0000" not in stored_json
+        assert "\u0000" not in stored_json
+
+        # Clean values must be preserved
+        assert events[0].data["clean_field"] == "this value has no nulls"
+        assert events[0].data["score"] == 0.95

--- a/libs/aegra-api/tests/unit/test_services/test_event_store.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_store.py
@@ -348,6 +348,33 @@ class TestStoreSSEEvent:
             assert parsed_back["normal"] == "string"
 
     @pytest.mark.asyncio
+    async def test_store_sse_event_strips_null_bytes(self) -> None:
+        """Regression test: data containing \\u0000 null bytes must be stripped before
+        PostgreSQL JSONB storage (PostgreSQL rejects \\u0000 in JSON fields)."""
+        with patch("aegra_api.services.event_store.event_store") as mock_event_store:
+            mock_event_store.store_event = AsyncMock()
+
+            # Simulate data from an external tool (e.g. Tavily) that contains null bytes
+            data = {
+                "content": "normal text\u0000with null byte",
+                "nested": {"key": "value\u0000\u0000end"},
+                "clean": "no nulls here",
+            }
+
+            await store_sse_event("run-123", "event-1", "test", data)
+
+            call_args = mock_event_store.store_event.call_args
+            _, stored_event = call_args[0]
+
+            # Null bytes must be stripped from stored data
+            json_str = json.dumps(stored_event.data)
+            assert "\\u0000" not in json_str
+            assert "\u0000" not in json_str
+
+            # Clean values must be preserved
+            assert stored_event.data["clean"] == "no nulls here"
+
+    @pytest.mark.asyncio
     async def test_store_sse_event_serialization_fallback(self):
         """Test fallback behavior when JSON serialization fails"""
         with patch("aegra_api.services.event_store.event_store") as mock_event_store:


### PR DESCRIPTION
## Description

  Fixes a crash that occurred when external tools (e.g. Tavily web search) returned data containing `\u0000` null bytes. PostgreSQL's JSONB type rejects null characters and raises `UntranslatableCharacter`, causing the entire run to fail with a status of `error`.

  The fix sanitizes null bytes from event data in `store_sse_event` after `json.dumps` and before `json.loads`, so the data reaching the database is always JSONB-safe.

  ## Type of Change

  - [x] `fix`: Bug fix

  ## Related Issues

  Closes #226

  ## Changes Made

  - `libs/aegra-api/src/aegra_api/services/event_store.py` — added `json_str.replace("\\u0000", "")` in `store_sse_event` between `json.dumps` and `json.loads` to strip null bytes
  before PostgreSQL JSONB insertion
  - `libs/aegra-api/tests/unit/test_services/test_event_store.py` — added regression unit test `test_store_sse_event_strips_null_bytes` verifying null bytes are absent from stored
  data
  - `libs/aegra-api/tests/integration/test_services/test_event_store_integration.py` — added regression integration test `test_store_sse_event_with_null_bytes_does_not_crash`
  verifying the fix against a real PostgreSQL instance

  ## Testing

  - [x] Unit tests added/updated
  - [x] Integration tests added/updated
  - [ ] E2E tests added/updated
  - [x] Manual testing performed

  Unit test runs without a database and verifies null bytes are stripped from the serialized data. Integration test connects to a real PostgreSQL instance and confirms that
  `store_sse_event` no longer raises `psycopg.errors.UntranslatableCharacter` when data contains `\u0000`.

  ## Checklist

  - [x] Code follows project style (Ruff formatting)
  - [x] All linting checks pass (`make lint`)
  - [x] Type checking passes (`make type-check`)
  - [x] All tests pass (`make test`)
  - [ ] Documentation updated (if needed)
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] PR title follows Conventional Commits format

  ## Additional Notes

  This bug is distinct from the fixes in #215 and #212. PR #215 fixed double-escaped `\\uXXXX` sequences in the **SSE stream output** (`format_sse_message`). This PR fixes null
  bytes in the **database storage path** (`store_sse_event`). The two code paths are independent — #215 did not protect the JSONB insert.

  Note: `\ufffd` (Unicode replacement character) and other non-ASCII characters visible in the original error trace are accepted by PostgreSQL without issue. Only `\u0000` is
  rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event storage errors caused by null bytes in event data. Events are now automatically processed to remove null bytes before storage, ensuring reliable persistence while preserving all valid fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->