### PR TITLE
fix: set requires-python to >=3.12 in project templates

### DIFF
--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.8.0"
+version = "0.8.1"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.8.0"
+version = "0.8.1"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/src/aegra_cli/templates/react-agent/pyproject.toml.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/react-agent/pyproject.toml.template
@@ -2,7 +2,7 @@
 name = "$slug"
 version = "0.1.0"
 description = "$project_name"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 
 dependencies = [
     "aegra-cli>=$aegra_version",

--- a/libs/aegra-cli/src/aegra_cli/templates/simple-chatbot/pyproject.toml.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/simple-chatbot/pyproject.toml.template
@@ -2,7 +2,7 @@
 name = "$slug"
 version = "0.1.0"
 description = "$project_name"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 
 dependencies = [
     "aegra-cli>=$aegra_version",

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -92,7 +92,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary
- Generated projects from `aegra init` had `requires-python = ">=3.11"` but `aegra-cli` requires Python 3.12+
- This caused `uv sync` to fail on fresh projects with a confusing dependency resolution error
- Fixed in both `simple-chatbot` and `react-agent` templates
- Patch bump: 0.8.0 → 0.8.1

## Test plan
- [x] All 65 init tests pass
- [x] Verified end-to-end: `aegra init` → `uv sync` → `aegra dev` on 0.8.0 hit this exact error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.8.1
  * Updated minimum Python version requirement from 3.11 to 3.12 for new projects created from templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->