### PR TITLE
ci: parallelize release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,8 @@ jobs:
 
   # ---------------------------------------------------------------
   # Publish stage — sequential (API first, CLI depends on it)
-  # Each environment has a protection rule requiring manual approval,
-  # so you approve once and both publish back-to-back.
+  # Each environment (release-api, release-cli) has its own protection
+  # rule requiring separate manual approval before publishing.
   # ---------------------------------------------------------------
   publish-api:
     needs: [build-api]


### PR DESCRIPTION
## Summary
- Both `build-api` and `build-cli` now run in parallel instead of sequentially
- Single approval gate (on `release-api` environment) triggers both publishes back-to-back
- API still publishes before CLI (CLI depends on it at install time via `aegra-api~=X.Y.Z`)

**Before:**
```
build-api → approve → publish-api → build-cli → approve → publish-cli → create-release
```

**After:**
```
build-api ─┐
            ├→ approve → publish-api → publish-cli → create-release
build-cli ─┘
```

## Test plan
- [ ] Trigger workflow with `both` option and verify builds run in parallel
- [ ] Verify approval is requested once (on `release-api` environment)
- [ ] Verify API publishes before CLI
- [ ] Verify `aegra-cli` only release still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined release pipeline to publish API first, then CLI, enforcing sequential, protected release steps.
  * Builds still run in parallel for speed; publishing now uses distinct, environment-protected stages.
  * Release creation now runs after successful publishes, assembling release notes from publish artifacts and creating the final GitHub release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->