### PR TITLE
fix: wrap 'before' checkpoint_id as RunnableConfig in thread history POST

### DIFF
--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -684,7 +684,7 @@ async def get_thread_history_post(
         state_snapshots = []
         kwargs = {
             "limit": limit,
-            "before": before,
+            "before": {"configurable": {"checkpoint_id": before}} if before else None,
         }
         if metadata is not None:
             kwargs["metadata"] = metadata


### PR DESCRIPTION
## Summary

- `get_thread_history_post` passes the `before` string directly to LangGraph's `aget_state_history`, but that method expects `before` to be a `RunnableConfig` dict (`{"configurable": {"checkpoint_id": "..."}}`) — not a plain string.
- This caused a `TypeError: string indices must be integers` (HTTP 500) whenever a client tried to paginate thread history using the `before` parameter.

## Fix

Wrap the `before` checkpoint ID string into the expected config structure before passing it to `aget_state_history`:

\`\`\`python
"before": {"configurable": {"checkpoint_id": before}} if before else None,
\`\`\`

## Test plan

- [ ] Call `POST /threads/{thread_id}/history` with a valid `before` checkpoint ID string
- [ ] Verify the response returns the page of states older than that checkpoint (no 500)
- [ ] Verify `before=null` still returns the first page correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed pagination handling in thread history retrieval to correctly filter checkpoint results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->