### PR TITLE
fix(codecov): restore consistent PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -39,10 +39,11 @@ comment:
   # Use condensed layout for cleaner, more focused PR comments
   layout: "condensed_header, condensed_files, condensed_footer"
   behavior: default  # Update existing comment, or post new if doesn't exist
-  # Only post if coverage changes (reduces noise)
-  require_changes: true
-  # Require both base and head reports for meaningful comparison
-  require_base: true
+  # Post comments even when there is no visible coverage delta.
+  # This keeps PR feedback consistent for docs-only and config-only changes.
+  require_changes: false
+  # Allow comments when base coverage is unavailable or cannot be compared cleanly.
+  require_base: false
   require_head: true
   # Hide project coverage, focus on patch/diff coverage (cleaner view)
   hide_project_coverage: true


### PR DESCRIPTION
## Summary
- set comment.require_changes back to alse so Codecov can comment even when there is no visible coverage delta
- set comment.require_base back to alse so PR comments are not suppressed when base comparison is unavailable or incomplete
- keep the condensed layout and equire_head: true

## Why
Recent PRs were uploading coverage successfully, but Codecov comments were being skipped because the repo config required both a clean base comparison and a detectable coverage change before posting.

This change restores more consistent PR feedback while keeping the existing compact comment format.

## Test plan
- [ ] Wait for CI + Codecov on this PR and confirm the PR comment appears consistently


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting configuration to provide more consistent feedback on pull requests, including scenarios where coverage baseline data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->