### PR TITLE
feat: add LOG_EXCLUDE_PATHS to suppress access logs for noisy endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,7 @@ PORT=2026
 LOG_LEVEL=INFO
 ENV_MODE=LOCAL # DEVELOPMENT, PRODUCTION, LOCAL (PRODUCTION outputs JSON logs)
 LOG_VERBOSITY=standard # standard, verbose (verbose outputs request-id)
+# LOG_EXCLUDE_PATHS=/health,/ok  # Comma-separated path prefixes to skip in access logs
 
 # --- Redis (Event Broker & Job Queue) ---
 # Enable Redis for multi-instance SSE streaming and worker job dispatch.

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -88,6 +88,7 @@ Aegra uses two connection pools: one for SQLAlchemy (metadata) and one for LangG
 | `LOG_LEVEL` | `INFO` | Logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | `ENV_MODE` | `LOCAL` | Environment mode: `LOCAL`, `DEVELOPMENT`, `PRODUCTION` (PRODUCTION outputs JSON logs) |
 | `LOG_VERBOSITY` | `standard` | `standard` or `verbose` (verbose includes request-id) |
+| `LOG_EXCLUDE_PATHS` | `""` | Comma-separated path prefixes whose successful (2xx/3xx) access logs are suppressed. Errors (4xx/5xx) are still logged. Example: `/health,/metrics` |
 
 ## LLM providers
 

--- a/libs/aegra-api/src/aegra_api/middleware/logger_middleware.py
+++ b/libs/aegra-api/src/aegra_api/middleware/logger_middleware.py
@@ -53,43 +53,53 @@ class StructLogMiddleware:
             raise
         finally:
             process_time = time.perf_counter_ns() - info["start_time"]
-            client_host, client_port = scope["client"]
-            http_method = scope["method"]
-            http_version = scope["http_version"]
-            url = get_path_with_query_string(scope)
-
-            # Recreate the Uvicorn access log format, but add all parameters as structured information
-            log_data = {
-                "url": str(url),
-                "status_code": info.get("status_code", 500),
-                "method": http_method,
-                "version": http_version,
-            }
-            if settings.app.LOG_VERBOSITY == "verbose":
-                log_data["request_id"] = correlation_id.get()
-
             status_code = info.get("status_code", 500)
-            if 400 <= status_code < 500:
-                # Log as warning for client errors (4xx)
-                access_logger.warning(
-                    f"""{client_host}:{client_port} - "{http_method} {scope["path"]} HTTP/{http_version}" {status_code}""",
-                    http=log_data,
-                    network={"client": {"ip": client_host, "port": client_port}},
-                    duration=process_time,
-                )
-            elif 500 <= status_code < 600:
-                # Log as error for server errors (5xx)
-                access_logger.error(
-                    f"""{client_host}:{client_port} - "{http_method} {scope["path"]} HTTP/{http_version}" {status_code}""",
-                    http=log_data,
-                    network={"client": {"ip": client_host, "port": client_port}},
-                    duration=process_time,
-                )
-            else:
-                # Normal log for successful responses (2xx, 3xx)
-                access_logger.info(
-                    f"""{client_host}:{client_port} - "{http_method} {scope["path"]} HTTP/{http_version}" {status_code}""",
-                    http=log_data,
-                    network={"client": {"ip": client_host, "port": client_port}},
-                    duration=process_time,
-                )
+            path: str = scope["path"]
+
+            # Skip access log for excluded paths on successful responses.
+            # Errors (4xx/5xx) are always logged, even for excluded paths.
+            exclude_prefixes = settings.app.log_exclude_paths
+            is_excluded = (
+                status_code < 400 and exclude_prefixes and any(path.startswith(prefix) for prefix in exclude_prefixes)
+            )
+
+            if not is_excluded:
+                client_host, client_port = scope["client"]
+                http_method = scope["method"]
+                http_version = scope["http_version"]
+                url = get_path_with_query_string(scope)
+
+                # Recreate the Uvicorn access log format, but add all parameters as structured information
+                log_data = {
+                    "url": str(url),
+                    "status_code": status_code,
+                    "method": http_method,
+                    "version": http_version,
+                }
+                if settings.app.LOG_VERBOSITY == "verbose":
+                    log_data["request_id"] = correlation_id.get()
+
+                if 400 <= status_code < 500:
+                    # Log as warning for client errors (4xx)
+                    access_logger.warning(
+                        f"""{client_host}:{client_port} - "{http_method} {scope["path"]} HTTP/{http_version}" {status_code}""",
+                        http=log_data,
+                        network={"client": {"ip": client_host, "port": client_port}},
+                        duration=process_time,
+                    )
+                elif 500 <= status_code < 600:
+                    # Log as error for server errors (5xx)
+                    access_logger.error(
+                        f"""{client_host}:{client_port} - "{http_method} {scope["path"]} HTTP/{http_version}" {status_code}""",
+                        http=log_data,
+                        network={"client": {"ip": client_host, "port": client_port}},
+                        duration=process_time,
+                    )
+                else:
+                    # Normal log for successful responses (2xx, 3xx)
+                    access_logger.info(
+                        f"""{client_host}:{client_port} - "{http_method} {scope["path"]} HTTP/{http_version}" {status_code}""",
+                        http=log_data,
+                        network={"client": {"ip": client_host, "port": client_port}},
+                        duration=process_time,
+                    )

--- a/libs/aegra-api/src/aegra_api/middleware/logger_middleware.py
+++ b/libs/aegra-api/src/aegra_api/middleware/logger_middleware.py
@@ -1,9 +1,10 @@
 import time
-from typing import TypedDict
+from typing import TypedDict, cast
 
 import structlog
 from asgi_correlation_id import correlation_id
 from starlette.types import ASGIApp, Receive, Scope, Send
+from uvicorn._types import HTTPScope
 from uvicorn.protocols.utils import get_path_with_query_string
 
 from aegra_api.settings import settings
@@ -27,6 +28,7 @@ class StructLogMiddleware:
             await self.app(scope, receive, send)
             return
 
+        http_scope = cast(HTTPScope, scope)
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(request_id=correlation_id.get())
 
@@ -54,7 +56,7 @@ class StructLogMiddleware:
         finally:
             process_time = time.perf_counter_ns() - info["start_time"]
             status_code = info.get("status_code", 500)
-            path: str = scope["path"]
+            path: str = http_scope["path"]
 
             # Skip access log for excluded paths on successful responses.
             # Errors (4xx/5xx) are always logged, even for excluded paths.
@@ -64,10 +66,11 @@ class StructLogMiddleware:
             )
 
             if not is_excluded:
-                client_host, client_port = scope["client"]
-                http_method = scope["method"]
-                http_version = scope["http_version"]
-                url = get_path_with_query_string(scope)
+                client_info = http_scope.get("client")
+                client_host, client_port = client_info if client_info else ("unknown", 0)
+                http_method = http_scope["method"]
+                http_version = http_scope["http_version"]
+                url = get_path_with_query_string(http_scope)
 
                 # Recreate the Uvicorn access log format, but add all parameters as structured information
                 log_data = {
@@ -82,7 +85,7 @@ class StructLogMiddleware:
                 if 400 <= status_code < 500:
                     # Log as warning for client errors (4xx)
                     access_logger.warning(
-                        f"""{client_host}:{client_port} - "{http_method} {scope["path"]} HTTP/{http_version}" {status_code}""",
+                        f"""{client_host}:{client_port} - "{http_method} {path} HTTP/{http_version}" {status_code}""",
                         http=log_data,
                         network={"client": {"ip": client_host, "port": client_port}},
                         duration=process_time,
@@ -90,7 +93,7 @@ class StructLogMiddleware:
                 elif 500 <= status_code < 600:
                     # Log as error for server errors (5xx)
                     access_logger.error(
-                        f"""{client_host}:{client_port} - "{http_method} {scope["path"]} HTTP/{http_version}" {status_code}""",
+                        f"""{client_host}:{client_port} - "{http_method} {path} HTTP/{http_version}" {status_code}""",
                         http=log_data,
                         network={"client": {"ip": client_host, "port": client_port}},
                         duration=process_time,
@@ -98,7 +101,7 @@ class StructLogMiddleware:
                 else:
                     # Normal log for successful responses (2xx, 3xx)
                     access_logger.info(
-                        f"""{client_host}:{client_port} - "{http_method} {scope["path"]} HTTP/{http_version}" {status_code}""",
+                        f"""{client_host}:{client_port} - "{http_method} {path} HTTP/{http_version}" {status_code}""",
                         http=log_data,
                         network={"client": {"ip": client_host, "port": client_port}},
                         duration=process_time,

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -63,6 +63,15 @@ class AppSettings(EnvBase):
     # Logging
     LOG_LEVEL: UpperStr = "INFO"
     LOG_VERBOSITY: LowerStr = "verbose"
+    LOG_EXCLUDE_PATHS: str = ""  # Comma-separated path prefixes to skip in access logs
+
+    @computed_field
+    @property
+    def log_exclude_paths(self) -> tuple[str, ...]:
+        """Parse LOG_EXCLUDE_PATHS into a tuple of path prefixes."""
+        if not self.LOG_EXCLUDE_PATHS:
+            return ()
+        return tuple(part.strip() for part in self.LOG_EXCLUDE_PATHS.split(",") if part.strip())
 
 
 class DatabaseSettings(EnvBase):

--- a/libs/aegra-api/tests/integration/test_log_exclude_paths.py
+++ b/libs/aegra-api/tests/integration/test_log_exclude_paths.py
@@ -1,0 +1,79 @@
+"""Integration tests for LOG_EXCLUDE_PATHS middleware behaviour.
+
+Tests verify that the full FastAPI app (with StructLogMiddleware) respects
+LOG_EXCLUDE_PATHS by suppressing access logs for matched prefixes while
+still logging errors on those paths.
+"""
+
+import importlib
+import sys
+from collections.abc import Callable
+
+from starlette.testclient import TestClient
+
+
+def _reload_settings_and_middleware() -> None:
+    """Reload settings and middleware so they pick up env var changes."""
+    importlib.reload(sys.modules["aegra_api.settings"])
+    if "aegra_api.middleware.logger_middleware" in sys.modules:
+        importlib.reload(sys.modules["aegra_api.middleware.logger_middleware"])
+
+
+def _make_capture_log(logged_calls: list[str]) -> Callable[[str], Callable[..., None]]:
+    """Create a log capture factory bound to the given list."""
+
+    def capture_log(method_name: str) -> Callable[..., None]:
+        def _log(msg: str, *args: object, **kwargs: object) -> None:
+            logged_calls.append(method_name)
+
+        return _log
+
+    return capture_log
+
+
+def test_excluded_path_suppresses_access_log(monkeypatch) -> None:
+    """GET /info with LOG_EXCLUDE_PATHS=/info should not produce an access log entry."""
+    monkeypatch.setenv("LOG_EXCLUDE_PATHS", "/info")
+    _reload_settings_and_middleware()
+
+    from aegra_api.main import app
+    from aegra_api.middleware.logger_middleware import access_logger
+
+    logged_calls: list[str] = []
+    capture_log = _make_capture_log(logged_calls)
+
+    monkeypatch.setattr(access_logger, "info", capture_log("info"))
+    monkeypatch.setattr(access_logger, "warning", capture_log("warning"))
+    monkeypatch.setattr(access_logger, "error", capture_log("error"))
+
+    client = TestClient(app)
+
+    # /info returns 200 without DB — should be excluded from access log
+    logged_calls.clear()
+    resp = client.get("/info")
+    assert resp.status_code == 200
+    assert "info" not in logged_calls, "Expected /info access log to be suppressed"
+
+
+def test_non_excluded_path_still_logged(monkeypatch) -> None:
+    """Endpoints not in LOG_EXCLUDE_PATHS should still produce access log entries."""
+    monkeypatch.setenv("LOG_EXCLUDE_PATHS", "/info")
+    _reload_settings_and_middleware()
+
+    from aegra_api.main import app
+    from aegra_api.middleware.logger_middleware import access_logger
+
+    logged_calls: list[str] = []
+    capture_log = _make_capture_log(logged_calls)
+
+    monkeypatch.setattr(access_logger, "info", capture_log("info"))
+    monkeypatch.setattr(access_logger, "warning", capture_log("warning"))
+    monkeypatch.setattr(access_logger, "error", capture_log("error"))
+
+    client = TestClient(app)
+
+    # /nonexistent will 404 — should still be logged (4xx is never excluded)
+    logged_calls.clear()
+    resp = client.get("/nonexistent")
+    assert resp.status_code in (404, 405)
+    assert len(logged_calls) == 1, "Expected non-excluded error path to be logged"

--- a/libs/aegra-api/tests/integration/test_log_exclude_paths.py
+++ b/libs/aegra-api/tests/integration/test_log_exclude_paths.py
@@ -7,20 +7,28 @@ still logging errors on those paths.
 
 import importlib
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 
+import pytest
 from starlette.testclient import TestClient
 
 import aegra_api.main as aegra_main
 import aegra_api.middleware.logger_middleware as logger_middleware
 
 
-def _reload_settings_and_middleware() -> None:
-    """Reload settings and middleware so they pick up env var changes."""
+def _reload_modules() -> None:
+    """Reload settings, middleware, and app so they pick up env var changes."""
     importlib.reload(importlib.import_module("aegra_api.settings"))
     importlib.reload(importlib.import_module("aegra_api.middleware.logger_middleware"))
     if "aegra_api.main" in sys.modules:
         importlib.reload(sys.modules["aegra_api.main"])
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_state() -> Generator[None, None, None]:
+    """Reload modules before and after each test to prevent cross-test leakage."""
+    yield
+    _reload_modules()
 
 
 def _make_capture_log(logged_calls: list[str]) -> Callable[[str], Callable[..., None]]:
@@ -38,7 +46,7 @@ def _make_capture_log(logged_calls: list[str]) -> Callable[[str], Callable[..., 
 def test_excluded_path_suppresses_access_log(monkeypatch) -> None:
     """GET /info with LOG_EXCLUDE_PATHS=/info should not produce an access log entry."""
     monkeypatch.setenv("LOG_EXCLUDE_PATHS", "/info")
-    _reload_settings_and_middleware()
+    _reload_modules()
 
     app = aegra_main.app
     access_logger = logger_middleware.access_logger
@@ -62,7 +70,7 @@ def test_excluded_path_suppresses_access_log(monkeypatch) -> None:
 def test_non_excluded_path_still_logged(monkeypatch) -> None:
     """Endpoints not in LOG_EXCLUDE_PATHS should still produce access log entries."""
     monkeypatch.setenv("LOG_EXCLUDE_PATHS", "/info")
-    _reload_settings_and_middleware()
+    _reload_modules()
 
     app = aegra_main.app
     access_logger = logger_middleware.access_logger

--- a/libs/aegra-api/tests/integration/test_log_exclude_paths.py
+++ b/libs/aegra-api/tests/integration/test_log_exclude_paths.py
@@ -11,6 +11,9 @@ from collections.abc import Callable
 
 from starlette.testclient import TestClient
 
+import aegra_api.main as aegra_main
+import aegra_api.middleware.logger_middleware as logger_middleware
+
 
 def _reload_settings_and_middleware() -> None:
     """Reload settings and middleware so they pick up env var changes."""
@@ -37,8 +40,8 @@ def test_excluded_path_suppresses_access_log(monkeypatch) -> None:
     monkeypatch.setenv("LOG_EXCLUDE_PATHS", "/info")
     _reload_settings_and_middleware()
 
-    from aegra_api.main import app
-    from aegra_api.middleware.logger_middleware import access_logger
+    app = aegra_main.app
+    access_logger = logger_middleware.access_logger
 
     logged_calls: list[str] = []
     capture_log = _make_capture_log(logged_calls)
@@ -53,7 +56,7 @@ def test_excluded_path_suppresses_access_log(monkeypatch) -> None:
     logged_calls.clear()
     resp = client.get("/info")
     assert resp.status_code == 200
-    assert "info" not in logged_calls, "Expected /info access log to be suppressed"
+    assert logged_calls == [], "Expected /info access log to be fully suppressed"
 
 
 def test_non_excluded_path_still_logged(monkeypatch) -> None:
@@ -61,8 +64,8 @@ def test_non_excluded_path_still_logged(monkeypatch) -> None:
     monkeypatch.setenv("LOG_EXCLUDE_PATHS", "/info")
     _reload_settings_and_middleware()
 
-    from aegra_api.main import app
-    from aegra_api.middleware.logger_middleware import access_logger
+    app = aegra_main.app
+    access_logger = logger_middleware.access_logger
 
     logged_calls: list[str] = []
     capture_log = _make_capture_log(logged_calls)

--- a/libs/aegra-api/tests/integration/test_log_exclude_paths.py
+++ b/libs/aegra-api/tests/integration/test_log_exclude_paths.py
@@ -14,9 +14,10 @@ from starlette.testclient import TestClient
 
 def _reload_settings_and_middleware() -> None:
     """Reload settings and middleware so they pick up env var changes."""
-    importlib.reload(sys.modules["aegra_api.settings"])
-    if "aegra_api.middleware.logger_middleware" in sys.modules:
-        importlib.reload(sys.modules["aegra_api.middleware.logger_middleware"])
+    importlib.reload(importlib.import_module("aegra_api.settings"))
+    importlib.reload(importlib.import_module("aegra_api.middleware.logger_middleware"))
+    if "aegra_api.main" in sys.modules:
+        importlib.reload(sys.modules["aegra_api.main"])
 
 
 def _make_capture_log(logged_calls: list[str]) -> Callable[[str], Callable[..., None]]:
@@ -76,4 +77,4 @@ def test_non_excluded_path_still_logged(monkeypatch) -> None:
     logged_calls.clear()
     resp = client.get("/nonexistent")
     assert resp.status_code in (404, 405)
-    assert len(logged_calls) == 1, "Expected non-excluded error path to be logged"
+    assert logged_calls == ["warning"], "Expected 4xx path to be logged at warning level"

--- a/libs/aegra-api/tests/unit/test_middleware/test_logger_middleware.py
+++ b/libs/aegra-api/tests/unit/test_middleware/test_logger_middleware.py
@@ -1,11 +1,12 @@
 import importlib
 import json
 import sys
+from collections.abc import Callable
 
 from starlette.testclient import TestClient
 
 
-def reload_logging_modules():
+def reload_logging_modules() -> None:
     """
     Helper to reload settings and logging setup modules safely.
     Uses sys.modules lookup to avoid ImportError if alias is stale.
@@ -60,8 +61,8 @@ def test_log_exclude_paths_skips_access_log_for_successful_responses(monkeypatch
 
     logged_calls: list[str] = []
 
-    def capture_log(method_name: str):
-        def _log(msg: str, *args, **kwargs) -> None:
+    def capture_log(method_name: str) -> Callable[..., None]:
+        def _log(msg: str, *args: object, **kwargs: object) -> None:
             logged_calls.append(method_name)
 
         return _log
@@ -104,8 +105,8 @@ def test_log_exclude_paths_still_logs_errors_for_excluded_paths(monkeypatch):
 
     logged_calls: list[str] = []
 
-    def capture_log(method_name: str):
-        def _log(msg: str, *args, **kwargs) -> None:
+    def capture_log(method_name: str) -> Callable[..., None]:
+        def _log(msg: str, *args: object, **kwargs: object) -> None:
             logged_calls.append(method_name)
 
         return _log

--- a/libs/aegra-api/tests/unit/test_middleware/test_logger_middleware.py
+++ b/libs/aegra-api/tests/unit/test_middleware/test_logger_middleware.py
@@ -19,6 +19,9 @@ def reload_logging_modules():
     if "aegra_api.utils.setup_logging" in sys.modules:
         importlib.reload(sys.modules["aegra_api.utils.setup_logging"])
 
+    if "aegra_api.middleware.logger_middleware" in sys.modules:
+        importlib.reload(sys.modules["aegra_api.middleware.logger_middleware"])
+
 
 def test_structlog_middleware_handles_exceptions_and_success():
     """Test that the middleware correctly logs requests and handles exceptions."""
@@ -46,6 +49,134 @@ def test_structlog_middleware_handles_exceptions_and_success():
 
     r2 = client_boom.get("/")
     assert r2.status_code == 500
+
+
+def test_log_exclude_paths_skips_access_log_for_successful_responses(monkeypatch):
+    """Excluded paths with 2xx responses should not produce access log entries."""
+    monkeypatch.setenv("LOG_EXCLUDE_PATHS", "/health,/metrics")
+    reload_logging_modules()
+
+    from aegra_api.middleware.logger_middleware import StructLogMiddleware, access_logger
+
+    logged_calls: list[str] = []
+
+    def capture_log(method_name: str):
+        def _log(msg: str, *args, **kwargs) -> None:
+            logged_calls.append(method_name)
+
+        return _log
+
+    monkeypatch.setattr(access_logger, "info", capture_log("info"))
+    monkeypatch.setattr(access_logger, "warning", capture_log("warning"))
+    monkeypatch.setattr(access_logger, "error", capture_log("error"))
+
+    async def asgi_ok(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    client = TestClient(StructLogMiddleware(asgi_ok))
+
+    # Excluded paths — should NOT log
+    logged_calls.clear()
+    client.get("/health")
+    assert logged_calls == [], "Expected /health to be excluded from access log"
+
+    logged_calls.clear()
+    client.get("/health/ready")
+    assert logged_calls == [], "Expected /health/ready to be excluded (prefix match)"
+
+    logged_calls.clear()
+    client.get("/metrics")
+    assert logged_calls == [], "Expected /metrics to be excluded from access log"
+
+    # Non-excluded path — should log
+    logged_calls.clear()
+    client.get("/api/threads")
+    assert logged_calls == ["info"], "Expected /api/threads to be logged"
+
+
+def test_log_exclude_paths_still_logs_errors_for_excluded_paths(monkeypatch):
+    """4xx/5xx responses on excluded paths should still be logged."""
+    monkeypatch.setenv("LOG_EXCLUDE_PATHS", "/health")
+    reload_logging_modules()
+
+    from aegra_api.middleware.logger_middleware import StructLogMiddleware, access_logger
+
+    logged_calls: list[str] = []
+
+    def capture_log(method_name: str):
+        def _log(msg: str, *args, **kwargs) -> None:
+            logged_calls.append(method_name)
+
+        return _log
+
+    monkeypatch.setattr(access_logger, "info", capture_log("info"))
+    monkeypatch.setattr(access_logger, "warning", capture_log("warning"))
+    monkeypatch.setattr(access_logger, "error", capture_log("error"))
+
+    async def asgi_404(scope, receive, send):
+        await send({"type": "http.response.start", "status": 404, "headers": []})
+        await send({"type": "http.response.body", "body": b"not found"})
+
+    async def asgi_500(scope, receive, send):
+        await send({"type": "http.response.start", "status": 500, "headers": []})
+        await send({"type": "http.response.body", "body": b"error"})
+
+    # 404 on excluded path — should still log as warning
+    logged_calls.clear()
+    TestClient(StructLogMiddleware(asgi_404)).get("/health")
+    assert logged_calls == ["warning"], "Expected 404 on /health to be logged as warning"
+
+    # 500 on excluded path — should still log as error
+    logged_calls.clear()
+    TestClient(StructLogMiddleware(asgi_500)).get("/health")
+    assert logged_calls == ["error"], "Expected 500 on /health to be logged as error"
+
+
+def test_log_exclude_paths_empty_logs_everything(monkeypatch):
+    """When LOG_EXCLUDE_PATHS is empty (default), all paths are logged."""
+    monkeypatch.setenv("LOG_EXCLUDE_PATHS", "")
+    reload_logging_modules()
+
+    from aegra_api.middleware.logger_middleware import StructLogMiddleware, access_logger
+
+    logged_calls: list[str] = []
+
+    monkeypatch.setattr(access_logger, "info", lambda *a, **kw: logged_calls.append("info"))
+    monkeypatch.setattr(access_logger, "warning", lambda *a, **kw: logged_calls.append("warning"))
+    monkeypatch.setattr(access_logger, "error", lambda *a, **kw: logged_calls.append("error"))
+
+    async def asgi_ok(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    client = TestClient(StructLogMiddleware(asgi_ok))
+
+    logged_calls.clear()
+    client.get("/health")
+    assert logged_calls == ["info"], "Expected /health to be logged when no exclusions configured"
+
+
+def test_log_exclude_paths_parsing(monkeypatch):
+    """Test that LOG_EXCLUDE_PATHS is parsed correctly into a tuple."""
+    monkeypatch.setenv("LOG_EXCLUDE_PATHS", " /health , /ok ,, /metrics ")
+    reload_logging_modules()
+
+    from aegra_api.settings import AppSettings
+
+    s = AppSettings()
+    assert s.log_exclude_paths == ("/health", "/ok", "/metrics")
+
+
+def test_log_exclude_paths_parsing_empty(monkeypatch):
+    """Empty LOG_EXCLUDE_PATHS returns empty tuple."""
+    monkeypatch.setenv("LOG_EXCLUDE_PATHS", "")
+    reload_logging_modules()
+
+    from aegra_api.settings import AppSettings
+
+    s = AppSettings()
+    assert s.log_exclude_paths == ()
 
 
 def test_get_logging_config_and_setup(monkeypatch):

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -41,6 +41,7 @@ PORT=2026
 LOG_LEVEL=INFO
 ENV_MODE=LOCAL # DEVELOPMENT, PRODUCTION, LOCAL (PRODUCTION outputs JSON logs)
 LOG_VERBOSITY=standard # standard, verbose (verbose outputs request-id)
+# LOG_EXCLUDE_PATHS=/health,/ok  # Comma-separated path prefixes to skip in access logs
 
 # --- Redis (Event Broker & Job Queue) ---
 # Enable Redis for multi-instance SSE streaming and worker job dispatch.


### PR DESCRIPTION
## Description

  Health checks from load balancers and orchestrators (Kubernetes probes, AWS ALB, etc.) flood access logs in production, making it harder to spot meaningful traffic. This adds a `LOG_EXCLUDE_PATHS` environment variable to suppress access logging for configurable path prefixes.

  ## Type of Change

  - [x] `feat`: New feature

  ## Related Issues

  Closes #291

  ## Changes Made

  - Added `LOG_EXCLUDE_PATHS` setting to `AppSettings` with `computed_field` that parses comma-separated prefixes into a tuple
  - Updated `StructLogMiddleware` to skip access log entries for excluded paths on successful responses (2xx/3xx)
  - 4xx/5xx responses are always logged, even for excluded paths
  - Updated both `.env.example` files with the new variable

  ## Testing

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] E2E tests added/updated
  - [ ] Manual testing performed

  5 new unit tests:
  - Excluded paths with 200 skip access log (including prefix matching)
  - 404/500 on excluded paths still logged as warning/error
  - Empty config (default) logs everything
  - Parsing with spaces, empty elements, multiple prefixes

  ## Checklist

  - [x] Code follows project style (Ruff formatting)
  - [x] All linting checks pass (`make lint`)
  - [ ] Type checking passes (`make type-check`)
  - [x] All tests pass (`make test`)
  - [x] Documentation updated (if needed)
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] PR title follows Conventional Commits format

  ## Additional Notes

  Usage:
  ```env
  LOG_EXCLUDE_PATHS=/health,/metrics

  /health matches /health, /health/ready, /healthz, etc. (prefix matching).
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for LOG_EXCLUDE_PATHS to suppress access logs for configured path prefixes — successful (2xx) responses matching those prefixes are omitted; 4xx/5xx responses are still logged.

* **Tests**
  * Added unit and integration tests validating parsing of LOG_EXCLUDE_PATHS and middleware behavior for excluded vs non‑excluded paths and for error statuses.

* **Chores**
  * Documented the logging exclusion option in the environment template (commented example).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `LOG_EXCLUDE_PATHS`, a comma-separated list of path prefixes whose successful (status < 400) access-log entries are suppressed by `StructLogMiddleware`. Error responses (4xx/5xx) are always logged regardless of the setting, which is the right default for production observability.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped, well-tested, and has no effect on existing behaviour when LOG_EXCLUDE_PATHS is unset.

All remaining findings are P2 style nits (a misleading docstring and a redundant guard expression). The core logic is correct, the computed_field integrates cleanly with the existing settings pattern, and both .env.example files are updated in sync as required by project rules.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/middleware/logger_middleware.py | Adds prefix-based exclusion check in the finally block; correctly suppresses access logs for status < 400 and always logs 4xx/5xx. |
| libs/aegra-api/src/aegra_api/settings.py | Adds LOG_EXCLUDE_PATHS field and log_exclude_paths computed_field that parses comma-separated prefixes into a tuple; clean implementation. |
| libs/aegra-api/tests/unit/test_middleware/test_logger_middleware.py | Five new unit tests covering parsing, exclusion, error-always-logged, and empty-default cases. |
| libs/aegra-api/tests/integration/test_log_exclude_paths.py | Integration tests for full-app middleware behaviour; autouse fixture docstring is misleading (only tears down, not setup). |
| .env.example | Adds commented LOG_EXCLUDE_PATHS example in the Logging section, kept in sync with the CLI template. |
| libs/aegra-cli/src/aegra_cli/templates/env.example.template | Mirrors root .env.example — adds identical commented LOG_EXCLUDE_PATHS example; both env files are in sync as required. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTTP Request arrives] --> B[Record start_time]
    B --> C[Execute ASGI app]
    C --> D[Capture status_code]
    D --> E{status_code < 400?}
    E -->|No — 4xx/5xx| H[Always log as warning/error]
    E -->|Yes — 2xx/3xx| I{log_exclude_paths non-empty?}
    I -->|No, empty tuple| J[Log as info]
    I -->|Yes| K{path.startswith any prefix?}
    K -->|No match| J
    K -->|Match found| L[Skip access log entirely]
    H --> M[Done]
    J --> M
    L --> M
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `libs/aegra-api/tests/unit/test_middleware/test_logger_middleware.py`, line 8 ([link](https://github.com/ibbybuilds/aegra/blob/0fc5d0c802bd08630c4dbd97855ade38590ea432/libs/aegra-api/tests/unit/test_middleware/test_logger_middleware.py#L8)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing return type annotations on new helper functions**

   `reload_logging_modules` (line 8) and the nested `capture_log` (lines 63, 107) are both missing return type annotations. Per the project's strict type annotation policy, every function must annotate its return type — `-> None` for `reload_logging_modules` and `-> Callable[..., None]` for `capture_log`.

   

   For `capture_log`, the corrected signature would be:
   ```python
   from collections.abc import Callable

   def capture_log(method_name: str) -> Callable[..., None]:
       def _log(msg: str, *args: object, **kwargs: object) -> None:
           logged_calls.append(method_name)
       return _log
   ```

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Funit%2Ftest_middleware%2Ftest_logger_middleware.py%0ALine%3A%208%0A%0AComment%3A%0A**Missing%20return%20type%20annotations%20on%20new%20helper%20functions**%0A%0A%60reload_logging_modules%60%20%28line%208%29%20and%20the%20nested%20%60capture_log%60%20%28lines%2063%2C%20107%29%20are%20both%20missing%20return%20type%20annotations.%20Per%20the%20project's%20strict%20type%20annotation%20policy%2C%20every%20function%20must%20annotate%20its%20return%20type%20%E2%80%94%20%60-%3E%20None%60%20for%20%60reload_logging_modules%60%20and%20%60-%3E%20Callable%5B...%2C%20None%5D%60%20for%20%60capture_log%60.%0A%0A%60%60%60suggestion%0Adef%20reload_logging_modules%28%29%20-%3E%20None%3A%0A%60%60%60%0A%0AFor%20%60capture_log%60%2C%20the%20corrected%20signature%20would%20be%3A%0A%60%60%60python%0Afrom%20collections.abc%20import%20Callable%0A%0Adef%20capture_log%28method_name%3A%20str%29%20-%3E%20Callable%5B...%2C%20None%5D%3A%0A%20%20%20%20def%20_log%28msg%3A%20str%2C%20*args%3A%20object%2C%20**kwargs%3A%20object%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20logged_calls.append%28method_name%29%0A%20%20%20%20return%20_log%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ibbybuilds%2Faegra"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Funit%2Ftest_middleware%2Ftest_logger_middleware.py%0ALine%3A%208%0A%0AComment%3A%0A**Missing%20return%20type%20annotations%20on%20new%20helper%20functions**%0A%0A%60reload_logging_modules%60%20%28line%208%29%20and%20the%20nested%20%60capture_log%60%20%28lines%2063%2C%20107%29%20are%20both%20missing%20return%20type%20annotations.%20Per%20the%20project's%20strict%20type%20annotation%20policy%2C%20every%20function%20must%20annotate%20its%20return%20type%20%E2%80%94%20%60-%3E%20None%60%20for%20%60reload_logging_modules%60%20and%20%60-%3E%20Callable%5B...%2C%20None%5D%60%20for%20%60capture_log%60.%0A%0A%60%60%60suggestion%0Adef%20reload_logging_modules%28%29%20-%3E%20None%3A%0A%60%60%60%0A%0AFor%20%60capture_log%60%2C%20the%20corrected%20signature%20would%20be%3A%0A%60%60%60python%0Afrom%20collections.abc%20import%20Callable%0A%0Adef%20capture_log%28method_name%3A%20str%29%20-%3E%20Callable%5B...%2C%20None%5D%3A%0A%20%20%20%20def%20_log%28msg%3A%20str%2C%20*args%3A%20object%2C%20**kwargs%3A%20object%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20logged_calls.append%28method_name%29%0A%20%20%20%20return%20_log%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Funit%2Ftest_middleware%2Ftest_logger_middleware.py%0ALine%3A%208%0A%0AComment%3A%0A**Missing%20return%20type%20annotations%20on%20new%20helper%20functions**%0A%0A%60reload_logging_modules%60%20%28line%208%29%20and%20the%20nested%20%60capture_log%60%20%28lines%2063%2C%20107%29%20are%20both%20missing%20return%20type%20annotations.%20Per%20the%20project's%20strict%20type%20annotation%20policy%2C%20every%20function%20must%20annotate%20its%20return%20type%20%E2%80%94%20%60-%3E%20None%60%20for%20%60reload_logging_modules%60%20and%20%60-%3E%20Callable%5B...%2C%20None%5D%60%20for%20%60capture_log%60.%0A%0A%60%60%60suggestion%0Adef%20reload_logging_modules%28%29%20-%3E%20None%3A%0A%60%60%60%0A%0AFor%20%60capture_log%60%2C%20the%20corrected%20signature%20would%20be%3A%0A%60%60%60python%0Afrom%20collections.abc%20import%20Callable%0A%0Adef%20capture_log%28method_name%3A%20str%29%20-%3E%20Callable%5B...%2C%20None%5D%3A%0A%20%20%20%20def%20_log%28msg%3A%20str%2C%20*args%3A%20object%2C%20**kwargs%3A%20object%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20logged_calls.append%28method_name%29%0A%20%20%20%20return%20_log%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ibbybuilds%2Faegra"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Ftests%2Fintegration%2Ftest_log_exclude_paths.py%3A27-31%0A**Fixture%20docstring%20says%20%22before%20and%20after%22%20but%20only%20runs%20teardown**%0A%0AThe%20fixture%20yields%20with%20no%20setup%20code%2C%20so%20modules%20are%20only%20reloaded%20*after*%20each%20test.%20Each%20test%20compensates%20by%20calling%20%60_reload_modules%28%29%60%20explicitly%20at%20its%20top%20so%20the%20behaviour%20is%20correct%2C%20but%20the%20docstring%20is%20misleading.%20Either%20add%20a%20pre-yield%20call%20or%20update%20the%20comment.%0A%0A%60%60%60suggestion%0A%40pytest.fixture%28autouse%3DTrue%29%0Adef%20_isolate_module_state%28%29%20-%3E%20Generator%5BNone%2C%20None%2C%20None%5D%3A%0A%20%20%20%20%22%22%22Reload%20modules%20after%20each%20test%20to%20prevent%20cross-test%20leakage.%22%22%22%0A%20%20%20%20yield%0A%20%20%20%20_reload_modules%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmiddleware%2Flogger_middleware.py%3A64-65%0A**%60exclude_prefixes%20and%60%20guard%20is%20redundant**%0A%0A%60any%28%29%60%20on%20an%20empty%20tuple%20already%20returns%20%60False%60%2C%20so%20the%20%60exclude_prefixes%20and%60%20short-circuit%20is%20unnecessary%20and%20adds%20minor%20cognitive%20overhead%20without%20changing%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20is_excluded%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20status_code%20%3C%20400%20and%20any%28path.startswith%28prefix%29%20for%20prefix%20in%20exclude_prefixes%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A&repo=ibbybuilds%2Faegra"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Ftests%2Fintegration%2Ftest_log_exclude_paths.py%3A27-31%0A**Fixture%20docstring%20says%20%22before%20and%20after%22%20but%20only%20runs%20teardown**%0A%0AThe%20fixture%20yields%20with%20no%20setup%20code%2C%20so%20modules%20are%20only%20reloaded%20*after*%20each%20test.%20Each%20test%20compensates%20by%20calling%20%60_reload_modules%28%29%60%20explicitly%20at%20its%20top%20so%20the%20behaviour%20is%20correct%2C%20but%20the%20docstring%20is%20misleading.%20Either%20add%20a%20pre-yield%20call%20or%20update%20the%20comment.%0A%0A%60%60%60suggestion%0A%40pytest.fixture%28autouse%3DTrue%29%0Adef%20_isolate_module_state%28%29%20-%3E%20Generator%5BNone%2C%20None%2C%20None%5D%3A%0A%20%20%20%20%22%22%22Reload%20modules%20after%20each%20test%20to%20prevent%20cross-test%20leakage.%22%22%22%0A%20%20%20%20yield%0A%20%20%20%20_reload_modules%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmiddleware%2Flogger_middleware.py%3A64-65%0A**%60exclude_prefixes%20and%60%20guard%20is%20redundant**%0A%0A%60any%28%29%60%20on%20an%20empty%20tuple%20already%20returns%20%60False%60%2C%20so%20the%20%60exclude_prefixes%20and%60%20short-circuit%20is%20unnecessary%20and%20adds%20minor%20cognitive%20overhead%20without%20changing%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20is_excluded%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20status_code%20%3C%20400%20and%20any%28path.startswith%28prefix%29%20for%20prefix%20in%20exclude_prefixes%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Ftests%2Fintegration%2Ftest_log_exclude_paths.py%3A27-31%0A**Fixture%20docstring%20says%20%22before%20and%20after%22%20but%20only%20runs%20teardown**%0A%0AThe%20fixture%20yields%20with%20no%20setup%20code%2C%20so%20modules%20are%20only%20reloaded%20*after*%20each%20test.%20Each%20test%20compensates%20by%20calling%20%60_reload_modules%28%29%60%20explicitly%20at%20its%20top%20so%20the%20behaviour%20is%20correct%2C%20but%20the%20docstring%20is%20misleading.%20Either%20add%20a%20pre-yield%20call%20or%20update%20the%20comment.%0A%0A%60%60%60suggestion%0A%40pytest.fixture%28autouse%3DTrue%29%0Adef%20_isolate_module_state%28%29%20-%3E%20Generator%5BNone%2C%20None%2C%20None%5D%3A%0A%20%20%20%20%22%22%22Reload%20modules%20after%20each%20test%20to%20prevent%20cross-test%20leakage.%22%22%22%0A%20%20%20%20yield%0A%20%20%20%20_reload_modules%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmiddleware%2Flogger_middleware.py%3A64-65%0A**%60exclude_prefixes%20and%60%20guard%20is%20redundant**%0A%0A%60any%28%29%60%20on%20an%20empty%20tuple%20already%20returns%20%60False%60%2C%20so%20the%20%60exclude_prefixes%20and%60%20short-circuit%20is%20unnecessary%20and%20adds%20minor%20cognitive%20overhead%20without%20changing%20behaviour.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20is_excluded%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20status_code%20%3C%20400%20and%20any%28path.startswith%28prefix%29%20for%20prefix%20in%20exclude_prefixes%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A&repo=ibbybuilds%2Faegra"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<sub>Reviews (5): Last reviewed commit: ["fix(tests): add autouse fixture to preve..."](https://github.com/ibbybuilds/aegra/commit/0e144ed6afa7bccafcab031b50c36dafdbd2a6b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27577119)</sub>

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->