### PR TITLE
fix: correct wrong ThreadHistoryRequest signature for before

### DIFF
--- a/libs/aegra-api/src/aegra_api/models/threads.py
+++ b/libs/aegra-api/src/aegra_api/models/threads.py
@@ -145,7 +145,7 @@ class ThreadHistoryRequest(BaseModel):
     """Request model for thread history endpoint"""
 
     limit: int | None = Field(10, ge=1, le=1000, description="Number of states to return")
-    before: str | None = Field(None, description="Return states before this checkpoint ID")
+    before: dict | None = Field(None, description="Return states before this checkpoint ID")
     metadata: dict[str, Any] | None = Field(None, description="Filter by metadata")
     checkpoint: dict[str, Any] | None = Field(None, description="Checkpoint for subgraph filtering")
     subgraphs: bool | None = Field(False, description="Include states from subgraphs")


### PR DESCRIPTION
## Description
Fix the `before` parameter type signature in `ThreadHistoryRequest` to accept `RunnableConfig` objects instead of plain strings. This resolves HTTP 422 validation errors when using LangChain's official `useStream()` SDK for paginating thread history.

The issue occurs because LangChain's `useStream()` sends pagination cursors as Config objects (`{ configurable: { checkpoint_id: "..." } }`), but aegra's Pydantic model expected a plain string. LangGraph's `aget_state_history()` also expects a `RunnableConfig`, not a string.

## Type of Change
- [x] `fix`: Bug fix

## Related Issues
<!-- Link related issues if any -->

## Changes Made
- Changed `before: str | None` to `before: dict | None` in `ThreadHistoryRequest` model (`aegra_api/models/threads.py`)

## Testing
- [x] Manual testing performed
- Verified pagination works with LangChain's `useStream()` hook
- Confirmed HTTP 422 validation error is resolved

## Additional Notes
This fix ensures aegra correctly implements the LangGraph Server API specification for the `/threads/{thread_id}/history` endpoint. The `before` parameter should match LangGraph SDK's `RunnableConfig` type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API request parameter structure to support object-based data formats instead of string-based formats, enabling more flexible request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->