### PR TITLE
docs(assistants): fix async example for assistant creation

### DIFF
--- a/docs/guides/assistants.mdx
+++ b/docs/guides/assistants.mdx
@@ -24,18 +24,24 @@ This automatically creates an assistant with ID `"agent"` that you can use immed
 Create custom assistants with specific configurations:
 
 ```python
+import asyncio
 from langgraph_sdk import get_client
 
-client = get_client(url="http://localhost:2026")
 
-assistant = await client.assistants.create(
-    graph_id="agent",
-    name="Customer Support Agent",
-    description="Handles customer inquiries with web search",
-    metadata={"department": "support", "tier": "premium"},
-)
+async def main():
+    client = get_client(url="http://localhost:2026")
 
-print(assistant["assistant_id"])
+    # Create an assistant from your graph
+    assistant = await client.assistants.create(
+        graph_id="agent",
+        name="Customer Support Agent",
+        description="Handles customer inquiries with web search",
+        metadata={"department": "support", "tier": "premium"},
+    )
+    print(f"Assistant ID: {assistant['assistant_id']}")
+
+
+asyncio.run(main())
 ```
 
 ### Idempotent creation


### PR DESCRIPTION
## Description
Updated the "creating assistants" example in the documentation to use a correct async pattern with `asyncio.run()`. The previous example had syntax errors (`await` outside a function).

## Type of Change
- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
Fixes broken example in assistants section of docs

## Changes Made
- Updated code snippet to use `asyncio`

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Screenshots (if applicable)
The old 

<img width="865" height="467" alt="Screenshot from 2026-03-27 23-55-51" src="https://github.com/user-attachments/assets/9781d9ca-a077-49e4-9631-be1c5e5dbda9" />

The new 
<img width="766" height="554" alt="Screenshot from 2026-03-28 00-18-23" src="https://github.com/user-attachments/assets/5dc80202-d794-40c9-9b7c-847de766a28e" />

## Additional Notes
This PR only updates documentation; no functional code changes were made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the assistant creation example code to demonstrate modern async/await patterns with proper function structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->