### PR TITLE
fix: correct ThreadHistoryRequest.before type to accept checkpoint dict

### DIFF
--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -681,10 +681,19 @@ async def get_thread_history_post(
         elif checkpoint_ns is not None:
             config["configurable"]["checkpoint_ns"] = checkpoint_ns
 
+        # Convert `before` to a RunnableConfig for aget_state_history.
+        # The SDK sends `before` as either a checkpoint ID string or a
+        # Checkpoint dict with thread_id/checkpoint_ns/checkpoint_id keys.
+        before_config: dict[str, Any] | None = None
+        if isinstance(before, str):
+            before_config = {"configurable": {"checkpoint_id": before}}
+        elif isinstance(before, dict):
+            before_config = {"configurable": before}
+
         state_snapshots = []
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "limit": limit,
-            "before": before,
+            "before": before_config,
         }
         if metadata is not None:
             kwargs["metadata"] = metadata

--- a/libs/aegra-api/src/aegra_api/models/threads.py
+++ b/libs/aegra-api/src/aegra_api/models/threads.py
@@ -145,7 +145,9 @@ class ThreadHistoryRequest(BaseModel):
     """Request model for thread history endpoint"""
 
     limit: int | None = Field(10, ge=1, le=1000, description="Number of states to return")
-    before: str | None = Field(None, description="Return states before this checkpoint ID")
+    before: dict[str, Any] | str | None = Field(
+        None, description="Return states before this checkpoint (checkpoint dict or checkpoint ID string)"
+    )
     metadata: dict[str, Any] | None = Field(None, description="Filter by metadata")
     checkpoint: dict[str, Any] | None = Field(None, description="Checkpoint for subgraph filtering")
     subgraphs: bool | None = Field(False, description="Include states from subgraphs")


### PR DESCRIPTION
## Summary
- Fix `ThreadHistoryRequest.before` type from `str | None` to `dict[str, Any] | str | None` to match the LangGraph SDK which sends either a checkpoint ID string or a Checkpoint dict
- Convert `before` values to `RunnableConfig` format (`{"configurable": ...}`) before passing to `aget_state_history`, which expects `RunnableConfig | None`

## Related Issues
Builds on the fix originally identified by @Jourdelune in #259 — they correctly spotted that `before` should accept a dict, not just a string. This PR expands on that by using fully parameterized types (`dict[str, Any]`), adding the RunnableConfig conversion in the handler, and keeping the GET endpoint compatible.

## Test plan
- [x] All 977 unit/integration tests pass
- [x] Ruff lint passes
- [ ] Verify with SDK client sending `before` as string (checkpoint_id pagination)
- [ ] Verify with SDK client sending `before` as Checkpoint dict

🤖 Generated with [Claude Code](https://claude.com/claude-code)