### PR TITLE
fix: add format_exc_info to structlog shared processors

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.1"
+    "version": "0.9.2"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.1"
+version = "0.9.2"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/utils/setup_logging.py
+++ b/libs/aegra-api/src/aegra_api/utils/setup_logging.py
@@ -1,5 +1,6 @@
 import logging
 import logging.config
+import sys
 from typing import Any
 
 import structlog
@@ -67,13 +68,20 @@ def get_logging_config() -> dict[str, Any]:
     # Use a colorful console renderer for local development, and JSON for production.
     final_renderer: structlog.typing.Processor
     if not is_production:
+        # RichTracebackFormatter uses Unicode box-drawing characters that
+        # Windows cp1252 console encoding cannot render, causing
+        # UnicodeEncodeError through colorama. Use plain_traceback on Windows.
+        if sys.platform == "win32":
+            exception_formatter = structlog.dev.plain_traceback
+        else:
+            exception_formatter = structlog.dev.RichTracebackFormatter(
+                show_locals=False,
+                max_frames=10,
+            )
         final_renderer = structlog.dev.ConsoleRenderer(
             colors=True,
             pad_level=True,
-            exception_formatter=structlog.dev.RichTracebackFormatter(
-                show_locals=False,
-                max_frames=10,
-            ),
+            exception_formatter=exception_formatter,
         )
     else:
         final_renderer = structlog.processors.JSONRenderer()

--- a/libs/aegra-api/src/aegra_api/utils/setup_logging.py
+++ b/libs/aegra-api/src/aegra_api/utils/setup_logging.py
@@ -56,10 +56,12 @@ def get_logging_config() -> dict[str, Any]:
     if is_production:
         shared_processors.append(structlog.processors.format_exc_info)
 
-    shared_processors.extend([
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.UnicodeDecoder(),
-    ])
+    shared_processors.extend(
+        [
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.UnicodeDecoder(),
+        ]
+    )
 
     # Determine the final renderer based on the environment
     # Use a colorful console renderer for local development, and JSON for production.

--- a/libs/aegra-api/src/aegra_api/utils/setup_logging.py
+++ b/libs/aegra-api/src/aegra_api/utils/setup_logging.py
@@ -33,6 +33,7 @@ def get_logging_config() -> dict[str, Any]:
             }
         ),
         structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.format_exc_info,
         # This processor must be last in the shared chain to format positional args.
         structlog.stdlib.PositionalArgumentsFormatter(),
     ]

--- a/libs/aegra-api/src/aegra_api/utils/setup_logging.py
+++ b/libs/aegra-api/src/aegra_api/utils/setup_logging.py
@@ -10,53 +10,23 @@ from aegra_api.settings import settings
 
 
 def get_logging_config() -> dict[str, Any]:
-    """
-    Returns a unified logging configuration dictionary that uses structlog
-    for consistent, structured logging across the application and Uvicorn.
+    """Return a unified logging config dict for structlog + stdlib integration.
 
-    This configuration solves the multiprocessing "pickling" error on Windows
-    by using string references for streams (e.g., "ext://sys.stdout").
+    Uses string references for streams (e.g., "ext://sys.stdout") to avoid
+    the multiprocessing pickling error on Windows.
     """
-    # Determine log level from environment or set a default
     env_mode = settings.app.ENV_MODE
     log_level = settings.app.LOG_LEVEL
 
-    # These processors will be used by BOTH structlog and standard logging
-    # to ensure consistent output for all logs.
+    # Determine mode-specific processors and renderer.
     #
-    # Ordering rationale:
-    #   1. merge_contextvars    — must be FIRST so request-scoped context
-    #      (request_id, run_id, etc.) is available to all subsequent processors
-    #   2. Enrichment           — add_log_level, add_logger_name, ExtraAdder,
-    #      CallsiteParameterAdder, TimeStamper
-    #   3. Exception rendering  — StackInfoRenderer, then format_exc_info
-    #      (production only; ConsoleRenderer handles exc_info internally)
-    #   4. Positional args      — PositionalArgumentsFormatter
-    #   5. Safety               — UnicodeDecoder (handles byte strings from libs)
-    shared_processors: list[Any] = [
-        structlog.contextvars.merge_contextvars,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.ExtraAdder(),
-        structlog.processors.CallsiteParameterAdder(
-            {
-                structlog.processors.CallsiteParameter.FILENAME,
-                structlog.processors.CallsiteParameter.FUNC_NAME,
-                structlog.processors.CallsiteParameter.LINENO,
-            }
-        ),
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.StackInfoRenderer(),
-    ]
-
-    # Branch on environment for exception handling and renderer.
+    # Production: format_exc_info converts exc_info into a traceback string
+    # because JSONRenderer cannot render exceptions on its own.
     #
-    # - Production: format_exc_info converts exc_info into a traceback string
-    #   because JSONRenderer cannot render exceptions on its own.
-    # - Dev: ConsoleRenderer handles exc_info internally via its
-    #   exception_formatter, so format_exc_info must be excluded (it would
-    #   convert exceptions to plain strings before ConsoleRenderer sees them,
-    #   killing pretty traceback rendering).
+    # Dev: ConsoleRenderer handles exc_info internally via its
+    # exception_formatter, so format_exc_info must be excluded (it would
+    # convert exceptions to plain strings before ConsoleRenderer sees them,
+    # killing pretty traceback rendering).
     final_renderer: structlog.typing.Processor
     if env_mode in ("LOCAL", "DEVELOPMENT"):
         # RichTracebackFormatter uses Unicode box-drawing characters that
@@ -74,31 +44,48 @@ def get_logging_config() -> dict[str, Any]:
             pad_level=True,
             exception_formatter=exception_formatter,
         )
+        mode_processors: list[Any] = []
     else:
-        shared_processors.append(structlog.processors.format_exc_info)
         final_renderer = structlog.processors.JSONRenderer()
+        mode_processors = [structlog.processors.format_exc_info]
 
-    shared_processors.extend(
-        [
-            structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.UnicodeDecoder(),
-        ]
-    )
+    # Shared processors used by BOTH structlog and stdlib (via foreign_pre_chain).
+    #
+    # Ordering constraints:
+    #   - merge_contextvars must be FIRST so request-scoped context
+    #     (request_id, run_id, etc.) is visible to all subsequent processors
+    #   - format_exc_info (production only) must come after StackInfoRenderer
+    shared_processors: list[Any] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.ExtraAdder(),
+        structlog.processors.CallsiteParameterAdder(
+            {
+                structlog.processors.CallsiteParameter.FILENAME,
+                structlog.processors.CallsiteParameter.FUNC_NAME,
+                structlog.processors.CallsiteParameter.LINENO,
+            }
+        ),
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        *mode_processors,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.UnicodeDecoder(),
+    ]
 
     return {
         "version": 1,
-        "disable_existing_loggers": False,  # Important for library logging
+        # Keep library loggers (uvicorn, httpx, etc.) alive
+        "disable_existing_loggers": False,
         "formatters": {
             "default": {
-                # Use structlog's formatter as the bridge
                 "()": "structlog.stdlib.ProcessorFormatter",
-                # These processors run on ALL records after pre-chain processing.
-                # remove_processors_meta strips internal keys before rendering.
+                # remove_processors_meta strips internal keys before rendering
                 "processors": [
                     structlog.stdlib.ProcessorFormatter.remove_processors_meta,
                     final_renderer,
                 ],
-                # These processors are run on ANY log record, including those from Uvicorn.
                 "foreign_pre_chain": shared_processors,
             },
         },
@@ -107,22 +94,17 @@ def get_logging_config() -> dict[str, Any]:
                 "level": log_level,
                 "class": "logging.StreamHandler",
                 "formatter": "default",
-                # IMPORTANT: Use the string reference to avoid the pickling error.
-                # This defers the lookup of sys.stdout until the config is loaded
-                # in the child process.
+                # String reference defers sys.stdout lookup until the config
+                # is loaded in the child process (avoids pickling error).
                 "stream": "ext://sys.stdout",
             },
         },
         "loggers": {
-            # Configure the root logger to catch everything
             "": {
                 "handlers": ["default"],
                 "level": log_level,
-                "propagate": False,  # Don't pass to other handlers
+                "propagate": False,
             },
-            # Uvicorn's loggers will now inherit the root logger's settings,
-            # ensuring they use the same handler and formatter.
-            # We explicitly set their level here.
             "uvicorn.error": {
                 "level": "INFO",
             },
@@ -134,32 +116,26 @@ def get_logging_config() -> dict[str, Any]:
 
 
 def setup_logging() -> None:
-    """
-    Configures both standard logging and structlog based on the
-    dictionary from get_logging_config(). This should be called
-    once at application startup.
-    """
+    """Configure both standard logging and structlog. Call once at startup."""
     config = get_logging_config()
 
-    # Configure the standard logging module
     logging.config.dictConfig(config)
-    # Propagate uvicorn logs instead of letting uvicorn configure the format
+
+    # Uvicorn installs its own handlers on startup; clear them so all logs
+    # go through our structlog formatter instead.
     for name in ["uvicorn", "uvicorn.access", "uvicorn.error"]:
         logging.getLogger(name).handlers.clear()
         logging.getLogger(name).propagate = True
 
-    # Reconfigure log levels for some overly chatty libraries
-    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+    # Silence overly chatty libraries
     logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
 
-    # Configure structlog to route its logs through the standard logging
-    # system that we just configured.
+    # Route structlog through the stdlib logging system we just configured.
+    shared_processors = config["formatters"]["default"]["foreign_pre_chain"]
     structlog.configure(
         processors=[
             structlog.stdlib.filter_by_level,
-            # Add shared processors to structlog's pipeline
-            *config["formatters"]["default"]["foreign_pre_chain"],
-            # Prepare the log record for the standard library's formatter
+            *shared_processors,
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),

--- a/libs/aegra-api/src/aegra_api/utils/setup_logging.py
+++ b/libs/aegra-api/src/aegra_api/utils/setup_logging.py
@@ -49,28 +49,19 @@ def get_logging_config() -> dict[str, Any]:
         structlog.processors.StackInfoRenderer(),
     ]
 
-    # format_exc_info converts exc_info into a traceback string. JSONRenderer
-    # needs this because it cannot render exceptions on its own. ConsoleRenderer
-    # handles exc_info internally via its exception_formatter (RichTracebackFormatter),
-    # so including format_exc_info in dev mode would kill pretty tracebacks.
-    is_production = env_mode not in ("LOCAL", "DEVELOPMENT")
-    if is_production:
-        shared_processors.append(structlog.processors.format_exc_info)
-
-    shared_processors.extend(
-        [
-            structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.UnicodeDecoder(),
-        ]
-    )
-
-    # Determine the final renderer based on the environment
-    # Use a colorful console renderer for local development, and JSON for production.
+    # Branch on environment for exception handling and renderer.
+    #
+    # - Production: format_exc_info converts exc_info into a traceback string
+    #   because JSONRenderer cannot render exceptions on its own.
+    # - Dev: ConsoleRenderer handles exc_info internally via its
+    #   exception_formatter, so format_exc_info must be excluded (it would
+    #   convert exceptions to plain strings before ConsoleRenderer sees them,
+    #   killing pretty traceback rendering).
     final_renderer: structlog.typing.Processor
-    if not is_production:
+    if env_mode in ("LOCAL", "DEVELOPMENT"):
         # RichTracebackFormatter uses Unicode box-drawing characters that
-        # Windows cp1252 console encoding cannot render, causing
-        # UnicodeEncodeError through colorama. Use plain_traceback on Windows.
+        # Windows cp1252 console encoding cannot render. Use plain_traceback
+        # on Windows to avoid UnicodeEncodeError through colorama.
         if sys.platform == "win32":
             exception_formatter = structlog.dev.plain_traceback
         else:
@@ -84,7 +75,15 @@ def get_logging_config() -> dict[str, Any]:
             exception_formatter=exception_formatter,
         )
     else:
+        shared_processors.append(structlog.processors.format_exc_info)
         final_renderer = structlog.processors.JSONRenderer()
+
+    shared_processors.extend(
+        [
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.UnicodeDecoder(),
+        ]
+    )
 
     return {
         "version": 1,

--- a/libs/aegra-api/src/aegra_api/utils/setup_logging.py
+++ b/libs/aegra-api/src/aegra_api/utils/setup_logging.py
@@ -22,9 +22,21 @@ def get_logging_config() -> dict[str, Any]:
 
     # These processors will be used by BOTH structlog and standard logging
     # to ensure consistent output for all logs.
+    #
+    # Ordering rationale:
+    #   1. merge_contextvars    — must be FIRST so request-scoped context
+    #      (request_id, run_id, etc.) is available to all subsequent processors
+    #   2. Enrichment           — add_log_level, add_logger_name, ExtraAdder,
+    #      CallsiteParameterAdder, TimeStamper
+    #   3. Exception rendering  — StackInfoRenderer, then format_exc_info
+    #      (production only; ConsoleRenderer handles exc_info internally)
+    #   4. Positional args      — PositionalArgumentsFormatter
+    #   5. Safety               — UnicodeDecoder (handles byte strings from libs)
     shared_processors: list[Any] = [
+        structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_log_level,
         structlog.stdlib.add_logger_name,
+        structlog.stdlib.ExtraAdder(),
         structlog.processors.CallsiteParameterAdder(
             {
                 structlog.processors.CallsiteParameter.FILENAME,
@@ -33,15 +45,26 @@ def get_logging_config() -> dict[str, Any]:
             }
         ),
         structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.format_exc_info,
-        # This processor must be last in the shared chain to format positional args.
-        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
     ]
+
+    # format_exc_info converts exc_info into a traceback string. JSONRenderer
+    # needs this because it cannot render exceptions on its own. ConsoleRenderer
+    # handles exc_info internally via its exception_formatter (RichTracebackFormatter),
+    # so including format_exc_info in dev mode would kill pretty tracebacks.
+    is_production = env_mode not in ("LOCAL", "DEVELOPMENT")
+    if is_production:
+        shared_processors.append(structlog.processors.format_exc_info)
+
+    shared_processors.extend([
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.UnicodeDecoder(),
+    ])
 
     # Determine the final renderer based on the environment
     # Use a colorful console renderer for local development, and JSON for production.
     final_renderer: structlog.typing.Processor
-    if env_mode in ("LOCAL", "DEVELOPMENT"):
+    if not is_production:
         final_renderer = structlog.dev.ConsoleRenderer(
             colors=True,
             pad_level=True,
@@ -60,8 +83,12 @@ def get_logging_config() -> dict[str, Any]:
             "default": {
                 # Use structlog's formatter as the bridge
                 "()": "structlog.stdlib.ProcessorFormatter",
-                # The final processor is the renderer.
-                "processor": final_renderer,
+                # These processors run on ALL records after pre-chain processing.
+                # remove_processors_meta strips internal keys before rendering.
+                "processors": [
+                    structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                    final_renderer,
+                ],
                 # These processors are run on ANY log record, including those from Uvicorn.
                 "foreign_pre_chain": shared_processors,
             },

--- a/libs/aegra-api/tests/unit/test_middleware/test_logger_middleware.py
+++ b/libs/aegra-api/tests/unit/test_middleware/test_logger_middleware.py
@@ -60,8 +60,9 @@ def test_get_logging_config_and_setup(monkeypatch):
     from aegra_api.utils.setup_logging import get_logging_config, setup_logging
 
     cfg = get_logging_config()
-    processor = cfg["formatters"]["default"]["processor"]
-    assert "ConsoleRenderer" in processor.__class__.__name__
+    # The renderer is the last entry in the "processors" list
+    renderer = cfg["formatters"]["default"]["processors"][-1]
+    assert "ConsoleRenderer" in renderer.__class__.__name__
 
     # --- 2. TEST PRODUCTION MODE ---
     monkeypatch.setenv("ENV_MODE", "PRODUCTION")
@@ -72,8 +73,8 @@ def test_get_logging_config_and_setup(monkeypatch):
     from aegra_api.utils.setup_logging import get_logging_config
 
     cfg2 = get_logging_config()
-    processor2 = cfg2["formatters"]["default"]["processor"]
-    assert "JSONRenderer" in processor2.__class__.__name__
+    renderer2 = cfg2["formatters"]["default"]["processors"][-1]
+    assert "JSONRenderer" in renderer2.__class__.__name__
 
     setup_logging()
     assert hasattr(structlog, "get_logger")

--- a/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
+++ b/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
@@ -5,6 +5,8 @@ Ensures the shared processor chain includes all required processors
 in the correct order for both dev and production modes.
 """
 
+import json
+import logging
 from unittest.mock import patch
 
 import structlog
@@ -186,3 +188,101 @@ class TestProcessorOrdering:
         assert stack_idx < exc_idx, "StackInfoRenderer must come before format_exc_info"
         assert exc_idx < pos_idx, "format_exc_info should come before PositionalArgumentsFormatter (convention)"
         assert pos_idx < unicode_idx, "PositionalArgumentsFormatter must come before UnicodeDecoder"
+
+
+class TestRuntimeOutput:
+    """End-to-end tests that exercise the full processor pipeline and verify
+    actual rendered output, not just processor chain configuration."""
+
+    def test_production_json_contains_traceback(self) -> None:
+        """Regression test for #295: JSONRenderer must include the full
+        traceback text in the rendered output, not just 'exc_info: true'."""
+        config = _get_config(env_mode="PRODUCTION")
+        formatter = structlog.stdlib.ProcessorFormatter(
+            processors=config["formatters"]["default"]["processors"],
+            foreign_pre_chain=config["formatters"]["default"]["foreign_pre_chain"],
+        )
+
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+
+        test_logger = logging.getLogger("test.runtime.production")
+        test_logger.handlers = [handler]
+        test_logger.setLevel(logging.DEBUG)
+        test_logger.propagate = False
+
+        # Capture the formatted output via the handler
+        records: list[str] = []
+        original_emit = handler.emit
+
+        def capturing_emit(record: logging.LogRecord) -> None:
+            records.append(formatter.format(record))
+
+        handler.emit = capturing_emit  # type: ignore[assignment]
+
+        try:
+            raise ValueError("test error for regression #295")
+        except ValueError:
+            test_logger.exception("Something failed")
+
+        handler.emit = original_emit  # type: ignore[assignment]
+
+        assert len(records) == 1
+        parsed = json.loads(records[0])
+        assert "exception" in parsed, "JSON output must contain 'exception' field"
+        assert "Traceback" in parsed["exception"]
+        assert "ValueError" in parsed["exception"]
+        assert "test error for regression #295" in parsed["exception"]
+
+    def test_production_json_contains_context_vars(self) -> None:
+        """merge_contextvars must propagate bound context into JSON output."""
+        config = _get_config(env_mode="PRODUCTION")
+
+        # Configure structlog with the production pipeline
+        structlog.configure(
+            processors=[
+                structlog.stdlib.filter_by_level,
+                *config["formatters"]["default"]["foreign_pre_chain"],
+                structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+            ],
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            wrapper_class=structlog.stdlib.BoundLogger,
+            cache_logger_on_first_use=False,
+        )
+
+        formatter = structlog.stdlib.ProcessorFormatter(
+            processors=config["formatters"]["default"]["processors"],
+            foreign_pre_chain=config["formatters"]["default"]["foreign_pre_chain"],
+        )
+
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+
+        # Attach to the underlying stdlib logger that structlog will use
+        stdlib_logger = logging.getLogger("test.runtime.contextvars")
+        stdlib_logger.handlers = [handler]
+        stdlib_logger.setLevel(logging.DEBUG)
+        stdlib_logger.propagate = False
+
+        records: list[str] = []
+        original_emit = handler.emit
+
+        def capturing_emit(record: logging.LogRecord) -> None:
+            records.append(formatter.format(record))
+
+        handler.emit = capturing_emit  # type: ignore[assignment]
+
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(request_id="test-req-123", user_id="alice")
+
+        logger = structlog.stdlib.get_logger("test.runtime.contextvars")
+        logger.info("request processed", status_code=200)
+
+        structlog.contextvars.clear_contextvars()
+        handler.emit = original_emit  # type: ignore[assignment]
+
+        assert len(records) == 1
+        parsed = json.loads(records[0])
+        assert parsed["request_id"] == "test-req-123"
+        assert parsed["user_id"] == "alice"
+        assert parsed["status_code"] == 200

--- a/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
+++ b/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
@@ -7,15 +7,21 @@ in the correct order for both dev and production modes.
 
 import json
 import logging
+from collections.abc import Iterator
 from unittest.mock import patch
 
+import pytest
 import structlog
 
 from aegra_api.utils.setup_logging import get_logging_config
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
 
 def _get_config(*, env_mode: str, log_level: str = "INFO") -> dict:
-    """Helper to get logging config with mocked settings."""
+    """Get logging config with mocked settings."""
     with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
         mock_settings.app.ENV_MODE = env_mode
         mock_settings.app.LOG_LEVEL = log_level
@@ -27,20 +33,42 @@ def _get_pre_chain(config: dict) -> list:
     return config["formatters"]["default"]["foreign_pre_chain"]
 
 
+def _make_capturing_logger(config: dict, name: str) -> tuple[logging.Logger, list[str]]:
+    """Create a stdlib logger that captures formatted output into a list."""
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processors=config["formatters"]["default"]["processors"],
+        foreign_pre_chain=config["formatters"]["default"]["foreign_pre_chain"],
+    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    records: list[str] = []
+    handler.emit = lambda record: records.append(formatter.format(record))  # type: ignore[assignment]
+
+    logger = logging.getLogger(name)
+    logger.handlers = [handler]
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    return logger, records
+
+
+# ---------------------------------------------------------------------------
+# Production mode (JSONRenderer)
+# ---------------------------------------------------------------------------
+
+
 class TestProcessorChainProduction:
-    """Tests for production mode (JSONRenderer) processor chain."""
+    """Tests for production mode processor chain."""
 
     def test_format_exc_info_present(self) -> None:
-        """format_exc_info must be in shared_processors so JSONRenderer
-        includes tracebacks in production log output (#295)."""
+        """format_exc_info must be present so JSONRenderer includes
+        tracebacks in production log output (#295)."""
         pre_chain = _get_pre_chain(_get_config(env_mode="PRODUCTION"))
         assert structlog.processors.format_exc_info in pre_chain
 
     def test_uses_json_renderer(self) -> None:
-        """Production mode must use JSONRenderer."""
         config = _get_config(env_mode="PRODUCTION")
         processors = config["formatters"]["default"]["processors"]
-        # Last processor is the renderer
         assert isinstance(processors[-1], structlog.processors.JSONRenderer)
 
     def test_format_exc_info_before_positional_args(self) -> None:
@@ -59,81 +87,72 @@ class TestProcessorChainProduction:
         assert exc_info_idx < pos_args_idx
 
 
+# ---------------------------------------------------------------------------
+# Dev mode (ConsoleRenderer)
+# ---------------------------------------------------------------------------
+
+
 class TestProcessorChainDev:
-    """Tests for LOCAL/DEVELOPMENT mode (ConsoleRenderer) processor chain."""
+    """Tests for LOCAL/DEVELOPMENT mode processor chain."""
 
-    def test_format_exc_info_absent(self) -> None:
+    @pytest.mark.parametrize("env_mode", ["LOCAL", "DEVELOPMENT"])
+    def test_format_exc_info_absent(self, env_mode: str) -> None:
         """format_exc_info must NOT be in dev mode so ConsoleRenderer's
-        RichTracebackFormatter can render pretty exceptions."""
-        pre_chain = _get_pre_chain(_get_config(env_mode="LOCAL"))
+        exception_formatter can render pretty tracebacks."""
+        pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
         assert structlog.processors.format_exc_info not in pre_chain
 
-    def test_format_exc_info_absent_development(self) -> None:
-        """Same check for DEVELOPMENT mode."""
-        pre_chain = _get_pre_chain(_get_config(env_mode="DEVELOPMENT"))
-        assert structlog.processors.format_exc_info not in pre_chain
-
-    def test_uses_console_renderer(self) -> None:
-        """LOCAL mode must use ConsoleRenderer."""
-        config = _get_config(env_mode="LOCAL")
+    @pytest.mark.parametrize("env_mode", ["LOCAL", "DEVELOPMENT"])
+    def test_uses_console_renderer(self, env_mode: str) -> None:
+        config = _get_config(env_mode=env_mode)
         processors = config["formatters"]["default"]["processors"]
         assert isinstance(processors[-1], structlog.dev.ConsoleRenderer)
 
 
-class TestSharedProcessorsCommon:
-    """Tests for processors that must be present in ALL modes."""
+# ---------------------------------------------------------------------------
+# Shared processors (present in ALL modes)
+# ---------------------------------------------------------------------------
 
-    def test_merge_contextvars_is_first(self) -> None:
+
+class TestSharedProcessorsCommon:
+    """Tests for processors that must be present in all modes."""
+
+    @pytest.mark.parametrize("env_mode", ["LOCAL", "PRODUCTION"])
+    def test_merge_contextvars_is_first(self, env_mode: str) -> None:
         """merge_contextvars must be the first processor so request-scoped
         context (request_id, run_id, etc.) is available to all others."""
-        for env_mode in ("LOCAL", "PRODUCTION"):
-            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
-            assert pre_chain[0] is structlog.contextvars.merge_contextvars, (
-                f"merge_contextvars must be first in {env_mode} mode"
-            )
+        pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+        assert pre_chain[0] is structlog.contextvars.merge_contextvars
 
-    def test_stack_info_renderer_present(self) -> None:
-        """StackInfoRenderer must be present so stack_info=True in log
-        calls actually renders the stack trace."""
-        for env_mode in ("LOCAL", "PRODUCTION"):
-            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
-            assert any(isinstance(p, structlog.processors.StackInfoRenderer) for p in pre_chain), (
-                f"StackInfoRenderer missing in {env_mode} mode"
-            )
+    @pytest.mark.parametrize("env_mode", ["LOCAL", "PRODUCTION"])
+    def test_stack_info_renderer_present(self, env_mode: str) -> None:
+        pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+        assert any(isinstance(p, structlog.processors.StackInfoRenderer) for p in pre_chain)
 
-    def test_unicode_decoder_present(self) -> None:
-        """UnicodeDecoder must be present to handle byte strings from
-        third-party libraries."""
-        for env_mode in ("LOCAL", "PRODUCTION"):
-            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
-            assert any(isinstance(p, structlog.processors.UnicodeDecoder) for p in pre_chain), (
-                f"UnicodeDecoder missing in {env_mode} mode"
-            )
+    @pytest.mark.parametrize("env_mode", ["LOCAL", "PRODUCTION"])
+    def test_unicode_decoder_present(self, env_mode: str) -> None:
+        pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+        assert any(isinstance(p, structlog.processors.UnicodeDecoder) for p in pre_chain)
 
-    def test_extra_adder_present(self) -> None:
-        """ExtraAdder must be present so stdlib extra={} kwargs are
-        captured in structured output."""
-        for env_mode in ("LOCAL", "PRODUCTION"):
-            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
-            assert any(isinstance(p, structlog.stdlib.ExtraAdder) for p in pre_chain), (
-                f"ExtraAdder missing in {env_mode} mode"
-            )
+    @pytest.mark.parametrize("env_mode", ["LOCAL", "PRODUCTION"])
+    def test_extra_adder_present(self, env_mode: str) -> None:
+        pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+        assert any(isinstance(p, structlog.stdlib.ExtraAdder) for p in pre_chain)
 
-    def test_timestamper_present(self) -> None:
-        """TimeStamper must be present for ISO timestamps."""
-        for env_mode in ("LOCAL", "PRODUCTION"):
-            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
-            assert any(isinstance(p, structlog.processors.TimeStamper) for p in pre_chain), (
-                f"TimeStamper missing in {env_mode} mode"
-            )
+    @pytest.mark.parametrize("env_mode", ["LOCAL", "PRODUCTION"])
+    def test_timestamper_present(self, env_mode: str) -> None:
+        pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+        assert any(isinstance(p, structlog.processors.TimeStamper) for p in pre_chain)
 
-    def test_callsite_parameter_adder_present(self) -> None:
-        """CallsiteParameterAdder must be present for filename, func, lineno."""
-        for env_mode in ("LOCAL", "PRODUCTION"):
-            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
-            assert any(isinstance(p, structlog.processors.CallsiteParameterAdder) for p in pre_chain), (
-                f"CallsiteParameterAdder missing in {env_mode} mode"
-            )
+    @pytest.mark.parametrize("env_mode", ["LOCAL", "PRODUCTION"])
+    def test_callsite_parameter_adder_present(self, env_mode: str) -> None:
+        pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+        assert any(isinstance(p, structlog.processors.CallsiteParameterAdder) for p in pre_chain)
+
+
+# ---------------------------------------------------------------------------
+# ProcessorFormatter configuration
+# ---------------------------------------------------------------------------
 
 
 class TestProcessorFormatterConfig:
@@ -144,19 +163,22 @@ class TestProcessorFormatterConfig:
         not the legacy 'processor' (singular) parameter."""
         config = _get_config(env_mode="PRODUCTION")
         formatter_config = config["formatters"]["default"]
-        assert "processors" in formatter_config, "Should use 'processors' (plural), not legacy 'processor' (singular)"
+        assert "processors" in formatter_config
         assert "processor" not in formatter_config
 
     def test_remove_processors_meta_before_renderer(self) -> None:
-        """remove_processors_meta must come before the renderer."""
         config = _get_config(env_mode="PRODUCTION")
         processors = config["formatters"]["default"]["processors"]
         assert processors[0] is structlog.stdlib.ProcessorFormatter.remove_processors_meta
 
     def test_disable_existing_loggers_false(self) -> None:
-        """disable_existing_loggers must be False to keep library loggers."""
         config = _get_config(env_mode="PRODUCTION")
         assert config["disable_existing_loggers"] is False
+
+
+# ---------------------------------------------------------------------------
+# Processor ordering
+# ---------------------------------------------------------------------------
 
 
 class TestProcessorOrdering:
@@ -166,8 +188,6 @@ class TestProcessorOrdering:
         """Verify the complete processor ordering for production mode."""
         pre_chain = _get_pre_chain(_get_config(env_mode="PRODUCTION"))
 
-        # Build a map of processor to index. Handles both plain functions
-        # (identity check) and class instances (isinstance check).
         def find_idx(target: type | object) -> int:
             for i, p in enumerate(pre_chain):
                 if p is target:
@@ -183,49 +203,38 @@ class TestProcessorOrdering:
         pos_idx = find_idx(structlog.stdlib.PositionalArgumentsFormatter)
         unicode_idx = find_idx(structlog.processors.UnicodeDecoder)
 
-        # merge_contextvars < enrichment < stack_info < format_exc_info < pos_args < unicode
         assert merge_idx < level_idx, "merge_contextvars must come before enrichment"
         assert stack_idx < exc_idx, "StackInfoRenderer must come before format_exc_info"
         assert exc_idx < pos_idx, "format_exc_info should come before PositionalArgumentsFormatter (convention)"
         assert pos_idx < unicode_idx, "PositionalArgumentsFormatter must come before UnicodeDecoder"
 
 
+# ---------------------------------------------------------------------------
+# Runtime integration (end-to-end through the real pipeline)
+# ---------------------------------------------------------------------------
+
+
 class TestRuntimeOutput:
     """End-to-end tests that exercise the full processor pipeline and verify
     actual rendered output, not just processor chain configuration."""
 
+    @pytest.fixture(autouse=True)
+    def _reset_structlog(self) -> Iterator[None]:
+        """Restore structlog config after tests that call structlog.configure."""
+        old_config = structlog.get_config()
+        yield
+        structlog.configure(**old_config)
+
     def test_production_json_contains_traceback(self) -> None:
         """Regression test for #295: JSONRenderer must include the full
-        traceback text in the rendered output, not just 'exc_info: true'."""
+        traceback text, not just 'exc_info: true'."""
         config = _get_config(env_mode="PRODUCTION")
-        formatter = structlog.stdlib.ProcessorFormatter(
-            processors=config["formatters"]["default"]["processors"],
-            foreign_pre_chain=config["formatters"]["default"]["foreign_pre_chain"],
-        )
-
-        handler = logging.StreamHandler()
-        handler.setFormatter(formatter)
-
-        test_logger = logging.getLogger("test.runtime.production")
-        test_logger.handlers = [handler]
-        test_logger.setLevel(logging.DEBUG)
-        test_logger.propagate = False
-
-        # Capture the formatted output via the handler
-        records: list[str] = []
-        original_emit = handler.emit
-
-        def capturing_emit(record: logging.LogRecord) -> None:
-            records.append(formatter.format(record))
-
-        handler.emit = capturing_emit  # type: ignore[assignment]
+        logger, records = _make_capturing_logger(config, "test.runtime.traceback")
 
         try:
             raise ValueError("test error for regression #295")
         except ValueError:
-            test_logger.exception("Something failed")
-
-        handler.emit = original_emit  # type: ignore[assignment]
+            logger.exception("Something failed")
 
         assert len(records) == 1
         parsed = json.loads(records[0])
@@ -238,7 +247,6 @@ class TestRuntimeOutput:
         """merge_contextvars must propagate bound context into JSON output."""
         config = _get_config(env_mode="PRODUCTION")
 
-        # Configure structlog with the production pipeline
         structlog.configure(
             processors=[
                 structlog.stdlib.filter_by_level,
@@ -250,27 +258,7 @@ class TestRuntimeOutput:
             cache_logger_on_first_use=False,
         )
 
-        formatter = structlog.stdlib.ProcessorFormatter(
-            processors=config["formatters"]["default"]["processors"],
-            foreign_pre_chain=config["formatters"]["default"]["foreign_pre_chain"],
-        )
-
-        handler = logging.StreamHandler()
-        handler.setFormatter(formatter)
-
-        # Attach to the underlying stdlib logger that structlog will use
-        stdlib_logger = logging.getLogger("test.runtime.contextvars")
-        stdlib_logger.handlers = [handler]
-        stdlib_logger.setLevel(logging.DEBUG)
-        stdlib_logger.propagate = False
-
-        records: list[str] = []
-        original_emit = handler.emit
-
-        def capturing_emit(record: logging.LogRecord) -> None:
-            records.append(formatter.format(record))
-
-        handler.emit = capturing_emit  # type: ignore[assignment]
+        _, records = _make_capturing_logger(config, "test.runtime.contextvars")
 
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(request_id="test-req-123", user_id="alice")
@@ -279,7 +267,6 @@ class TestRuntimeOutput:
         logger.info("request processed", status_code=200)
 
         structlog.contextvars.clear_contextvars()
-        handler.emit = original_emit  # type: ignore[assignment]
 
         assert len(records) == 1
         parsed = json.loads(records[0])

--- a/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
+++ b/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
@@ -1,8 +1,8 @@
 """Tests for aegra_api.utils.setup_logging.
 
-Regression test for #295: structlog JSONRenderer was dropping exception
-tracebacks in production mode because format_exc_info was missing from
-the shared processor chain.
+Regression tests for #295 and the full logging processor chain audit.
+Ensures the shared processor chain includes all required processors
+in the correct order for both dev and production modes.
 """
 
 from unittest.mock import patch
@@ -12,65 +12,38 @@ import structlog
 from aegra_api.utils.setup_logging import get_logging_config
 
 
-class TestGetLoggingConfig:
-    """Tests for the get_logging_config function."""
+def _get_config(*, env_mode: str, log_level: str = "INFO") -> dict:
+    """Helper to get logging config with mocked settings."""
+    with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
+        mock_settings.app.ENV_MODE = env_mode
+        mock_settings.app.LOG_LEVEL = log_level
+        return get_logging_config()
 
-    def test_shared_processors_include_format_exc_info_production(self) -> None:
+
+def _get_pre_chain(config: dict) -> list:
+    """Extract the foreign_pre_chain from a logging config."""
+    return config["formatters"]["default"]["foreign_pre_chain"]
+
+
+class TestProcessorChainProduction:
+    """Tests for production mode (JSONRenderer) processor chain."""
+
+    def test_format_exc_info_present(self) -> None:
         """format_exc_info must be in shared_processors so JSONRenderer
         includes tracebacks in production log output (#295)."""
-        with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
-            mock_settings.app.ENV_MODE = "PRODUCTION"
-            mock_settings.app.LOG_LEVEL = "INFO"
-
-            config = get_logging_config()
-
-        pre_chain = config["formatters"]["default"]["foreign_pre_chain"]
+        pre_chain = _get_pre_chain(_get_config(env_mode="PRODUCTION"))
         assert structlog.processors.format_exc_info in pre_chain
 
-    def test_shared_processors_include_format_exc_info_local(self) -> None:
-        """format_exc_info should also be present in LOCAL mode for
-        consistency, even though ConsoleRenderer handles it internally."""
-        with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
-            mock_settings.app.ENV_MODE = "LOCAL"
-            mock_settings.app.LOG_LEVEL = "DEBUG"
+    def test_uses_json_renderer(self) -> None:
+        """Production mode must use JSONRenderer."""
+        config = _get_config(env_mode="PRODUCTION")
+        processors = config["formatters"]["default"]["processors"]
+        # Last processor is the renderer
+        assert isinstance(processors[-1], structlog.processors.JSONRenderer)
 
-            config = get_logging_config()
-
-        pre_chain = config["formatters"]["default"]["foreign_pre_chain"]
-        assert structlog.processors.format_exc_info in pre_chain
-
-    def test_production_uses_json_renderer(self) -> None:
-        """Production mode must use JSONRenderer, not ConsoleRenderer."""
-        with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
-            mock_settings.app.ENV_MODE = "PRODUCTION"
-            mock_settings.app.LOG_LEVEL = "INFO"
-
-            config = get_logging_config()
-
-        renderer = config["formatters"]["default"]["processor"]
-        assert isinstance(renderer, structlog.processors.JSONRenderer)
-
-    def test_local_uses_console_renderer(self) -> None:
-        """LOCAL mode must use ConsoleRenderer."""
-        with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
-            mock_settings.app.ENV_MODE = "LOCAL"
-            mock_settings.app.LOG_LEVEL = "DEBUG"
-
-            config = get_logging_config()
-
-        renderer = config["formatters"]["default"]["processor"]
-        assert isinstance(renderer, structlog.dev.ConsoleRenderer)
-
-    def test_format_exc_info_before_positional_args_formatter(self) -> None:
-        """format_exc_info must run before PositionalArgumentsFormatter
-        so that exception text is available when positional args are formatted."""
-        with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
-            mock_settings.app.ENV_MODE = "PRODUCTION"
-            mock_settings.app.LOG_LEVEL = "INFO"
-
-            config = get_logging_config()
-
-        pre_chain = config["formatters"]["default"]["foreign_pre_chain"]
+    def test_format_exc_info_before_positional_args(self) -> None:
+        """format_exc_info must run before PositionalArgumentsFormatter."""
+        pre_chain = _get_pre_chain(_get_config(env_mode="PRODUCTION"))
 
         exc_info_idx = pre_chain.index(structlog.processors.format_exc_info)
         pos_args_idx = next(
@@ -78,6 +51,142 @@ class TestGetLoggingConfig:
             for i, p in enumerate(pre_chain)
             if isinstance(p, structlog.stdlib.PositionalArgumentsFormatter)
         )
-        assert exc_info_idx < pos_args_idx, (
-            "format_exc_info must come before PositionalArgumentsFormatter"
+        assert exc_info_idx < pos_args_idx
+
+
+class TestProcessorChainDev:
+    """Tests for LOCAL/DEVELOPMENT mode (ConsoleRenderer) processor chain."""
+
+    def test_format_exc_info_absent(self) -> None:
+        """format_exc_info must NOT be in dev mode so ConsoleRenderer's
+        RichTracebackFormatter can render pretty exceptions."""
+        pre_chain = _get_pre_chain(_get_config(env_mode="LOCAL"))
+        assert structlog.processors.format_exc_info not in pre_chain
+
+    def test_format_exc_info_absent_development(self) -> None:
+        """Same check for DEVELOPMENT mode."""
+        pre_chain = _get_pre_chain(_get_config(env_mode="DEVELOPMENT"))
+        assert structlog.processors.format_exc_info not in pre_chain
+
+    def test_uses_console_renderer(self) -> None:
+        """LOCAL mode must use ConsoleRenderer."""
+        config = _get_config(env_mode="LOCAL")
+        processors = config["formatters"]["default"]["processors"]
+        assert isinstance(processors[-1], structlog.dev.ConsoleRenderer)
+
+
+class TestSharedProcessorsCommon:
+    """Tests for processors that must be present in ALL modes."""
+
+    def test_merge_contextvars_is_first(self) -> None:
+        """merge_contextvars must be the first processor so request-scoped
+        context (request_id, run_id, etc.) is available to all others."""
+        for env_mode in ("LOCAL", "PRODUCTION"):
+            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+            assert pre_chain[0] is structlog.contextvars.merge_contextvars, (
+                f"merge_contextvars must be first in {env_mode} mode"
+            )
+
+    def test_stack_info_renderer_present(self) -> None:
+        """StackInfoRenderer must be present so stack_info=True in log
+        calls actually renders the stack trace."""
+        for env_mode in ("LOCAL", "PRODUCTION"):
+            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+            assert any(
+                isinstance(p, structlog.processors.StackInfoRenderer)
+                for p in pre_chain
+            ), f"StackInfoRenderer missing in {env_mode} mode"
+
+    def test_unicode_decoder_present(self) -> None:
+        """UnicodeDecoder must be present to handle byte strings from
+        third-party libraries."""
+        for env_mode in ("LOCAL", "PRODUCTION"):
+            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+            assert any(
+                isinstance(p, structlog.processors.UnicodeDecoder)
+                for p in pre_chain
+            ), f"UnicodeDecoder missing in {env_mode} mode"
+
+    def test_extra_adder_present(self) -> None:
+        """ExtraAdder must be present so stdlib extra={} kwargs are
+        captured in structured output."""
+        for env_mode in ("LOCAL", "PRODUCTION"):
+            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+            assert any(
+                isinstance(p, structlog.stdlib.ExtraAdder)
+                for p in pre_chain
+            ), f"ExtraAdder missing in {env_mode} mode"
+
+    def test_timestamper_present(self) -> None:
+        """TimeStamper must be present for ISO timestamps."""
+        for env_mode in ("LOCAL", "PRODUCTION"):
+            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+            assert any(
+                isinstance(p, structlog.processors.TimeStamper)
+                for p in pre_chain
+            ), f"TimeStamper missing in {env_mode} mode"
+
+    def test_callsite_parameter_adder_present(self) -> None:
+        """CallsiteParameterAdder must be present for filename, func, lineno."""
+        for env_mode in ("LOCAL", "PRODUCTION"):
+            pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
+            assert any(
+                isinstance(p, structlog.processors.CallsiteParameterAdder)
+                for p in pre_chain
+            ), f"CallsiteParameterAdder missing in {env_mode} mode"
+
+
+class TestProcessorFormatterConfig:
+    """Tests for the ProcessorFormatter configuration."""
+
+    def test_uses_processors_list_not_singular(self) -> None:
+        """Must use 'processors' (plural) with remove_processors_meta,
+        not the legacy 'processor' (singular) parameter."""
+        config = _get_config(env_mode="PRODUCTION")
+        formatter_config = config["formatters"]["default"]
+        assert "processors" in formatter_config, (
+            "Should use 'processors' (plural), not legacy 'processor' (singular)"
         )
+        assert "processor" not in formatter_config
+
+    def test_remove_processors_meta_before_renderer(self) -> None:
+        """remove_processors_meta must come before the renderer."""
+        config = _get_config(env_mode="PRODUCTION")
+        processors = config["formatters"]["default"]["processors"]
+        assert processors[0] is structlog.stdlib.ProcessorFormatter.remove_processors_meta
+
+    def test_disable_existing_loggers_false(self) -> None:
+        """disable_existing_loggers must be False to keep library loggers."""
+        config = _get_config(env_mode="PRODUCTION")
+        assert config["disable_existing_loggers"] is False
+
+
+class TestProcessorOrdering:
+    """Tests for the correct ordering of all processors."""
+
+    def test_full_production_order(self) -> None:
+        """Verify the complete processor ordering for production mode."""
+        pre_chain = _get_pre_chain(_get_config(env_mode="PRODUCTION"))
+
+        # Build a map of processor to index. Handles both plain functions
+        # (identity check) and class instances (isinstance check).
+        def find_idx(target: type | object) -> int:
+            for i, p in enumerate(pre_chain):
+                if p is target:
+                    return i
+                if isinstance(target, type) and isinstance(p, target):
+                    return i
+            raise AssertionError(f"{target} not found in pre_chain")
+
+        merge_idx = find_idx(structlog.contextvars.merge_contextvars)
+        level_idx = find_idx(structlog.stdlib.add_log_level)
+        stack_idx = find_idx(structlog.processors.StackInfoRenderer)
+        exc_idx = pre_chain.index(structlog.processors.format_exc_info)
+        pos_idx = find_idx(structlog.stdlib.PositionalArgumentsFormatter)
+        unicode_idx = find_idx(structlog.processors.UnicodeDecoder)
+
+        # merge_contextvars < enrichment < stack_info < format_exc_info < pos_args < unicode
+        assert merge_idx < level_idx, "merge_contextvars must come before enrichment"
+        assert stack_idx < exc_idx, "StackInfoRenderer must come before format_exc_info"
+        assert exc_idx < pos_idx, "format_exc_info must come before PositionalArgumentsFormatter"
+        assert pos_idx < unicode_idx, "PositionalArgumentsFormatter must come before UnicodeDecoder"

--- a/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
+++ b/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
@@ -47,9 +47,7 @@ class TestProcessorChainProduction:
 
         exc_info_idx = pre_chain.index(structlog.processors.format_exc_info)
         pos_args_idx = next(
-            i
-            for i, p in enumerate(pre_chain)
-            if isinstance(p, structlog.stdlib.PositionalArgumentsFormatter)
+            i for i, p in enumerate(pre_chain) if isinstance(p, structlog.stdlib.PositionalArgumentsFormatter)
         )
         assert exc_info_idx < pos_args_idx
 
@@ -92,48 +90,43 @@ class TestSharedProcessorsCommon:
         calls actually renders the stack trace."""
         for env_mode in ("LOCAL", "PRODUCTION"):
             pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
-            assert any(
-                isinstance(p, structlog.processors.StackInfoRenderer)
-                for p in pre_chain
-            ), f"StackInfoRenderer missing in {env_mode} mode"
+            assert any(isinstance(p, structlog.processors.StackInfoRenderer) for p in pre_chain), (
+                f"StackInfoRenderer missing in {env_mode} mode"
+            )
 
     def test_unicode_decoder_present(self) -> None:
         """UnicodeDecoder must be present to handle byte strings from
         third-party libraries."""
         for env_mode in ("LOCAL", "PRODUCTION"):
             pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
-            assert any(
-                isinstance(p, structlog.processors.UnicodeDecoder)
-                for p in pre_chain
-            ), f"UnicodeDecoder missing in {env_mode} mode"
+            assert any(isinstance(p, structlog.processors.UnicodeDecoder) for p in pre_chain), (
+                f"UnicodeDecoder missing in {env_mode} mode"
+            )
 
     def test_extra_adder_present(self) -> None:
         """ExtraAdder must be present so stdlib extra={} kwargs are
         captured in structured output."""
         for env_mode in ("LOCAL", "PRODUCTION"):
             pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
-            assert any(
-                isinstance(p, structlog.stdlib.ExtraAdder)
-                for p in pre_chain
-            ), f"ExtraAdder missing in {env_mode} mode"
+            assert any(isinstance(p, structlog.stdlib.ExtraAdder) for p in pre_chain), (
+                f"ExtraAdder missing in {env_mode} mode"
+            )
 
     def test_timestamper_present(self) -> None:
         """TimeStamper must be present for ISO timestamps."""
         for env_mode in ("LOCAL", "PRODUCTION"):
             pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
-            assert any(
-                isinstance(p, structlog.processors.TimeStamper)
-                for p in pre_chain
-            ), f"TimeStamper missing in {env_mode} mode"
+            assert any(isinstance(p, structlog.processors.TimeStamper) for p in pre_chain), (
+                f"TimeStamper missing in {env_mode} mode"
+            )
 
     def test_callsite_parameter_adder_present(self) -> None:
         """CallsiteParameterAdder must be present for filename, func, lineno."""
         for env_mode in ("LOCAL", "PRODUCTION"):
             pre_chain = _get_pre_chain(_get_config(env_mode=env_mode))
-            assert any(
-                isinstance(p, structlog.processors.CallsiteParameterAdder)
-                for p in pre_chain
-            ), f"CallsiteParameterAdder missing in {env_mode} mode"
+            assert any(isinstance(p, structlog.processors.CallsiteParameterAdder) for p in pre_chain), (
+                f"CallsiteParameterAdder missing in {env_mode} mode"
+            )
 
 
 class TestProcessorFormatterConfig:
@@ -144,9 +137,7 @@ class TestProcessorFormatterConfig:
         not the legacy 'processor' (singular) parameter."""
         config = _get_config(env_mode="PRODUCTION")
         formatter_config = config["formatters"]["default"]
-        assert "processors" in formatter_config, (
-            "Should use 'processors' (plural), not legacy 'processor' (singular)"
-        )
+        assert "processors" in formatter_config, "Should use 'processors' (plural), not legacy 'processor' (singular)"
         assert "processor" not in formatter_config
 
     def test_remove_processors_meta_before_renderer(self) -> None:

--- a/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
+++ b/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
@@ -1,0 +1,83 @@
+"""Tests for aegra_api.utils.setup_logging.
+
+Regression test for #295: structlog JSONRenderer was dropping exception
+tracebacks in production mode because format_exc_info was missing from
+the shared processor chain.
+"""
+
+from unittest.mock import patch
+
+import structlog
+
+from aegra_api.utils.setup_logging import get_logging_config
+
+
+class TestGetLoggingConfig:
+    """Tests for the get_logging_config function."""
+
+    def test_shared_processors_include_format_exc_info_production(self) -> None:
+        """format_exc_info must be in shared_processors so JSONRenderer
+        includes tracebacks in production log output (#295)."""
+        with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
+            mock_settings.app.ENV_MODE = "PRODUCTION"
+            mock_settings.app.LOG_LEVEL = "INFO"
+
+            config = get_logging_config()
+
+        pre_chain = config["formatters"]["default"]["foreign_pre_chain"]
+        assert structlog.processors.format_exc_info in pre_chain
+
+    def test_shared_processors_include_format_exc_info_local(self) -> None:
+        """format_exc_info should also be present in LOCAL mode for
+        consistency, even though ConsoleRenderer handles it internally."""
+        with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
+            mock_settings.app.ENV_MODE = "LOCAL"
+            mock_settings.app.LOG_LEVEL = "DEBUG"
+
+            config = get_logging_config()
+
+        pre_chain = config["formatters"]["default"]["foreign_pre_chain"]
+        assert structlog.processors.format_exc_info in pre_chain
+
+    def test_production_uses_json_renderer(self) -> None:
+        """Production mode must use JSONRenderer, not ConsoleRenderer."""
+        with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
+            mock_settings.app.ENV_MODE = "PRODUCTION"
+            mock_settings.app.LOG_LEVEL = "INFO"
+
+            config = get_logging_config()
+
+        renderer = config["formatters"]["default"]["processor"]
+        assert isinstance(renderer, structlog.processors.JSONRenderer)
+
+    def test_local_uses_console_renderer(self) -> None:
+        """LOCAL mode must use ConsoleRenderer."""
+        with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
+            mock_settings.app.ENV_MODE = "LOCAL"
+            mock_settings.app.LOG_LEVEL = "DEBUG"
+
+            config = get_logging_config()
+
+        renderer = config["formatters"]["default"]["processor"]
+        assert isinstance(renderer, structlog.dev.ConsoleRenderer)
+
+    def test_format_exc_info_before_positional_args_formatter(self) -> None:
+        """format_exc_info must run before PositionalArgumentsFormatter
+        so that exception text is available when positional args are formatted."""
+        with patch("aegra_api.utils.setup_logging.settings") as mock_settings:
+            mock_settings.app.ENV_MODE = "PRODUCTION"
+            mock_settings.app.LOG_LEVEL = "INFO"
+
+            config = get_logging_config()
+
+        pre_chain = config["formatters"]["default"]["foreign_pre_chain"]
+
+        exc_info_idx = pre_chain.index(structlog.processors.format_exc_info)
+        pos_args_idx = next(
+            i
+            for i, p in enumerate(pre_chain)
+            if isinstance(p, structlog.stdlib.PositionalArgumentsFormatter)
+        )
+        assert exc_info_idx < pos_args_idx, (
+            "format_exc_info must come before PositionalArgumentsFormatter"
+        )

--- a/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
+++ b/libs/aegra-api/tests/unit/test_utils/test_setup_logging.py
@@ -42,7 +42,12 @@ class TestProcessorChainProduction:
         assert isinstance(processors[-1], structlog.processors.JSONRenderer)
 
     def test_format_exc_info_before_positional_args(self) -> None:
-        """format_exc_info must run before PositionalArgumentsFormatter."""
+        """format_exc_info should appear before PositionalArgumentsFormatter.
+
+        There is no strict dependency between them (they operate on different
+        event dict keys), but this ordering reflects the intended declaration
+        order in setup_logging.py.
+        """
         pre_chain = _get_pre_chain(_get_config(env_mode="PRODUCTION"))
 
         exc_info_idx = pre_chain.index(structlog.processors.format_exc_info)
@@ -179,5 +184,5 @@ class TestProcessorOrdering:
         # merge_contextvars < enrichment < stack_info < format_exc_info < pos_args < unicode
         assert merge_idx < level_idx, "merge_contextvars must come before enrichment"
         assert stack_idx < exc_idx, "StackInfoRenderer must come before format_exc_info"
-        assert exc_idx < pos_idx, "format_exc_info must come before PositionalArgumentsFormatter"
+        assert exc_idx < pos_idx, "format_exc_info should come before PositionalArgumentsFormatter (convention)"
         assert pos_idx < unicode_idx, "PositionalArgumentsFormatter must come before UnicodeDecoder"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.1"
+version = "0.9.2"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -94,7 +94,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary

Fixes #295.

- Add `structlog.processors.format_exc_info` to the `shared_processors` list in `setup_logging.py`, so `JSONRenderer` includes formatted tracebacks in production log output
- Add regression tests for the logging processor chain configuration
- Bump version to 0.9.2

## Root Cause

`ConsoleRenderer` (LOCAL/DEVELOPMENT mode) handles `exc_info` internally, so tracebacks appear in dev. But `JSONRenderer` (production mode) just serializes whatever keys exist in the event dict. Without `format_exc_info` converting the `exc_info=True` flag into an actual traceback string, production JSON logs get `"exc_info": true` (the raw boolean) instead of the traceback text.

This affected all 25+ `logger.exception()` and `logger.error(..., exc_info=True)` call sites across the codebase.

## Test plan

- [x] 5 new unit tests covering processor chain configuration
- [x] All 849 existing unit tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.9.2 (package and API spec versions updated)

* **Bug Fixes**
  * Improved logging: reordered and enhanced processor pipeline, added context merging, and environment-specific renderers with conditional exception formatting for clearer logs

* **Tests**
  * Added and updated unit tests to validate logging configuration, processor ordering, renderer selection, and exception formatting across environments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes issue #295 where production JSON logs emitted `"exc_info": true` (raw boolean) instead of a formatted traceback string. The root cause was that `structlog.processors.format_exc_info` was missing from the production processor chain, leaving `JSONRenderer` with an unrendered exception tuple it cannot serialize.

- Adds `format_exc_info` to production-only `mode_processors`, placed after `StackInfoRenderer` and before `PositionalArgumentsFormatter`
- Excludes `format_exc_info` from dev mode so `ConsoleRenderer`'s own `exception_formatter` can render pretty tracebacks
- Adds `merge_contextvars` as the first shared processor to propagate request-scoped context (`request_id`, `run_id`) to all downstream processors
- Adds `ExtraAdder`, `StackInfoRenderer`, and `UnicodeDecoder` to fill gaps in the previous pipeline
- Adds a Windows-specific `plain_traceback` fallback in dev mode to avoid `UnicodeEncodeError` from Rich's box-drawing characters on cp1252 consoles
- Bumps both packages from 0.9.1 to 0.9.2 (correct patch bump for a non-breaking bug fix)
- Adds comprehensive processor-chain and runtime integration regression tests

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is correct and well-tested; the only finding is a minor style violation that does not affect runtime behaviour

All findings are P2. The core fix correctly adds format_exc_info to the production processor chain, which directly resolves issue #295. Processor ordering is semantically sound. Tests cover the regression case, processor-chain ordering, and end-to-end JSON output. Version bump is correct for a patch release.

No files require special attention; the type: ignore[assignment] suppression in test_setup_logging.py is the only item to address

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/utils/setup_logging.py | Core fix: adds format_exc_info to production processor chain, merge_contextvars as first processor, and Windows plain_traceback fallback in dev mode — correct and well-documented |
| libs/aegra-api/tests/unit/test_utils/test_setup_logging.py | Comprehensive regression and runtime integration tests for the processor chain; one type: ignore[assignment] suppression should be replaced with a custom handler subclass per CLAUDE.md |
| libs/aegra-api/tests/unit/test_middleware/test_logger_middleware.py | Minor test updates compatible with the new processor chain; checks renderer class names rather than chain internals, making tests resilient to future changes |
| libs/aegra-api/pyproject.toml | Version bumped from 0.9.1 to 0.9.2 — correct patch bump for a non-breaking bug fix |
| libs/aegra-cli/pyproject.toml | Version bumped to 0.9.2 in sync with aegra-api; the aegra-api~=0.9.0 compatible release constraint still covers 0.9.2, so no constraint update is required |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Log Event] --> B[merge_contextvars]
    B --> C[add_log_level]
    C --> D[add_logger_name]
    D --> E[ExtraAdder]
    E --> F[CallsiteParameterAdder]
    F --> G[TimeStamper]
    G --> H[StackInfoRenderer]
    H --> I{Env Mode?}
    I -->|Production| J[format_exc_info]
    I -->|Dev / Local| K[skip]
    J --> L[PositionalArgumentsFormatter]
    K --> L
    L --> M[UnicodeDecoder]
    M --> N[remove_processors_meta]
    N --> O{Final Renderer}
    O -->|Production| P[JSONRenderer]
    O -->|Dev / Local| Q[ConsoleRenderer]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Ftests%2Funit%2Ftest_utils%2Ftest_setup_logging.py%3A36-52%0A**%60type%3A%20ignore%5Bassignment%5D%60%20suppression%20violates%20project%20convention**%0A%0ACLAUDE.md%20prohibits%20%60%23%20type%3A%20ignore%60%20suppressions%20when%20a%20correct%20fix%20exists.%20A%20%60_CapturingHandler%60%20subclass%20eliminates%20the%20suppression%20entirely%20and%20is%20fully%20type-safe%3A%0A%0A%60%60%60python%0Aclass%20_CapturingHandler%28logging.StreamHandler%29%3A%0A%20%20%20%20def%20__init__%28self%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20super%28%29.__init__%28%29%0A%20%20%20%20%20%20%20%20self.captured%3A%20list%5Bstr%5D%20%3D%20%5B%5D%0A%0A%20%20%20%20def%20emit%28self%2C%20record%3A%20logging.LogRecord%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20self.captured.append%28self.format%28record%29%29%0A%0Adef%20_make_capturing_logger%28config%3A%20dict%2C%20name%3A%20str%29%20-%3E%20tuple%5Blogging.Logger%2C%20list%5Bstr%5D%5D%3A%0A%20%20%20%20%22%22%22Create%20a%20stdlib%20logger%20that%20captures%20formatted%20output%20into%20a%20list.%22%22%22%0A%20%20%20%20formatter%20%3D%20structlog.stdlib.ProcessorFormatter%28%0A%20%20%20%20%20%20%20%20processors%3Dconfig%5B%22formatters%22%5D%5B%22default%22%5D%5B%22processors%22%5D%2C%0A%20%20%20%20%20%20%20%20foreign_pre_chain%3Dconfig%5B%22formatters%22%5D%5B%22default%22%5D%5B%22foreign_pre_chain%22%5D%2C%0A%20%20%20%20%29%0A%20%20%20%20handler%20%3D%20_CapturingHandler%28%29%0A%20%20%20%20handler.setFormatter%28formatter%29%0A%0A%20%20%20%20logger%20%3D%20logging.getLogger%28name%29%0A%20%20%20%20logger.handlers%20%3D%20%5Bhandler%5D%0A%20%20%20%20logger.setLevel%28logging.DEBUG%29%0A%20%20%20%20logger.propagate%20%3D%20False%0A%20%20%20%20return%20logger%2C%20handler.captured%0A%60%60%60%0A%0AThis%20does%20not%20change%20any%20test%20behaviour.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D49bdce28-7cb1-4d77-a7a8-6bbbab6aa631%29%29%0A%0A&repo=ibbybuilds%2Faegra"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Ftests%2Funit%2Ftest_utils%2Ftest_setup_logging.py%3A36-52%0A**%60type%3A%20ignore%5Bassignment%5D%60%20suppression%20violates%20project%20convention**%0A%0ACLAUDE.md%20prohibits%20%60%23%20type%3A%20ignore%60%20suppressions%20when%20a%20correct%20fix%20exists.%20A%20%60_CapturingHandler%60%20subclass%20eliminates%20the%20suppression%20entirely%20and%20is%20fully%20type-safe%3A%0A%0A%60%60%60python%0Aclass%20_CapturingHandler%28logging.StreamHandler%29%3A%0A%20%20%20%20def%20__init__%28self%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20super%28%29.__init__%28%29%0A%20%20%20%20%20%20%20%20self.captured%3A%20list%5Bstr%5D%20%3D%20%5B%5D%0A%0A%20%20%20%20def%20emit%28self%2C%20record%3A%20logging.LogRecord%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20self.captured.append%28self.format%28record%29%29%0A%0Adef%20_make_capturing_logger%28config%3A%20dict%2C%20name%3A%20str%29%20-%3E%20tuple%5Blogging.Logger%2C%20list%5Bstr%5D%5D%3A%0A%20%20%20%20%22%22%22Create%20a%20stdlib%20logger%20that%20captures%20formatted%20output%20into%20a%20list.%22%22%22%0A%20%20%20%20formatter%20%3D%20structlog.stdlib.ProcessorFormatter%28%0A%20%20%20%20%20%20%20%20processors%3Dconfig%5B%22formatters%22%5D%5B%22default%22%5D%5B%22processors%22%5D%2C%0A%20%20%20%20%20%20%20%20foreign_pre_chain%3Dconfig%5B%22formatters%22%5D%5B%22default%22%5D%5B%22foreign_pre_chain%22%5D%2C%0A%20%20%20%20%29%0A%20%20%20%20handler%20%3D%20_CapturingHandler%28%29%0A%20%20%20%20handler.setFormatter%28formatter%29%0A%0A%20%20%20%20logger%20%3D%20logging.getLogger%28name%29%0A%20%20%20%20logger.handlers%20%3D%20%5Bhandler%5D%0A%20%20%20%20logger.setLevel%28logging.DEBUG%29%0A%20%20%20%20logger.propagate%20%3D%20False%0A%20%20%20%20return%20logger%2C%20handler.captured%0A%60%60%60%0A%0AThis%20does%20not%20change%20any%20test%20behaviour.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D49bdce28-7cb1-4d77-a7a8-6bbbab6aa631%29%29%0A%0A"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Ftests%2Funit%2Ftest_utils%2Ftest_setup_logging.py%3A36-52%0A**%60type%3A%20ignore%5Bassignment%5D%60%20suppression%20violates%20project%20convention**%0A%0ACLAUDE.md%20prohibits%20%60%23%20type%3A%20ignore%60%20suppressions%20when%20a%20correct%20fix%20exists.%20A%20%60_CapturingHandler%60%20subclass%20eliminates%20the%20suppression%20entirely%20and%20is%20fully%20type-safe%3A%0A%0A%60%60%60python%0Aclass%20_CapturingHandler%28logging.StreamHandler%29%3A%0A%20%20%20%20def%20__init__%28self%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20super%28%29.__init__%28%29%0A%20%20%20%20%20%20%20%20self.captured%3A%20list%5Bstr%5D%20%3D%20%5B%5D%0A%0A%20%20%20%20def%20emit%28self%2C%20record%3A%20logging.LogRecord%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20self.captured.append%28self.format%28record%29%29%0A%0Adef%20_make_capturing_logger%28config%3A%20dict%2C%20name%3A%20str%29%20-%3E%20tuple%5Blogging.Logger%2C%20list%5Bstr%5D%5D%3A%0A%20%20%20%20%22%22%22Create%20a%20stdlib%20logger%20that%20captures%20formatted%20output%20into%20a%20list.%22%22%22%0A%20%20%20%20formatter%20%3D%20structlog.stdlib.ProcessorFormatter%28%0A%20%20%20%20%20%20%20%20processors%3Dconfig%5B%22formatters%22%5D%5B%22default%22%5D%5B%22processors%22%5D%2C%0A%20%20%20%20%20%20%20%20foreign_pre_chain%3Dconfig%5B%22formatters%22%5D%5B%22default%22%5D%5B%22foreign_pre_chain%22%5D%2C%0A%20%20%20%20%29%0A%20%20%20%20handler%20%3D%20_CapturingHandler%28%29%0A%20%20%20%20handler.setFormatter%28formatter%29%0A%0A%20%20%20%20logger%20%3D%20logging.getLogger%28name%29%0A%20%20%20%20logger.handlers%20%3D%20%5Bhandler%5D%0A%20%20%20%20logger.setLevel%28logging.DEBUG%29%0A%20%20%20%20logger.propagate%20%3D%20False%0A%20%20%20%20return%20logger%2C%20handler.captured%0A%60%60%60%0A%0AThis%20does%20not%20change%20any%20test%20behaviour.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D49bdce28-7cb1-4d77-a7a8-6bbbab6aa631%29%29%0A%0A&repo=ibbybuilds%2Faegra"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<sub>Reviews (5): Last reviewed commit: ["refactor: improve code quality of loggin..."](https://github.com/ibbybuilds/aegra/commit/775933771b9c7f6c67edd03b2b7748a2bdcb0f5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27464311)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=49bdce28-7cb1-4d77-a7a8-6bbbab6aa631))

<!-- /greptile_comment -->