### PR TITLE
fix: deep-copy graph config to prevent base graph mutation

### DIFF
--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -8,6 +8,7 @@ Architecture:
 """
 
 import asyncio
+import copy
 import importlib.util
 import json
 import sys
@@ -317,8 +318,19 @@ class LangGraphService:
             # Try to create a copy with checkpointer/store injected.
             # NOTE: Do this BEFORE yield to avoid dual-yield when exceptions
             # occur in the context body.
+            # Deep-copy the graph's config to prevent astream from mutating
+            # the cached base graph's nested dicts (e.g. config.metadata).
+            # Pregel.copy() is shallow, so without this, all copies share
+            # the same metadata dict, and writes during execution pollute
+            # the base graph — breaking subsequent runs.
             try:
-                graph_to_use = base_graph.copy(update={"checkpointer": checkpointer, "store": store})
+                graph_to_use = base_graph.copy(
+                    update={
+                        "checkpointer": checkpointer,
+                        "store": store,
+                        "config": copy.deepcopy(base_graph.config),
+                    }
+                )
             except Exception as exc:
                 logger.warning(
                     "graph_checkpointer_injection_failed",

--- a/libs/aegra-api/tests/integration/test_services/test_graph_factory_integration.py
+++ b/libs/aegra-api/tests/integration/test_services/test_graph_factory_integration.py
@@ -513,7 +513,11 @@ class TestNonFactoryGetGraphPreserved:
             async with service.get_graph("s") as graph:
                 assert graph is mock_copy
 
-            mock_base.copy.assert_called_once_with(update={"checkpointer": "cp", "store": "st"})
+            mock_base.copy.assert_called_once()
+            call_kwargs = mock_base.copy.call_args[1]["update"]
+            assert call_kwargs["checkpointer"] == "cp"
+            assert call_kwargs["store"] == "st"
+            assert "config" in call_kwargs
 
 
 # ---------------------------------------------------------------------------

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -233,7 +233,11 @@ class TestLangGraphServiceGraphs:
 
             async with service.get_graph("test_graph") as graph:
                 assert graph == mock_copy
-                mock_base_graph.copy.assert_called_once_with(update={"checkpointer": "checkpointer", "store": "store"})
+                mock_base_graph.copy.assert_called_once()
+                call_kwargs = mock_base_graph.copy.call_args[1]["update"]
+                assert call_kwargs["checkpointer"] == "checkpointer"
+                assert call_kwargs["store"] == "store"
+                assert "config" in call_kwargs
 
     @pytest.mark.asyncio
     async def test_get_graph_not_found(self):
@@ -825,6 +829,8 @@ async def test_get_graph_context_manager_injects_checkpointer(monkeypatch):
     service._graph_registry["g2"] = {"file_path": "f", "export_name": "g"}
 
     class Precompiled:
+        config: dict = {}
+
         def copy(self, update=None):
             return f"copied:{update.get('checkpointer')}:{update.get('store')}"
 


### PR DESCRIPTION
## Summary

Fixes #224 — graphs created by `create_deep_agent` only work for the first message; subsequent messages complete instantly with no LLM call.

- **Root cause**: `Pregel.copy()` is a shallow copy. Aegra caches compiled graphs and creates per-request copies via `.copy()`, but nested dicts like `config.metadata` remain shared references. When `astream` runs, it merges run metadata (`thread_id`, `run_id`, etc.) in-place into the shared `metadata` dict, polluting the cached base graph. On subsequent runs, the stale execution metadata causes the Pregel executor to skip node execution entirely.
- **Fix**: Deep-copy `base_graph.config` when creating per-request graph copies in `get_graph()`, so each execution gets an isolated config dict.
- **Scope**: 1 production file (`langgraph_service.py`), 2 test files updated for new assertion shape. All 964 tests pass.

## Test plan

- [x] All 964 unit/integration tests pass
- [x] Lint passes (ruff check + format)
- [x] E2E verified: started server with Docker, sent 3 consecutive messages to a `create_deep_agent` graph — all return proper AI responses (previously only the first worked)
- [x] Standard `react_agent` graphs unaffected (no pre-existing `config.metadata` to pollute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed graph configuration isolation to prevent unintended modifications that could occur across concurrent requests, ensuring configurations remain properly separated between operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->