### PR TITLE
fix: convert non-streaming LLM messages to chunk types in messages-tuple mode

### DIFF
--- a/libs/aegra-api/src/aegra_api/services/graph_streaming.py
+++ b/libs/aegra-api/src/aegra_api/services/graph_streaming.py
@@ -11,9 +11,11 @@ from typing import Any, cast
 
 import structlog
 from langchain_core.messages import (
+    AIMessage,
     AIMessageChunk,
     BaseMessage,
     BaseMessageChunk,
+    ToolMessage,
     ToolMessageChunk,
     convert_to_messages,
     message_chunk_to_message,
@@ -32,6 +34,26 @@ from pydantic.v1 import ValidationError as ValidationErrorLegacy
 from aegra_api.utils.run_utils import _filter_context_by_schema
 
 logger = structlog.getLogger(__name__)
+
+
+def _to_message_chunk(msg: BaseMessage) -> BaseMessage:
+    """Convert a complete message to its chunk equivalent for messages-tuple mode.
+
+    When an LLM does not stream (streaming=False), LangGraph emits complete
+    AIMessage/ToolMessage objects instead of AIMessageChunk/ToolMessageChunk.
+    This means messages-tuple returns "type": "ai" for non-streaming LLMs but
+    "type": "AIMessageChunk" for streaming ones — inconsistent wire types for
+    the same stream mode. This function normalizes them so that messages-tuple
+    always returns chunk types regardless of LLM streaming capability.
+    """
+    if isinstance(msg, (AIMessageChunk, ToolMessageChunk)):
+        return msg
+    if isinstance(msg, AIMessage):
+        return AIMessageChunk(**msg.model_dump(exclude={"type"}))
+    if isinstance(msg, ToolMessage):
+        return ToolMessageChunk(**msg.model_dump(exclude={"type"}))
+    return msg
+
 
 # Type alias for stream output
 AnyStream = AsyncIterator[tuple[str, Any]]
@@ -335,6 +357,10 @@ def _process_stream_event(
     # Handle messages mode
     if mode == "messages":
         if "messages-tuple" in stream_mode:
+            # Normalize message type to chunk for consistent client output
+            if isinstance(chunk, (tuple, list)) and len(chunk) == 2:
+                msg_, meta_ = chunk
+                chunk = (_to_message_chunk(msg_), meta_)
             # Pass through raw tuple format
             if subgraphs and namespace:
                 ns_str = "|".join(namespace) if isinstance(namespace, (list, tuple)) else str(namespace)

--- a/libs/aegra-api/tests/unit/test_services/test_graph_streaming.py
+++ b/libs/aegra-api/tests/unit/test_services/test_graph_streaming.py
@@ -5,12 +5,20 @@ and event processing logic.
 """
 
 import pytest
-from langchain_core.messages import AIMessageChunk, BaseMessageChunk, HumanMessage
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessageChunk,
+    HumanMessage,
+    ToolMessage,
+    ToolMessageChunk,
+)
 
 from aegra_api.services.graph_streaming import (
     _normalize_checkpoint_payload,
     _normalize_checkpoint_task,
     _process_stream_event,
+    _to_message_chunk,
 )
 
 
@@ -717,3 +725,166 @@ class TestStreamGraphEvents:
             # Verify filter called
             mock_filter.assert_called_once()
             assert mock_filter.call_args[0][0] == context
+
+
+class TestToMessageChunk:
+    """Test _to_message_chunk function."""
+
+    def test_preserves_ai_message_chunk(self) -> None:
+        """Test that AIMessageChunk is returned as-is."""
+        chunk = AIMessageChunk(id="1", content="hello")
+
+        result = _to_message_chunk(chunk)
+
+        assert result is chunk
+
+    def test_preserves_tool_message_chunk(self) -> None:
+        """Test that ToolMessageChunk is returned as-is."""
+        chunk = ToolMessageChunk(id="1", content="result", tool_call_id="tc-1")
+
+        result = _to_message_chunk(chunk)
+
+        assert result is chunk
+
+    def test_converts_ai_message_to_chunk(self) -> None:
+        """Test that AIMessage is converted to AIMessageChunk with all fields."""
+        msg = AIMessage(
+            id="msg-1",
+            content="hello",
+            name="assistant",
+            additional_kwargs={"key": "value"},
+            response_metadata={"model": "fake"},
+            tool_calls=[{"id": "tc-1", "name": "tool", "args": {}}],
+            invalid_tool_calls=[],
+        )
+
+        result = _to_message_chunk(msg)
+
+        assert isinstance(result, AIMessageChunk)
+        assert result.content == "hello"
+        assert result.id == "msg-1"
+        assert result.name == "assistant"
+        assert result.additional_kwargs == {"key": "value"}
+        assert result.response_metadata == {"model": "fake"}
+        assert result.tool_calls == [{"id": "tc-1", "name": "tool", "args": {}, "type": "tool_call"}]
+        assert result.invalid_tool_calls == []
+
+    def test_converts_tool_message_to_chunk(self) -> None:
+        """Test that ToolMessage is converted to ToolMessageChunk with all fields."""
+        msg = ToolMessage(
+            id="msg-2",
+            content="tool result",
+            name="search",
+            tool_call_id="tc-1",
+            additional_kwargs={"extra": "data"},
+            response_metadata={"status": "ok"},
+        )
+
+        result = _to_message_chunk(msg)
+
+        assert isinstance(result, ToolMessageChunk)
+        assert result.content == "tool result"
+        assert result.id == "msg-2"
+        assert result.name == "search"
+        assert result.tool_call_id == "tc-1"
+        assert result.additional_kwargs == {"extra": "data"}
+        assert result.response_metadata == {"status": "ok"}
+
+    def test_converts_tool_message_error_status_preserved(self) -> None:
+        """Test that status and artifact fields are preserved in ToolMessage conversion."""
+        msg = ToolMessage(
+            id="msg-3",
+            content="error output",
+            tool_call_id="tc-2",
+            status="error",
+            artifact={"raw": "data"},
+        )
+
+        result = _to_message_chunk(msg)
+
+        assert isinstance(result, ToolMessageChunk)
+        assert result.status == "error"
+        assert result.artifact == {"raw": "data"}
+
+    def test_returns_unknown_message_type_unchanged(self) -> None:
+        """Test that unrecognized message types are returned as-is."""
+        msg = HumanMessage(id="h-1", content="hi")
+
+        result = _to_message_chunk(msg)
+
+        assert result is msg
+
+    def test_serialized_type_field_is_ai_message_chunk(self) -> None:
+        """Test that converted AIMessage serializes with type 'AIMessageChunk'."""
+        msg = AIMessage(id="msg-1", content="hello")
+
+        result = _to_message_chunk(msg)
+        serialized = result.model_dump()
+
+        assert serialized["type"] == "AIMessageChunk"
+
+    def test_serialized_type_field_is_tool_message_chunk(self) -> None:
+        """Test that converted ToolMessage serializes with type 'ToolMessageChunk'."""
+        msg = ToolMessage(id="msg-1", content="result", tool_call_id="tc-1")
+
+        result = _to_message_chunk(msg)
+        serialized = result.model_dump()
+
+        assert serialized["type"] == "ToolMessageChunk"
+
+
+class TestProcessStreamEventMessagesTupleNormalization:
+    """Test that messages-tuple mode normalizes message types."""
+
+    def test_list_shaped_messages_tuple_converts_to_chunk(self) -> None:
+        """Test that list-shaped (message, metadata) payloads are normalized.
+
+        JS graphs deliver messages-tuple chunks as JSON-deserialized lists,
+        not Python tuples.
+        """
+        msg = AIMessage(id="msg-1", content="hello")
+        chunk = [msg, {"run_id": "test"}]
+
+        results = _process_stream_event(
+            mode="messages",
+            chunk=chunk,
+            namespace=None,
+            subgraphs=False,
+            stream_mode=["messages-tuple"],
+            messages={},
+            only_interrupt_updates=False,
+            on_checkpoint=lambda _: None,
+            on_task_result=lambda _: None,
+        )
+
+        assert results is not None
+        assert results[0][0] == "messages"
+        converted_msg, _meta = results[0][1]
+        assert isinstance(converted_msg, AIMessageChunk)
+
+    def test_non_streaming_ai_message_serializes_as_chunk(self) -> None:
+        """Test that a non-streaming AIMessage produces 'AIMessageChunk' in wire format.
+
+        Proves the end-to-end fix: a non-streaming LLM emitting AIMessage
+        (type: "ai") is normalized so the serialized SSE payload contains
+        type: "AIMessageChunk", matching what streaming LLMs produce.
+        """
+        msg = AIMessage(id="msg-1", content="non-streaming response")
+        chunk = (msg, {"run_id": "test"})
+
+        results = _process_stream_event(
+            mode="messages",
+            chunk=chunk,
+            namespace=None,
+            subgraphs=False,
+            stream_mode=["messages-tuple"],
+            messages={},
+            only_interrupt_updates=False,
+            on_checkpoint=lambda _: None,
+            on_task_result=lambda _: None,
+        )
+
+        assert results is not None
+        converted_msg, _meta = results[0][1]
+        serialized = converted_msg.model_dump()
+        assert serialized["type"] == "AIMessageChunk"

--- a/libs/aegra-api/tests/unit/test_services/test_graph_streaming.py
+++ b/libs/aegra-api/tests/unit/test_services/test_graph_streaming.py
@@ -754,6 +754,7 @@ class TestToMessageChunk:
             name="assistant",
             additional_kwargs={"key": "value"},
             response_metadata={"model": "fake"},
+            usage_metadata={"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
             tool_calls=[{"id": "tc-1", "name": "tool", "args": {}}],
             invalid_tool_calls=[],
         )
@@ -766,6 +767,7 @@ class TestToMessageChunk:
         assert result.name == "assistant"
         assert result.additional_kwargs == {"key": "value"}
         assert result.response_metadata == {"model": "fake"}
+        assert result.usage_metadata == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
         assert result.tool_calls == [{"id": "tc-1", "name": "tool", "args": {}, "type": "tool_call"}]
         assert result.invalid_tool_calls == []
 


### PR DESCRIPTION
## Description

  When an LLM does not stream (`streaming=False`), LangGraph core emits complete `AIMessage`/`ToolMessage` objects (serialized as `type: "ai"`) instead of AIMessageChunk`/`ToolMessageChunk` (`type: "AIMessageChunk"`) in the `messages-tuple` stream mode. This creates inconsistent wire types — the same stream mode returns different `type` values depending on whether the underlying LLM supports streaming.

  The official `langgraph-api` server does not normalize message types — it passes them through as-is. The `@langchain/langgraph-sdk` JS SDK works around this client-side by stripping the `MessageChunk` suffix in `MessageTupleManager.add()`, so agent-chat-ui and LangGraph Studio are unaffected. But any client consuming the raw SSE stream directly sees inconsistent types.

  This fix normalizes messages in `messages-tuple` mode so that clients always receive chunk types (`AIMessageChunk`, `ToolMessageChunk`) regardless of LLM streaming capability.

  ## Type of Change

  - [x] `fix`: Bug fix

  ## Changes Made

  - Add `_to_message_chunk` in `graph_streaming.py` — converts `AIMessage` → `AIMessageChunk` and `ToolMessage` → `ToolMessageChunk` using `model_dump(exclude={"type"})` for full field preservation (tool_calls, usage_metadata, response_metadata, tool_call_id, status, artifact, etc.)
  - Apply normalization in `_process_stream_event` for `messages-tuple` mode, handling both tuple (Python graphs) and list (JS graphs via JSON deserialization) payload shapes
  - Add 10 unit tests: 8 for `_to_message_chunk` (passthrough, conversion with field assertions including usage_metadata, unknown type passthrough, serialized type field checks) and 2 for `_process_stream_event` integration (list-shaped payloads, wire format serialization)

  ## Testing

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] E2E tests added/updated
  - [x] Manual testing performed (verified with fake non-streaming BaseChatModel)

  ## Checklist

  - [x] Code follows project style (Ruff formatting)
  - [x] All linting checks pass (`make lint`)
  - [x] Type checking passes (`make type-check`)
  - [x] All tests pass (`make test`)
  - [ ] Documentation updated (if needed)
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] PR title follows Conventional Commits format

  ## Additional Notes

  Verified the behavior by building a minimal test graph with a fake non-streaming `BaseChatModel` — LangGraph's `StreamMessagesHandler.on_llm_end` emits `AIMessage` (not `AIMessageChunk`) when the model doesn't stream. The `model_dump(exclude={"type"})` approach ensures all current and future langchain-core fields are preserved without manual enumeration.