### PR TITLE
feat(db): support multi-host DATABASE_URL for native PostgreSQL HA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ AEGRA_CONFIG=aegra.json
 # Option 1: Single connection string (standard for containers/cloud)
 # DATABASE_URL=postgresql://user:password@host:5432/aegra
 #
+# Option 1b: Multi-host for native PostgreSQL HA (failover handled by drivers)
+# DATABASE_URL=postgresql://user:password@primary:5432,standby:5432/aegra?target_session_attrs=read-write
+#
 # Option 2: Individual fields (used when DATABASE_URL is not set)
 POSTGRES_DB=aegra
 POSTGRES_HOST=localhost

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -71,7 +71,8 @@
               "guides/dependencies",
               "guides/observability",
               "guides/deployment",
-              "guides/worker-architecture"
+              "guides/worker-architecture",
+              "guides/high-availability"
             ]
           },
           {

--- a/docs/guides/high-availability.mdx
+++ b/docs/guides/high-availability.mdx
@@ -1,0 +1,66 @@
+---
+title: "High availability"
+description: "Configure Aegra for PostgreSQL high availability with multi-host failover."
+---
+
+Aegra supports native PostgreSQL multi-host connections for automatic failover. When the primary database becomes unreachable, both connection pools (SQLAlchemy and LangGraph) transparently reconnect to a standby host with no application restart required.
+
+This works with any PostgreSQL HA setup that exposes multiple endpoints: Patroni, Stolon, CloudNativePG, Amazon RDS Multi-AZ, Google Cloud SQL HA, or manual streaming replication.
+
+## Configuration
+
+Pass comma-separated hosts in `DATABASE_URL`:
+
+```bash
+DATABASE_URL=postgresql://user:password@primary:5432,standby1:5432,standby2:5432/aegra
+```
+
+Aegra automatically handles the driver split:
+- **psycopg** (LangGraph pool) receives the URL as-is -- libpq natively supports comma-separated hosts
+- **asyncpg** (SQLAlchemy pool) receives a rewritten URL with hosts and ports as query parameters, which is the format asyncpg requires for multi-host connections
+
+No code changes or extra configuration needed.
+
+## target_session_attrs
+
+PostgreSQL's `target_session_attrs` parameter controls which host is selected from the list. Append it as a query parameter:
+
+```bash
+# Connect to any available host (default behavior without the parameter)
+DATABASE_URL=postgresql://user:pass@primary:5432,standby:5432/aegra?target_session_attrs=any
+
+# Only connect to a read-write host (primary)
+DATABASE_URL=postgresql://user:pass@primary:5432,standby:5432/aegra?target_session_attrs=read-write
+
+# Prefer standby for read traffic, fall back to primary
+DATABASE_URL=postgresql://user:pass@primary:5432,standby:5432/aegra?target_session_attrs=prefer-standby
+```
+
+| Value | Behavior |
+|-------|----------|
+| `any` | Connect to the first available host |
+| `read-write` | Only connect to a host accepting writes (primary) |
+| `read-only` | Only connect to a read-only host (standby) |
+| `prefer-standby` | Prefer standby, fall back to primary |
+| `primary` | Only connect to the primary |
+| `standby` | Only connect to a standby |
+
+For most deployments, omit `target_session_attrs` or use `any` -- Aegra needs a writable connection for metadata and checkpoints, and standalone primaries satisfy all session attribute filters.
+
+## Pool recovery
+
+Aegra's SQLAlchemy pool is configured with `pool_pre_ping=True`. This means each connection is validated with a lightweight ping before use. When a host goes down:
+
+1. Existing pooled connections to the dead host fail the ping check
+2. The pool discards the dead connection
+3. A new connection is created using the multi-host URL
+4. The driver tries each host in order until one responds
+
+No manual intervention or restart is needed. The LangGraph pool (psycopg) handles this natively through its built-in connection health checks.
+
+## Limitations
+
+- **IPv6 addresses** must use bracket notation: `[::1]:5432,[::2]:5433`
+- **Ports** must be numeric. Non-numeric ports (e.g. `host:abc`) are rejected at startup with a clear error
+- **Individual `POSTGRES_*` fields** do not support multi-host -- use `DATABASE_URL`
+- Multi-host does not provide load balancing -- the driver connects to the first responsive host

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -48,7 +48,7 @@ POSTGRES_USER=user
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DATABASE_URL` | — | Full PostgreSQL connection string |
+| `DATABASE_URL` | — | Full PostgreSQL connection string. Supports comma-separated hosts for [high availability](/guides/high-availability) (e.g. `host1:5432,host2:5432`) |
 | `POSTGRES_DB` | `aegra` | Database name |
 | `POSTGRES_HOST` | `localhost` | Database host |
 | `POSTGRES_PASSWORD` | `password` | Database password |

--- a/libs/aegra-api/src/aegra_api/constants.py
+++ b/libs/aegra-api/src/aegra_api/constants.py
@@ -1,5 +1,17 @@
+import re
 from uuid import UUID
 
 # Standard namespace UUID for deriving deterministic assistant IDs from graph IDs.
 # IMPORTANT: Do not change after initial deploy unless you plan a data migration.
 ASSISTANT_NAMESPACE_UUID = UUID("6ba7b821-9dad-11d1-80b4-00c04fd430c8")
+
+# Regex to decompose a PostgreSQL URL into its components.
+# Used by DatabaseSettings._to_sqlalchemy_multihost() to detect and rewrite
+# comma-separated host lists into SQLAlchemy query-param format.
+MULTIHOST_URL_RE = re.compile(
+    r"^(?P<scheme>[^:]+://)"
+    r"(?:(?P<userinfo>.+)@)?"
+    r"(?P<hostlist>[^/?]+)"
+    r"(?:/(?P<path>[^?]*))?"
+    r"(?:\?(?P<query>.+))?$"
+)

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -116,6 +116,9 @@ class DatabaseSettings(EnvBase):
         for spec in hostlist.split(","):
             if spec.startswith("["):
                 # IPv6 literal: [::1]:5432 or [::1]
+                if "]" not in spec:
+                    msg = f"Malformed IPv6 in DATABASE_URL: `{spec}` — missing closing bracket"
+                    raise ValueError(msg)
                 bracket_end = spec.index("]")
                 host = spec[: bracket_end + 1]
                 rest = spec[bracket_end + 1 :]

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -114,12 +114,19 @@ class DatabaseSettings(EnvBase):
         hosts: list[str] = []
         ports: list[str] = []
         for spec in hostlist.split(","):
-            host, _, port = spec.rpartition(":")
-            if host:
+            if spec.startswith("["):
+                # IPv6 literal: [::1]:5432 or [::1]
+                bracket_end = spec.index("]")
+                host = spec[: bracket_end + 1]
+                rest = spec[bracket_end + 1 :]
+                port = rest[1:] if rest.startswith(":") else ""
+            else:
+                host, _, port = spec.rpartition(":")
+            if host and port:
                 hosts.append(host)
                 ports.append(port)
             else:
-                hosts.append(spec)
+                hosts.append(host if host else spec)
                 ports.append("5432")
 
         auth = f"{userinfo}@" if userinfo else ""

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -126,6 +126,9 @@ class DatabaseSettings(EnvBase):
             else:
                 host, _, port = spec.rpartition(":")
             if host and port:
+                if not port.isdigit():
+                    msg = f"Non-integer port in DATABASE_URL: `{spec}` — port must be a number, got `{port}`"
+                    raise ValueError(msg)
                 hosts.append(host)
                 ports.append(port)
             else:

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -5,6 +5,7 @@ from pydantic import BeforeValidator, computed_field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from aegra_api import __version__
+from aegra_api.constants import MULTIHOST_URL_RE
 
 
 def parse_lower(v: str) -> str:
@@ -87,12 +88,59 @@ class DatabaseSettings(EnvBase):
         """Replace the URL scheme/driver prefix with the target scheme."""
         return re.sub(r"^postgres(?:ql)?(\+\w+)?://", f"{target_scheme}://", url)
 
+    @staticmethod
+    def _to_sqlalchemy_multihost(url: str) -> str:
+        """Convert a libpq multi-host URL to SQLAlchemy query-param format.
+
+        PostgreSQL libpq and psycopg accept comma-separated hosts in the
+        URL authority (``host1:5432,host2:5433``).  SQLAlchemy's asyncpg
+        dialect requires hosts and ports as query parameters instead.
+
+        Single-host URLs are returned unchanged.
+        """
+        m = MULTIHOST_URL_RE.match(url)
+        if not m:
+            return url
+
+        hostlist = m.group("hostlist")
+        if "," not in hostlist:
+            return url
+
+        scheme = m.group("scheme")
+        userinfo = m.group("userinfo") or ""
+        path = m.group("path") or ""
+        query = m.group("query") or ""
+
+        hosts: list[str] = []
+        ports: list[str] = []
+        for spec in hostlist.split(","):
+            host, _, port = spec.rpartition(":")
+            if host:
+                hosts.append(host)
+                ports.append(port)
+            else:
+                hosts.append(spec)
+                ports.append("5432")
+
+        auth = f"{userinfo}@" if userinfo else ""
+        ha_params = f"host={','.join(hosts)}&port={','.join(ports)}"
+        all_params = f"{ha_params}&{query}" if query else ha_params
+
+        return f"{scheme}{auth}/{path}?{all_params}"
+
     @computed_field
     @property
     def database_url(self) -> str:
-        """Async URL for SQLAlchemy (asyncpg)."""
+        """Async URL for SQLAlchemy (asyncpg).
+
+        When ``DATABASE_URL`` contains multiple comma-separated hosts
+        (e.g. ``postgresql://h1:5432,h2:5432/db``), the URL is rewritten
+        into SQLAlchemy's query-param multi-host format so that asyncpg
+        receives hosts as a list and can fail over natively.
+        """
         if self.DATABASE_URL:
-            return self._normalize_scheme(self.DATABASE_URL, "postgresql+asyncpg")
+            url = self._normalize_scheme(self.DATABASE_URL, "postgresql+asyncpg")
+            return self._to_sqlalchemy_multihost(url)
         return (
             f"postgresql+asyncpg://{self.POSTGRES_USER}:{self.POSTGRES_PASSWORD}@"
             f"{self.POSTGRES_HOST}:{self.POSTGRES_PORT}/{self.POSTGRES_DB}"

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -261,6 +261,15 @@ class TestMultiHostDatabaseURL:
         with pytest.raises(ValueError, match="missing closing bracket"):
             _ = db.database_url
 
+    def test_non_integer_port_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-integer port in multi-host URL raises at startup."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h1:abc,h2:5433/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        with pytest.raises(ValueError, match="Non-integer port"):
+            _ = db.database_url
+
     def test_single_host_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Single-host URL is not rewritten."""
         monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@h1:5432/db")

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -239,6 +239,33 @@ class TestMultiHostDatabaseURL:
         assert "host=h1,h2,h3" in db.database_url
         assert "port=5432,5432,5432" in db.database_url
 
+    def test_trailing_colon_defaults_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Host with trailing colon but no port defaults to 5432."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h1:,h2:5433/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert "host=h1,h2" in db.database_url
+        assert "port=5432,5433" in db.database_url
+
+    def test_ipv6_hosts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """IPv6 literal addresses are parsed correctly."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@[::1]:5432,[::2]:5433/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert "host=[::1],[::2]" in db.database_url
+        assert "port=5432,5433" in db.database_url
+
+    def test_ipv6_without_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """IPv6 literal without port defaults to 5432."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@[::1],[::2]/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert "host=[::1],[::2]" in db.database_url
+        assert "port=5432,5432" in db.database_url
+
 
 class TestWorkerSettingsLeaseValidation:
     """Test that lease timing invariants are enforced at startup."""

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -196,23 +196,70 @@ class TestMultiHostDatabaseURL:
         assert "target_session_attrs=read-write" in url
         assert "sslmode=require" in url
 
-    def test_multihost_defaults_port_when_omitted(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Hosts without explicit port default to 5432."""
-        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@h1,h2/db")
+    @pytest.mark.parametrize(
+        ("env_url", "expected_hosts", "expected_ports"),
+        [
+            pytest.param(
+                "postgresql://user:pass@h1,h2/db",
+                "host=h1,h2",
+                "port=5432,5432",
+                id="defaults_port_when_omitted",
+            ),
+            pytest.param(
+                "postgresql://user:pass@h1:5432,h2/db",
+                "host=h1,h2",
+                "port=5432,5432",
+                id="mixed_ports",
+            ),
+            pytest.param(
+                "postgresql://u:p@h1:5432,h2:5432,h3:5432/db",
+                "host=h1,h2,h3",
+                "port=5432,5432,5432",
+                id="three_hosts",
+            ),
+            pytest.param(
+                "postgresql://u:p@h1:,h2:5433/db",
+                "host=h1,h2",
+                "port=5432,5433",
+                id="trailing_colon_defaults_port",
+            ),
+            pytest.param(
+                "postgresql://u:p@[::1]:5432,[::2]:5433/db",
+                "host=[::1],[::2]",
+                "port=5432,5433",
+                id="ipv6_hosts",
+            ),
+            pytest.param(
+                "postgresql://u:p@[::1],[::2]/db",
+                "host=[::1],[::2]",
+                "port=5432,5432",
+                id="ipv6_without_port",
+            ),
+        ],
+    )
+    def test_multihost_host_port_matrix(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        env_url: str,
+        expected_hosts: str,
+        expected_ports: str,
+    ) -> None:
+        """Multi-host URLs are parsed into correct host/port query params."""
+        monkeypatch.setenv("DATABASE_URL", env_url)
 
         db = DatabaseSettings(_env_file=None)
 
-        assert "host=h1,h2" in db.database_url
-        assert "port=5432,5432" in db.database_url
+        assert expected_hosts in db.database_url
+        assert expected_ports in db.database_url
 
-    def test_multihost_mixed_ports(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Hosts with mixed port specifications are handled correctly."""
-        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@h1:5432,h2/db")
+    def test_malformed_ipv6_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Malformed bracketed IPv6 (missing closing bracket) raises at startup."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@[::1:5432,[::2]:5433/db")
 
         db = DatabaseSettings(_env_file=None)
 
-        assert "host=h1,h2" in db.database_url
-        assert "port=5432,5432" in db.database_url
+        with pytest.raises(ValueError, match="missing closing bracket"):
+            _ = db.database_url
 
     def test_single_host_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Single-host URL is not rewritten."""
@@ -229,42 +276,6 @@ class TestMultiHostDatabaseURL:
         db = DatabaseSettings(_env_file=None)
 
         assert db.database_url == "postgresql+asyncpg:///db?host=h1,h2&port=5432,5432"
-
-    def test_three_hosts(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Three-host URL is converted correctly."""
-        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h1:5432,h2:5432,h3:5432/db")
-
-        db = DatabaseSettings(_env_file=None)
-
-        assert "host=h1,h2,h3" in db.database_url
-        assert "port=5432,5432,5432" in db.database_url
-
-    def test_trailing_colon_defaults_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Host with trailing colon but no port defaults to 5432."""
-        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h1:,h2:5433/db")
-
-        db = DatabaseSettings(_env_file=None)
-
-        assert "host=h1,h2" in db.database_url
-        assert "port=5432,5433" in db.database_url
-
-    def test_ipv6_hosts(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """IPv6 literal addresses are parsed correctly."""
-        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@[::1]:5432,[::2]:5433/db")
-
-        db = DatabaseSettings(_env_file=None)
-
-        assert "host=[::1],[::2]" in db.database_url
-        assert "port=5432,5433" in db.database_url
-
-    def test_ipv6_without_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """IPv6 literal without port defaults to 5432."""
-        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@[::1],[::2]/db")
-
-        db = DatabaseSettings(_env_file=None)
-
-        assert "host=[::1],[::2]" in db.database_url
-        assert "port=5432,5432" in db.database_url
 
 
 class TestWorkerSettingsLeaseValidation:

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -161,6 +161,85 @@ class TestDatabaseURLSupport:
         assert db.DATABASE_URL == "not-a-url"
 
 
+class TestMultiHostDatabaseURL:
+    """Test multi-host DATABASE_URL support for native PostgreSQL HA."""
+
+    def test_multihost_converted_for_asyncpg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Multi-host libpq URL is converted to SQLAlchemy query-param format for asyncpg."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@h1:5432,h2:5433/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert db.database_url == "postgresql+asyncpg://user:pass@/db?host=h1,h2&port=5432,5433"
+
+    def test_multihost_preserved_for_psycopg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Multi-host URL is kept in libpq format for psycopg (database_url_sync)."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@h1:5432,h2:5433/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert db.database_url_sync == "postgresql://user:pass@h1:5432,h2:5433/db"
+
+    def test_multihost_preserves_query_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Query params like target_session_attrs are preserved after conversion."""
+        monkeypatch.setenv(
+            "DATABASE_URL",
+            "postgresql://user:pass@h1:5432,h2:5432/db?target_session_attrs=read-write&sslmode=require",
+        )
+
+        db = DatabaseSettings(_env_file=None)
+
+        url = db.database_url
+        assert url.startswith("postgresql+asyncpg://user:pass@/db?")
+        assert "host=h1,h2" in url
+        assert "port=5432,5432" in url
+        assert "target_session_attrs=read-write" in url
+        assert "sslmode=require" in url
+
+    def test_multihost_defaults_port_when_omitted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Hosts without explicit port default to 5432."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@h1,h2/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert "host=h1,h2" in db.database_url
+        assert "port=5432,5432" in db.database_url
+
+    def test_multihost_mixed_ports(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Hosts with mixed port specifications are handled correctly."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@h1:5432,h2/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert "host=h1,h2" in db.database_url
+        assert "port=5432,5432" in db.database_url
+
+    def test_single_host_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Single-host URL is not rewritten."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@h1:5432/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert db.database_url == "postgresql+asyncpg://user:pass@h1:5432/db"
+
+    def test_multihost_no_userinfo(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Multi-host URL without userinfo is converted correctly."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://h1:5432,h2:5432/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert db.database_url == "postgresql+asyncpg:///db?host=h1,h2&port=5432,5432"
+
+    def test_three_hosts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Three-host URL is converted correctly."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h1:5432,h2:5432,h3:5432/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert "host=h1,h2,h3" in db.database_url
+        assert "port=5432,5432,5432" in db.database_url
+
+
 class TestWorkerSettingsLeaseValidation:
     """Test that lease timing invariants are enforced at startup."""
 

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -10,6 +10,9 @@ AEGRA_CONFIG=aegra.json
 # Option 1: Single connection string (standard for containers/cloud)
 # DATABASE_URL=postgresql://user:password@host:5432/$slug
 #
+# Option 1b: Multi-host for native PostgreSQL HA (failover handled by drivers)
+# DATABASE_URL=postgresql://user:password@primary:5432,standby:5432/$slug?target_session_attrs=read-write
+#
 # Option 2: Individual fields (used when DATABASE_URL is not set)
 POSTGRES_DB=$slug
 POSTGRES_HOST=localhost


### PR DESCRIPTION
## Description

  Add native database failover support via standard PostgreSQL multi-host connection strings. When `DATABASE_URL` contains comma-separated hosts (e.g. `primary:5432,standby:5432`), both drivers (asyncpg and psycopg) automatically try each host in order and connect to the first one matching `target_session_attrs`.

  ## Type of Change

  - [x] `feat`: New feature

  ## Changes Made

  - Add `_to_sqlalchemy_multihost()` in `DatabaseSettings` — converts libpq multi-host URL to SQLAlchemy query-param format for asyncpg (`?host=h1,h2&port=5432,5432`)
  - `database_url_sync` (psycopg) passes the URL unchanged — libpq format is natively supported
  - Add `MULTIHOST_URL_RE` regex constant to `constants.py`
  - Add multi-host URL example to `.env.example` and CLI template

  ## Testing

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] E2E tests added/updated
  - [x] Manual testing performed

  8 unit tests covering: multi-host conversion with/without ports, query param preservation, userinfo handling, single-host passthrough, three-host URLs, psycopg URL preservation.

  Manual testing with two PostgreSQL Docker containers verified: baseline connectivity, failover on primary kill, failback on restore, both-hosts-dead error handling, pool auto-recovery via `pool_pre_ping`, `target_session_attrs=read-write` filtering, rapid failover/failback, and DDL operations through converted URL.

  ## Checklist

  - [x] Code follows project style (Ruff formatting)
  - [x] All linting checks pass (`make lint`)
  - [x] Type checking passes (`make type-check`)
  - [x] All tests pass (`make test`)
  - [x] Documentation updated (if needed)
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] PR title follows Conventional Commits format

  ## Additional Notes

  **How it works:** PostgreSQL drivers (asyncpg ≥0.28, psycopg3) natively support multi-host URIs with `target_session_attrs`. The only code change needed is URL format conversion — psycopg uses standard libpq format (`host1,host2` in authority) while SQLAlchemy's asyncpg dialect requires hosts as query parameters (`host=h1,h2&port=p1,p2`). Existing single-host URLs are unaffected.

  **Usage:**
  ```env
  DATABASE_URL=postgresql://user:pass@primary:5432,standby:5432/db?target_session_attrs=read-write

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for PostgreSQL multi-host (primary/standby) DATABASE_URLs: scheme normalization, automatic rewrite for async drivers, preservation of existing query parameters, and validation for malformed IPv6 and non-numeric ports.

* **Documentation**
  * Added a high-availability guide and updated environment docs and templates with commented multi-host DATABASE_URL examples.

* **Tests**
  * Added unit tests covering multi-host parsing, port defaults, IPv6 edge cases, malformed inputs, and sync vs async behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds native PostgreSQL HA failover support by detecting and converting multi-host `DATABASE_URL` strings (e.g. `primary:5432,standby:5432`) to the correct per-driver format — SQLAlchemy asyncpg query-param style (`host=h1,h2&port=p1,p2`) vs. unchanged libpq format for psycopg. Single-host URLs pass through untouched. Test coverage is thorough across port defaults, IPv6 literals, mixed ports, query param preservation, no-userinfo, and malformed-input detection.

<h3>Confidence Score: 5/5</h3>

Safe to merge — implementation is correct and all identified issues are P2 style suggestions.

Traced all key code paths: multi-host with/without ports, IPv6 brackets, trailing colons, query param preservation, no-userinfo, and single-host passthrough all produce correct output as confirmed by the test assertions. The only gap is that non-integer port strings aren't validated before injection into the query string, but this only surfaces on already-malformed configuration.

No files require special attention; settings.py contains all the core logic and is well-covered by unit tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/constants.py | Adds MULTIHOST_URL_RE regex constant for decomposing PostgreSQL URLs into named groups: scheme, userinfo, hostlist, path, query |
| libs/aegra-api/src/aegra_api/settings.py | Adds _to_sqlalchemy_multihost() to rewrite libpq multi-host authority into asyncpg query-param format; single-host and psycopg paths are unchanged |
| libs/aegra-api/tests/unit/test_settings.py | Adds 8 unit tests covering multi-host conversion, port defaulting, IPv6, mixed ports, query param preservation, psycopg passthrough, and malformed IPv6 detection |
| .env.example | Adds commented multi-host DATABASE_URL example (Option 1b) for HA deployments |
| libs/aegra-cli/src/aegra_cli/templates/env.example.template | Mirrors the multi-host DATABASE_URL example into the aegra init project template |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DATABASE_URL set?] -- Yes --> B[_normalize_scheme
postgresql+asyncpg://]
    A -- No --> C[Build from POSTGRES_* vars]
    B --> D{comma in hostlist?}
    D -- No: single-host --> E[Return asyncpg URL unchanged]
    D -- Yes: multi-host --> F[Parse via MULTIHOST_URL_RE]
    F --> G[For each host spec
IPv6 bracket handling
rpartition colon for port]
    G --> H[Default port to 5432
if missing or empty]
    H --> I[Reconstruct:
postgresql+asyncpg://auth/db
?host=h1,h2&port=p1,p2&...]
    C --> J[postgresql+asyncpg://
user:pass@host:port/db]

    subgraph sync [database_url_sync - psycopg]
      K[DATABASE_URL set?] -- Yes --> L[_normalize_scheme only
no multihost conversion]
      K -- No --> M[Build from POSTGRES_* vars]
      L --> N[postgresql://user:pass
@h1:5432,h2:5432/db
libpq format preserved]
      M --> O[postgresql://user:pass
@host:port/db]
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%3A128-133%0A**Non-integer%20port%20values%20are%20silently%20accepted**%0A%0APort%20strings%20extracted%20from%20the%20hostlist%20%28e.g.%20%60%22abc%22%60%20from%20%60h1%3Aabc%60%29%20pass%20the%20%60if%20host%20and%20port%3A%60%20check%20and%20are%20injected%20directly%20into%20the%20query%20string%20as%20%60port%3Dabc%2C5432%60.%20asyncpg%20would%20then%20fail%20at%20connection%20time%20with%20a%20driver-level%20error%20rather%20than%20a%20clear%20startup%20message.%20Consider%20validating%20that%20each%20extracted%20port%20is%20a%20valid%20integer%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20host%20and%20port%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20not%20port.isdigit%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20msg%20%3D%20f%22Invalid%20port%20in%20DATABASE_URL%20host%20spec%20%60%7Bspec%7D%60%3A%20%60%7Bport%7D%60%20is%20not%20a%20valid%20integer%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20raise%20ValueError%28msg%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20hosts.append%28host%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ports.append%28port%29%0A%20%20%20%20%20%20%20%20%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20hosts.append%28host%20if%20host%20else%20spec%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ports.append%28%225432%22%29%0A%60%60%60%0A%0A&repo=ibbybuilds%2Faegra"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%3A128-133%0A**Non-integer%20port%20values%20are%20silently%20accepted**%0A%0APort%20strings%20extracted%20from%20the%20hostlist%20%28e.g.%20%60%22abc%22%60%20from%20%60h1%3Aabc%60%29%20pass%20the%20%60if%20host%20and%20port%3A%60%20check%20and%20are%20injected%20directly%20into%20the%20query%20string%20as%20%60port%3Dabc%2C5432%60.%20asyncpg%20would%20then%20fail%20at%20connection%20time%20with%20a%20driver-level%20error%20rather%20than%20a%20clear%20startup%20message.%20Consider%20validating%20that%20each%20extracted%20port%20is%20a%20valid%20integer%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20host%20and%20port%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20not%20port.isdigit%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20msg%20%3D%20f%22Invalid%20port%20in%20DATABASE_URL%20host%20spec%20%60%7Bspec%7D%60%3A%20%60%7Bport%7D%60%20is%20not%20a%20valid%20integer%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20raise%20ValueError%28msg%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20hosts.append%28host%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ports.append%28port%29%0A%20%20%20%20%20%20%20%20%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20hosts.append%28host%20if%20host%20else%20spec%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ports.append%28%225432%22%29%0A%60%60%60%0A%0A"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%3A128-133%0A**Non-integer%20port%20values%20are%20silently%20accepted**%0A%0APort%20strings%20extracted%20from%20the%20hostlist%20%28e.g.%20%60%22abc%22%60%20from%20%60h1%3Aabc%60%29%20pass%20the%20%60if%20host%20and%20port%3A%60%20check%20and%20are%20injected%20directly%20into%20the%20query%20string%20as%20%60port%3Dabc%2C5432%60.%20asyncpg%20would%20then%20fail%20at%20connection%20time%20with%20a%20driver-level%20error%20rather%20than%20a%20clear%20startup%20message.%20Consider%20validating%20that%20each%20extracted%20port%20is%20a%20valid%20integer%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20host%20and%20port%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20not%20port.isdigit%28%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20msg%20%3D%20f%22Invalid%20port%20in%20DATABASE_URL%20host%20spec%20%60%7Bspec%7D%60%3A%20%60%7Bport%7D%60%20is%20not%20a%20valid%20integer%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20raise%20ValueError%28msg%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20hosts.append%28host%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ports.append%28port%29%0A%20%20%20%20%20%20%20%20%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20hosts.append%28host%20if%20host%20else%20spec%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ports.append%28%225432%22%29%0A%60%60%60%0A%0A&repo=ibbybuilds%2Faegra"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<sub>Reviews (3): Last reviewed commit: ["fix(settings): validate malformed IPv6 i..."](https://github.com/ibbybuilds/aegra/commit/76fbb498d29a793ac3a270ccb4a97516b0db7000) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27567914)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=49bdce28-7cb1-4d77-a7a8-6bbbab6aa631))

<!-- /greptile_comment -->