### PR TITLE
feat(observability): add optional Prometheus metrics endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,10 @@ OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=...
 # TOGETHER_API_KEY=...
 
+# --- Prometheus Metrics ---
+# Expose /metrics endpoint with HTTP request metrics in Prometheus format.
+ENABLE_PROMETHEUS_METRICS=false
+
 # --- Observability (OpenTelemetry) ---
 # Unified config for tracing. Supports multiple targets via Fan-out.
 OTEL_SERVICE_NAME=aegra-backend

--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,8 @@ OPENAI_API_KEY=sk-...
 
 # --- Prometheus Metrics ---
 # Expose /metrics endpoint with HTTP request metrics in Prometheus format.
+# Note: /metrics is unauthenticated by design (scrapers don't support app-level auth).
+# Use network-level controls to restrict access if needed.
 ENABLE_PROMETHEUS_METRICS=false
 
 # --- Observability (OpenTelemetry) ---

--- a/docs/guides/observability.mdx
+++ b/docs/guides/observability.mdx
@@ -107,3 +107,15 @@ The main variables you'll need:
 | `OTEL_CONSOLE_EXPORT` | Log traces to console (`true`/`false`) |
 
 Each provider has its own set of variables (endpoints, API keys). See the [environment variables reference](/reference/environment-variables) for the full list including all Langfuse, Phoenix, and generic OTLP variables.
+
+## Prometheus metrics
+
+For infrastructure-level monitoring (request rates, latency, error rates), Aegra supports an optional Prometheus metrics endpoint alongside OpenTelemetry tracing.
+
+```bash
+ENABLE_PROMETHEUS_METRICS=true
+```
+
+This exposes a `/metrics` endpoint with standard HTTP request metrics in Prometheus exposition format. Scrape it with any Prometheus-compatible collector and visualize with Grafana.
+
+See the [environment variables reference](/reference/environment-variables#prometheus-metrics) for details.

--- a/docs/guides/observability.mdx
+++ b/docs/guides/observability.mdx
@@ -118,4 +118,6 @@ ENABLE_PROMETHEUS_METRICS=true
 
 This exposes a `/metrics` endpoint with standard HTTP request metrics in Prometheus exposition format. Scrape it with any Prometheus-compatible collector and visualize with Grafana.
 
+The `/metrics` endpoint is **not** protected by Aegra's authentication middleware. This is intentional — Prometheus scrapers typically do not support application-level auth. If you need to restrict access, use network-level controls (firewall rules, internal load-balancer listeners, etc.).
+
 See the [environment variables reference](/reference/environment-variables#prometheus-metrics) for details.

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -127,6 +127,14 @@ In dev mode (`REDIS_BROKER_ENABLED=false`), runs execute as in-process asyncio t
 
 Total capacity per instance = `WORKER_COUNT` x `N_JOBS_PER_WORKER` (default: 30 concurrent runs).
 
+## Prometheus metrics
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_PROMETHEUS_METRICS` | `false` | Expose `/metrics` endpoint with HTTP request metrics in Prometheus format |
+
+When enabled, a `/metrics` endpoint serves standard HTTP request metrics (request count, latency histograms, in-progress requests) using [prometheus-fastapi-instrumentator](https://github.com/trallnag/prometheus-fastapi-instrumentator). Compatible with any Prometheus/Grafana stack.
+
 ## Observability (OpenTelemetry)
 
 | Variable | Default | Description |

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = [
     "opentelemetry-exporter-otlp>=1.39.1",
     "openinference-instrumentation-langchain>=0.1.58",
 
+    # Metrics
+    "prometheus-fastapi-instrumentator>=7.1.0",
+
     # Utils
     "structlog>=25.4.0",
     "asgi-correlation-id>=4.3.4",

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -30,6 +30,7 @@ from aegra_api.core.route_merger import (
 )
 from aegra_api.middleware import ContentTypeFixMiddleware, StructLogMiddleware
 from aegra_api.models.errors import AgentProtocolError, get_error_type
+from aegra_api.observability.metrics import setup_prometheus_metrics
 from aegra_api.observability.setup import setup_observability
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.executor import executor
@@ -355,6 +356,8 @@ def create_app() -> FastAPI:
             application.exception_handler(exc_type)(handler)
 
         application.get("/")(root_handler)
+
+    setup_prometheus_metrics(application)
 
     return application
 

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -17,7 +17,7 @@ from aegra_api.api.runs import router as runs_router
 from aegra_api.api.stateless_runs import router as stateless_runs_router
 from aegra_api.api.store import router as store_router
 from aegra_api.api.threads import router as threads_router
-from aegra_api.config import HttpConfig, get_config_dir, load_http_config
+from aegra_api.config import CorsConfig, HttpConfig, get_config_dir, load_http_config
 from aegra_api.core.app_loader import load_custom_app
 from aegra_api.core.auth_deps import auth_dependency
 from aegra_api.core.database import db_manager
@@ -216,7 +216,7 @@ def _apply_auth_to_routes(app: FastAPI, auth_deps: list[Any]) -> None:
     logger.info("Applied authentication dependency to custom routes")
 
 
-def _add_cors_middleware(app: FastAPI, cors_config: dict[str, Any] | None) -> None:
+def _add_cors_middleware(app: FastAPI, cors_config: CorsConfig | None) -> None:
     """Add CORS middleware with config or defaults.
 
     When ``allow_origins`` is ``["*"]`` (the default), ``allow_credentials``
@@ -254,7 +254,7 @@ def _add_cors_middleware(app: FastAPI, cors_config: dict[str, Any] | None) -> No
         )
 
 
-def _add_common_middleware(app: FastAPI, cors_config: dict[str, Any] | None) -> None:
+def _add_common_middleware(app: FastAPI, cors_config: CorsConfig | None) -> None:
     """Add common middleware stack in correct order.
 
     Middleware runs in reverse registration order, so we register:
@@ -302,7 +302,7 @@ def create_app() -> FastAPI:
         Configured FastAPI application instance
     """
     http_config: HttpConfig | None = load_http_config()
-    cors_config = http_config.get("cors") if http_config else None
+    cors_config: CorsConfig | None = http_config.get("cors") if http_config else None
 
     # Try to load custom app if configured
     user_app = None

--- a/libs/aegra-api/src/aegra_api/middleware/logger_middleware.py
+++ b/libs/aegra-api/src/aegra_api/middleware/logger_middleware.py
@@ -18,7 +18,7 @@ class AccessInfo(TypedDict, total=False):
 
 
 class StructLogMiddleware:
-    def __init__(self, app: ASGIApp):
+    def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:

--- a/libs/aegra-api/src/aegra_api/observability/metrics.py
+++ b/libs/aegra-api/src/aegra_api/observability/metrics.py
@@ -5,6 +5,7 @@ When enabled, exposes a ``/metrics`` endpoint with standard HTTP and
 Python runtime metrics in Prometheus exposition format.
 """
 
+import prometheus_client
 import structlog
 from fastapi import FastAPI
 from prometheus_fastapi_instrumentator import Instrumentator
@@ -14,10 +15,25 @@ from aegra_api.settings import settings
 logger = structlog.getLogger(__name__)
 
 
-def setup_prometheus_metrics(app: FastAPI) -> None:
+def setup_prometheus_metrics(
+    app: FastAPI,
+    registry: prometheus_client.CollectorRegistry | None = None,
+) -> None:
     """Conditionally attach Prometheus instrumentator to the app.
 
     No-op when ``ENABLE_PROMETHEUS_METRICS`` is false.
+
+    Args:
+        app: FastAPI application instance.
+        registry: Optional Prometheus collector registry. When provided, metrics
+            are collected into this registry instead of the global default.
+            Primarily useful in tests to avoid cross-test pollution.
+
+    Note:
+        The ``/metrics`` endpoint is **not** protected by Aegra's authentication
+        middleware. This is intentional — Prometheus scrapers typically do not
+        support application-level auth. If the endpoint must be restricted, use
+        network-level controls (firewall rules, internal load-balancer, etc.).
     """
     if not settings.observability.ENABLE_PROMETHEUS_METRICS:
         return
@@ -26,6 +42,7 @@ def setup_prometheus_metrics(app: FastAPI) -> None:
         should_group_status_codes=False,
         should_ignore_untemplated=True,
         excluded_handlers=["/health", "/ready", "/live", "/info", "/metrics", "/docs", "/redoc", "/openapi.json"],
+        registry=registry,
     )
     instrumentator.instrument(app)
     instrumentator.expose(app, endpoint="/metrics", include_in_schema=False)

--- a/libs/aegra-api/src/aegra_api/observability/metrics.py
+++ b/libs/aegra-api/src/aegra_api/observability/metrics.py
@@ -1,0 +1,32 @@
+"""Optional Prometheus metrics via prometheus-fastapi-instrumentator.
+
+Controlled by ``ENABLE_PROMETHEUS_METRICS`` env var (default: false).
+When enabled, exposes a ``/metrics`` endpoint with standard HTTP and
+Python runtime metrics in Prometheus exposition format.
+"""
+
+import structlog
+from fastapi import FastAPI
+from prometheus_fastapi_instrumentator import Instrumentator
+
+from aegra_api.settings import settings
+
+logger = structlog.getLogger(__name__)
+
+
+def setup_prometheus_metrics(app: FastAPI) -> None:
+    """Conditionally attach Prometheus instrumentator to the app.
+
+    No-op when ``ENABLE_PROMETHEUS_METRICS`` is false.
+    """
+    if not settings.observability.ENABLE_PROMETHEUS_METRICS:
+        return
+
+    instrumentator = Instrumentator(
+        should_group_status_codes=False,
+        should_ignore_untemplated=True,
+        excluded_handlers=["/health", "/ready", "/live", "/info", "/metrics", "/docs", "/redoc", "/openapi.json"],
+    )
+    instrumentator.instrument(app)
+    instrumentator.expose(app, endpoint="/metrics", include_in_schema=False)
+    logger.info("Prometheus metrics enabled at /metrics")

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -135,6 +135,9 @@ class ObservabilitySettings(EnvBase):
     OTEL_EXPORTER_OTLP_ENDPOINT: str | None = None
     OTEL_EXPORTER_OTLP_HEADERS: str | None = None
 
+    # --- Prometheus Metrics ---
+    ENABLE_PROMETHEUS_METRICS: bool = False
+
     # --- Langfuse Specifics ---
     LANGFUSE_BASE_URL: str = "http://localhost:3000"
     LANGFUSE_PUBLIC_KEY: str | None = None

--- a/libs/aegra-api/tests/e2e/test_prometheus_metrics.py
+++ b/libs/aegra-api/tests/e2e/test_prometheus_metrics.py
@@ -13,6 +13,9 @@ from aegra_api.settings import settings
 @pytest.mark.asyncio
 async def test_metrics_endpoint_returns_prometheus_format() -> None:
     """Test that /metrics returns Prometheus exposition text from a real server."""
+    if not settings.observability.ENABLE_PROMETHEUS_METRICS:
+        pytest.skip("ENABLE_PROMETHEUS_METRICS=false; /metrics endpoint is intentionally disabled")
+
     server_url = settings.app.SERVER_URL
 
     async with httpx.AsyncClient(base_url=server_url, timeout=5.0) as client:
@@ -24,4 +27,5 @@ async def test_metrics_endpoint_returns_prometheus_format() -> None:
         assert "text/plain" in response.headers["content-type"]
 
         body = response.text
-        assert "http_request_duration" in body or "http_requests" in body
+        assert "# HELP" in body
+        assert "# TYPE" in body

--- a/libs/aegra-api/tests/e2e/test_prometheus_metrics.py
+++ b/libs/aegra-api/tests/e2e/test_prometheus_metrics.py
@@ -1,0 +1,27 @@
+"""E2E tests for the Prometheus /metrics endpoint.
+
+Requires a running server with ENABLE_PROMETHEUS_METRICS=true.
+"""
+
+import httpx
+import pytest
+
+from aegra_api.settings import settings
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_metrics_endpoint_returns_prometheus_format() -> None:
+    """Test that /metrics returns Prometheus exposition text from a real server."""
+    server_url = settings.app.SERVER_URL
+
+    async with httpx.AsyncClient(base_url=server_url, timeout=5.0) as client:
+        # Make a request so there's something to report
+        await client.get("/health")
+
+        response = await client.get("/metrics")
+        assert response.status_code == 200
+        assert "text/plain" in response.headers["content-type"]
+
+        body = response.text
+        assert "http_request_duration" in body or "http_requests" in body

--- a/libs/aegra-api/tests/integration/test_prometheus_metrics.py
+++ b/libs/aegra-api/tests/integration/test_prometheus_metrics.py
@@ -1,0 +1,76 @@
+"""Integration tests for the Prometheus /metrics endpoint."""
+
+import contextlib
+from unittest.mock import patch
+
+import prometheus_client
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aegra_api.observability.metrics import setup_prometheus_metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset_prometheus_registry() -> None:
+    """Reset the default Prometheus registry between tests.
+
+    prometheus-fastapi-instrumentator registers collectors on the default
+    global registry. Without a reset, the second test that calls
+    ``setup_prometheus_metrics`` raises ``ValueError: Duplicated ...``.
+    """
+    collectors = list(prometheus_client.REGISTRY._names_to_collectors.values())
+    for collector in collectors:
+        with contextlib.suppress(Exception):
+            prometheus_client.REGISTRY.unregister(collector)
+
+
+def _make_app() -> FastAPI:
+    """Create a minimal FastAPI app with Prometheus metrics enabled."""
+    app = FastAPI()
+
+    @app.get("/hello")
+    def hello() -> dict[str, str]:
+        return {"msg": "world"}
+
+    with patch("aegra_api.observability.metrics.settings") as mock_settings:
+        mock_settings.observability.ENABLE_PROMETHEUS_METRICS = True
+        setup_prometheus_metrics(app)
+
+    return app
+
+
+def test_metrics_endpoint_returns_prometheus_format() -> None:
+    """Test that /metrics returns text in Prometheus exposition format."""
+    app = _make_app()
+    client = TestClient(app)
+
+    # Make a request so there's something to report
+    response = client.get("/hello")
+    assert response.status_code == 200
+
+    # Scrape metrics
+    metrics_response = client.get("/metrics")
+    assert metrics_response.status_code == 200
+    assert "text/plain" in metrics_response.headers["content-type"]
+
+    body = metrics_response.text
+    # Should contain standard HTTP metrics from the instrumentator
+    assert "http_request_duration" in body or "http_requests" in body
+
+
+def test_metrics_endpoint_not_exposed_when_disabled() -> None:
+    """Test that /metrics is not available when metrics are disabled."""
+    app = FastAPI()
+
+    @app.get("/hello")
+    def hello() -> dict[str, str]:
+        return {"msg": "world"}
+
+    with patch("aegra_api.observability.metrics.settings") as mock_settings:
+        mock_settings.observability.ENABLE_PROMETHEUS_METRICS = False
+        setup_prometheus_metrics(app)
+
+    client = TestClient(app)
+    response = client.get("/metrics")
+    assert response.status_code == 404

--- a/libs/aegra-api/tests/integration/test_prometheus_metrics.py
+++ b/libs/aegra-api/tests/integration/test_prometheus_metrics.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from aegra_api.observability import metrics as metrics_module
 from aegra_api.observability.metrics import setup_prometheus_metrics
 
 
@@ -25,10 +26,7 @@ def _make_app(
     def hello() -> dict[str, str]:
         return {"msg": "world"}
 
-    monkeypatch.setattr(
-        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
-        True,
-    )
+    monkeypatch.setattr(metrics_module.settings.observability, "ENABLE_PROMETHEUS_METRICS", True)
     setup_prometheus_metrics(app, registry=registry)
     return app
 
@@ -65,10 +63,7 @@ def test_metrics_endpoint_not_exposed_when_disabled(
     def hello() -> dict[str, str]:
         return {"msg": "world"}
 
-    monkeypatch.setattr(
-        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
-        False,
-    )
+    monkeypatch.setattr(metrics_module.settings.observability, "ENABLE_PROMETHEUS_METRICS", False)
     setup_prometheus_metrics(app)
 
     client = TestClient(app)

--- a/libs/aegra-api/tests/integration/test_prometheus_metrics.py
+++ b/libs/aegra-api/tests/integration/test_prometheus_metrics.py
@@ -1,8 +1,5 @@
 """Integration tests for the Prometheus /metrics endpoint."""
 
-import contextlib
-from unittest.mock import patch
-
 import prometheus_client
 import pytest
 from fastapi import FastAPI
@@ -11,21 +8,16 @@ from fastapi.testclient import TestClient
 from aegra_api.observability.metrics import setup_prometheus_metrics
 
 
-@pytest.fixture(autouse=True)
-def _reset_prometheus_registry() -> None:
-    """Reset the default Prometheus registry between tests.
-
-    prometheus-fastapi-instrumentator registers collectors on the default
-    global registry. Without a reset, the second test that calls
-    ``setup_prometheus_metrics`` raises ``ValueError: Duplicated ...``.
-    """
-    collectors = list(prometheus_client.REGISTRY._names_to_collectors.values())
-    for collector in collectors:
-        with contextlib.suppress(Exception):
-            prometheus_client.REGISTRY.unregister(collector)
+@pytest.fixture
+def fresh_registry() -> prometheus_client.CollectorRegistry:
+    """Return an isolated Prometheus registry to avoid global state leaks."""
+    return prometheus_client.CollectorRegistry()
 
 
-def _make_app() -> FastAPI:
+def _make_app(
+    monkeypatch: pytest.MonkeyPatch,
+    registry: prometheus_client.CollectorRegistry,
+) -> FastAPI:
     """Create a minimal FastAPI app with Prometheus metrics enabled."""
     app = FastAPI()
 
@@ -33,16 +25,20 @@ def _make_app() -> FastAPI:
     def hello() -> dict[str, str]:
         return {"msg": "world"}
 
-    with patch("aegra_api.observability.metrics.settings") as mock_settings:
-        mock_settings.observability.ENABLE_PROMETHEUS_METRICS = True
-        setup_prometheus_metrics(app)
-
+    monkeypatch.setattr(
+        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
+        True,
+    )
+    setup_prometheus_metrics(app, registry=registry)
     return app
 
 
-def test_metrics_endpoint_returns_prometheus_format() -> None:
+def test_metrics_endpoint_returns_prometheus_format(
+    monkeypatch: pytest.MonkeyPatch,
+    fresh_registry: prometheus_client.CollectorRegistry,
+) -> None:
     """Test that /metrics returns text in Prometheus exposition format."""
-    app = _make_app()
+    app = _make_app(monkeypatch, fresh_registry)
     client = TestClient(app)
 
     # Make a request so there's something to report
@@ -59,7 +55,9 @@ def test_metrics_endpoint_returns_prometheus_format() -> None:
     assert "http_request_duration" in body or "http_requests" in body
 
 
-def test_metrics_endpoint_not_exposed_when_disabled() -> None:
+def test_metrics_endpoint_not_exposed_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Test that /metrics is not available when metrics are disabled."""
     app = FastAPI()
 
@@ -67,9 +65,11 @@ def test_metrics_endpoint_not_exposed_when_disabled() -> None:
     def hello() -> dict[str, str]:
         return {"msg": "world"}
 
-    with patch("aegra_api.observability.metrics.settings") as mock_settings:
-        mock_settings.observability.ENABLE_PROMETHEUS_METRICS = False
-        setup_prometheus_metrics(app)
+    monkeypatch.setattr(
+        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
+        False,
+    )
+    setup_prometheus_metrics(app)
 
     client = TestClient(app)
     response = client.get("/metrics")

--- a/libs/aegra-api/tests/unit/test_observability/test_metrics.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_metrics.py
@@ -1,83 +1,105 @@
 """Unit tests for the Prometheus metrics setup module."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import prometheus_client
 import pytest
 from fastapi import FastAPI
 
 from aegra_api.observability.metrics import setup_prometheus_metrics
 
 
-class TestSetupPrometheusMetrics:
-    """Tests for the setup_prometheus_metrics function."""
+@pytest.fixture
+def app() -> FastAPI:
+    return FastAPI()
 
-    @pytest.fixture
-    def app(self) -> FastAPI:
-        return FastAPI()
 
-    def test_noop_when_disabled(self, app: FastAPI) -> None:
-        """Test that no instrumentation is attached when metrics are disabled."""
-        with patch("aegra_api.observability.metrics.settings") as mock_settings:
-            mock_settings.observability.ENABLE_PROMETHEUS_METRICS = False
+@pytest.fixture
+def fresh_registry() -> prometheus_client.CollectorRegistry:
+    return prometheus_client.CollectorRegistry()
 
-            setup_prometheus_metrics(app)
 
-        # No /metrics route should exist
-        paths = {route.path for route in app.routes if hasattr(route, "path")}
-        assert "/metrics" not in paths
+def test_noop_when_disabled(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that no instrumentation is attached when metrics are disabled."""
+    monkeypatch.setattr(
+        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
+        False,
+    )
+    setup_prometheus_metrics(app)
 
-    def test_exposes_metrics_endpoint_when_enabled(self, app: FastAPI) -> None:
-        """Test that /metrics endpoint is added when metrics are enabled."""
-        with patch("aegra_api.observability.metrics.settings") as mock_settings:
-            mock_settings.observability.ENABLE_PROMETHEUS_METRICS = True
+    paths = {route.path for route in app.routes if hasattr(route, "path")}
+    assert "/metrics" not in paths
 
-            setup_prometheus_metrics(app)
 
-        paths = {route.path for route in app.routes if hasattr(route, "path")}
-        assert "/metrics" in paths
+def test_exposes_metrics_endpoint_when_enabled(
+    app: FastAPI,
+    fresh_registry: prometheus_client.CollectorRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that /metrics endpoint is added when metrics are enabled."""
+    monkeypatch.setattr(
+        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
+        True,
+    )
+    setup_prometheus_metrics(app, registry=fresh_registry)
 
-    def test_excludes_health_and_docs(self, app: FastAPI) -> None:
-        """Test that the instrumentator excludes health and docs endpoints."""
-        with (
-            patch("aegra_api.observability.metrics.settings") as mock_settings,
-            patch("aegra_api.observability.metrics.Instrumentator") as mock_cls,
-        ):
-            mock_settings.observability.ENABLE_PROMETHEUS_METRICS = True
-            mock_instance = MagicMock()
-            mock_cls.return_value = mock_instance
-            mock_instance.instrument.return_value = mock_instance
+    paths = {route.path for route in app.routes if hasattr(route, "path")}
+    assert "/metrics" in paths
 
-            setup_prometheus_metrics(app)
 
-            mock_cls.assert_called_once_with(
-                should_group_status_codes=False,
-                should_ignore_untemplated=True,
-                excluded_handlers=[
-                    "/health",
-                    "/ready",
-                    "/live",
-                    "/info",
-                    "/metrics",
-                    "/docs",
-                    "/redoc",
-                    "/openapi.json",
-                ],
-            )
-            mock_instance.instrument.assert_called_once_with(app)
-            mock_instance.expose.assert_called_once_with(
-                app,
-                endpoint="/metrics",
-                include_in_schema=False,
-            )
+def test_excludes_health_and_docs(
+    app: FastAPI,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that the instrumentator excludes health and docs endpoints."""
+    monkeypatch.setattr(
+        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
+        True,
+    )
+    mock_cls = MagicMock()
+    mock_instance = MagicMock()
+    mock_cls.return_value = mock_instance
+    mock_instance.instrument.return_value = mock_instance
+    monkeypatch.setattr("aegra_api.observability.metrics.Instrumentator", mock_cls)
 
-    def test_logs_when_enabled(self, app: FastAPI) -> None:
-        """Test that a log message is emitted when metrics are enabled."""
-        with (
-            patch("aegra_api.observability.metrics.settings") as mock_settings,
-            patch("aegra_api.observability.metrics.logger") as mock_logger,
-        ):
-            mock_settings.observability.ENABLE_PROMETHEUS_METRICS = True
+    setup_prometheus_metrics(app)
 
-            setup_prometheus_metrics(app)
+    mock_cls.assert_called_once_with(
+        should_group_status_codes=False,
+        should_ignore_untemplated=True,
+        excluded_handlers=[
+            "/health",
+            "/ready",
+            "/live",
+            "/info",
+            "/metrics",
+            "/docs",
+            "/redoc",
+            "/openapi.json",
+        ],
+        registry=None,
+    )
+    mock_instance.instrument.assert_called_once_with(app)
+    mock_instance.expose.assert_called_once_with(
+        app,
+        endpoint="/metrics",
+        include_in_schema=False,
+    )
 
-            mock_logger.info.assert_called_once_with("Prometheus metrics enabled at /metrics")
+
+def test_logs_when_enabled(
+    app: FastAPI,
+    fresh_registry: prometheus_client.CollectorRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a log message is emitted when metrics are enabled."""
+    monkeypatch.setattr(
+        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
+        True,
+    )
+    mock_logger = MagicMock()
+    monkeypatch.setattr("aegra_api.observability.metrics.logger", mock_logger)
+
+    setup_prometheus_metrics(app, registry=fresh_registry)
+
+    mock_logger.info.assert_called_once_with("Prometheus metrics enabled at /metrics")

--- a/libs/aegra-api/tests/unit/test_observability/test_metrics.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_metrics.py
@@ -6,6 +6,7 @@ import prometheus_client
 import pytest
 from fastapi import FastAPI
 
+from aegra_api.observability import metrics as metrics_module
 from aegra_api.observability.metrics import setup_prometheus_metrics
 
 
@@ -21,10 +22,7 @@ def fresh_registry() -> prometheus_client.CollectorRegistry:
 
 def test_noop_when_disabled(app: FastAPI, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that no instrumentation is attached when metrics are disabled."""
-    monkeypatch.setattr(
-        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
-        False,
-    )
+    monkeypatch.setattr(metrics_module.settings.observability, "ENABLE_PROMETHEUS_METRICS", False)
     setup_prometheus_metrics(app)
 
     paths = {route.path for route in app.routes if hasattr(route, "path")}
@@ -37,10 +35,7 @@ def test_exposes_metrics_endpoint_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that /metrics endpoint is added when metrics are enabled."""
-    monkeypatch.setattr(
-        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
-        True,
-    )
+    monkeypatch.setattr(metrics_module.settings.observability, "ENABLE_PROMETHEUS_METRICS", True)
     setup_prometheus_metrics(app, registry=fresh_registry)
 
     paths = {route.path for route in app.routes if hasattr(route, "path")}
@@ -52,15 +47,12 @@ def test_excludes_health_and_docs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that the instrumentator excludes health and docs endpoints."""
-    monkeypatch.setattr(
-        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
-        True,
-    )
+    monkeypatch.setattr(metrics_module.settings.observability, "ENABLE_PROMETHEUS_METRICS", True)
     mock_cls = MagicMock()
     mock_instance = MagicMock()
     mock_cls.return_value = mock_instance
     mock_instance.instrument.return_value = mock_instance
-    monkeypatch.setattr("aegra_api.observability.metrics.Instrumentator", mock_cls)
+    monkeypatch.setattr(metrics_module, "Instrumentator", mock_cls)
 
     setup_prometheus_metrics(app)
 
@@ -93,12 +85,9 @@ def test_logs_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test that a log message is emitted when metrics are enabled."""
-    monkeypatch.setattr(
-        "aegra_api.observability.metrics.settings.observability.ENABLE_PROMETHEUS_METRICS",
-        True,
-    )
+    monkeypatch.setattr(metrics_module.settings.observability, "ENABLE_PROMETHEUS_METRICS", True)
     mock_logger = MagicMock()
-    monkeypatch.setattr("aegra_api.observability.metrics.logger", mock_logger)
+    monkeypatch.setattr(metrics_module, "logger", mock_logger)
 
     setup_prometheus_metrics(app, registry=fresh_registry)
 

--- a/libs/aegra-api/tests/unit/test_observability/test_metrics.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_metrics.py
@@ -1,0 +1,83 @@
+"""Unit tests for the Prometheus metrics setup module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+
+from aegra_api.observability.metrics import setup_prometheus_metrics
+
+
+class TestSetupPrometheusMetrics:
+    """Tests for the setup_prometheus_metrics function."""
+
+    @pytest.fixture
+    def app(self) -> FastAPI:
+        return FastAPI()
+
+    def test_noop_when_disabled(self, app: FastAPI) -> None:
+        """Test that no instrumentation is attached when metrics are disabled."""
+        with patch("aegra_api.observability.metrics.settings") as mock_settings:
+            mock_settings.observability.ENABLE_PROMETHEUS_METRICS = False
+
+            setup_prometheus_metrics(app)
+
+        # No /metrics route should exist
+        paths = {route.path for route in app.routes if hasattr(route, "path")}
+        assert "/metrics" not in paths
+
+    def test_exposes_metrics_endpoint_when_enabled(self, app: FastAPI) -> None:
+        """Test that /metrics endpoint is added when metrics are enabled."""
+        with patch("aegra_api.observability.metrics.settings") as mock_settings:
+            mock_settings.observability.ENABLE_PROMETHEUS_METRICS = True
+
+            setup_prometheus_metrics(app)
+
+        paths = {route.path for route in app.routes if hasattr(route, "path")}
+        assert "/metrics" in paths
+
+    def test_excludes_health_and_docs(self, app: FastAPI) -> None:
+        """Test that the instrumentator excludes health and docs endpoints."""
+        with (
+            patch("aegra_api.observability.metrics.settings") as mock_settings,
+            patch("aegra_api.observability.metrics.Instrumentator") as mock_cls,
+        ):
+            mock_settings.observability.ENABLE_PROMETHEUS_METRICS = True
+            mock_instance = MagicMock()
+            mock_cls.return_value = mock_instance
+            mock_instance.instrument.return_value = mock_instance
+
+            setup_prometheus_metrics(app)
+
+            mock_cls.assert_called_once_with(
+                should_group_status_codes=False,
+                should_ignore_untemplated=True,
+                excluded_handlers=[
+                    "/health",
+                    "/ready",
+                    "/live",
+                    "/info",
+                    "/metrics",
+                    "/docs",
+                    "/redoc",
+                    "/openapi.json",
+                ],
+            )
+            mock_instance.instrument.assert_called_once_with(app)
+            mock_instance.expose.assert_called_once_with(
+                app,
+                endpoint="/metrics",
+                include_in_schema=False,
+            )
+
+    def test_logs_when_enabled(self, app: FastAPI) -> None:
+        """Test that a log message is emitted when metrics are enabled."""
+        with (
+            patch("aegra_api.observability.metrics.settings") as mock_settings,
+            patch("aegra_api.observability.metrics.logger") as mock_logger,
+        ):
+            mock_settings.observability.ENABLE_PROMETHEUS_METRICS = True
+
+            setup_prometheus_metrics(app)
+
+            mock_logger.info.assert_called_once_with("Prometheus metrics enabled at /metrics")

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -69,6 +69,10 @@ OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=...
 # TOGETHER_API_KEY=...
 
+# --- Prometheus Metrics ---
+# Expose /metrics endpoint with HTTP request metrics in Prometheus format.
+ENABLE_PROMETHEUS_METRICS=false
+
 # --- Observability (OpenTelemetry) ---
 # Unified config for tracing. Supports multiple targets via Fan-out.
 OTEL_SERVICE_NAME=aegra-backend

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -71,6 +71,8 @@ OPENAI_API_KEY=sk-...
 
 # --- Prometheus Metrics ---
 # Expose /metrics endpoint with HTTP request metrics in Prometheus format.
+# Note: /metrics is unauthenticated by design (scrapers don't support app-level auth).
+# Use network-level controls to restrict access if needed.
 ENABLE_PROMETHEUS_METRICS=false
 
 # --- Observability (OpenTelemetry) ---

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-sdk" },
+    { name = "prometheus-fastapi-instrumentator" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -68,6 +69,7 @@ requires-dist = [
     { name = "opentelemetry-api", specifier = ">=1.39.1" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.39.1" },
     { name = "opentelemetry-sdk", specifier = ">=1.39.1" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.1.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
@@ -1571,6 +1573,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
+]
+
+[[package]]
+name = "prometheus-fastapi-instrumentator"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prometheus-client" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/72/0824c18f3bc75810f55dacc2dd933f6ec829771180245ae3cc976195dec0/prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9", size = 19296, upload-time = "2025-03-19T19:35:04.323Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

  Add an optional `/metrics` endpoint that exposes HTTP and Python runtime metrics in Prometheus exposition format. Controlled by `ENABLE_PROMETHEUS_METRICS` env var (default: `false`). Uses `prometheus-fastapi-instrumentator` to automatically collect request duration, count, and size metrics.

  ## Type of Change

  - [x] `feat`: New feature

  ## Related Issues

  Closes #282

  ## Changes Made

  - New `observability/metrics.py` module with `setup_prometheus_metrics()` that conditionally attaches Prometheus instrumentator to the FastAPI app
  - `ENABLE_PROMETHEUS_METRICS` setting in `ObservabilitySettings` (default: `false`)
  - Wired up in `create_app()` in `main.py`
  - Added `prometheus-fastapi-instrumentator>=7.1.0` dependency
  - Updated both `.env.example` files with the new env var
  - Updated observability guide and environment variables reference docs

  ## Testing

  - [x] Unit tests added/updated
  - [x] Integration tests added/updated
  - [ ] E2E tests added/updated
  - [ ] Manual testing performed

  ## Checklist

  - [x] Code follows project style (Ruff formatting)
  - [x] All linting checks pass (`make lint`)
  - [x] Type checking passes (`make type-check`)
  - [x] All tests pass (`make test`)
  - [x] Documentation updated (if needed)
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] PR title follows Conventional Commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Prometheus /metrics endpoint to expose HTTP request metrics (disabled by default via new env flag).

* **Documentation**
  * Guides and env reference updated to describe the Prometheus metrics option, how to enable it, and that /metrics is exposed without application auth.

* **Tests**
  * Added unit, integration, and end-to-end tests for metrics behavior.

* **Chores**
  * Added Prometheus instrumentation dependency and updated example env template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional `/metrics` endpoint powered by `prometheus-fastapi-instrumentator`, gated by `ENABLE_PROMETHEUS_METRICS` (default `false`). The auth bypass is now explicitly documented in the module docstring and `.env.example`. Several concerns from the prior review — private `_names_to_collectors` access, broad `contextlib.suppress(Exception)`, and the missing E2E skip guard — have all been resolved in the current revision.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge; the unresolved P1 from the previous thread on hard dependency placement keeps the score at 4.

The five prior-round concerns are largely addressed: registry isolation is correct, the E2E skip guard is in place, and the auth bypass is documented. The prometheus-fastapi-instrumentator dependency remains in the main dependencies array rather than an extras group — the P1 from the previous thread is still open. The only new finding is a P2 missing type annotation on inner_send in the changed middleware file.

libs/aegra-api/pyproject.toml (hard dependency not in extras) and libs/aegra-api/src/aegra_api/middleware/logger_middleware.py (missing type annotation)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/observability/metrics.py | New metrics module — clean implementation; auth-bypass explicitly documented in docstring and .env.example |
| libs/aegra-api/src/aegra_api/main.py | setup_prometheus_metrics correctly wired into create_app() after all middleware and routes are registered |
| libs/aegra-api/src/aegra_api/middleware/logger_middleware.py | Changed file — inner_send closure missing Message type annotation and return type (CLAUDE.md violation) |
| libs/aegra-api/tests/integration/test_prometheus_metrics.py | Uses isolated fresh_registry; prior concerns about _names_to_collectors and suppress(Exception) are resolved |
| libs/aegra-api/tests/e2e/test_prometheus_metrics.py | E2E test correctly skips when ENABLE_PROMETHEUS_METRICS=false |
| libs/aegra-api/src/aegra_api/settings.py | ENABLE_PROMETHEUS_METRICS bool setting added correctly to ObservabilitySettings with False default |
| libs/aegra-api/tests/unit/test_observability/test_metrics.py | Unit tests cover disabled path, endpoint registration, excluded handlers, and log output |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[create_app] --> B[_add_common_middleware]
    B --> C[_include_core_routers]
    C --> D[setup_prometheus_metrics]
    D --> E{ENABLE_PROMETHEUS_METRICS?}
    E -->|false| F[no-op return]
    E -->|true| G[Instrumentator.instrument app]
    G --> H[Instrumentator.expose /metrics]
    H --> I[Log: metrics enabled]
    F --> J[FastAPI app returned]
    I --> J
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmiddleware%2Flogger_middleware.py%3A36-39%0A**Missing%20type%20annotations%20on%20%60inner_send%60**%0A%0A%60inner_send%60%20is%20defined%20without%20a%20type%20annotation%20for%20%60message%60%20or%20a%20return%20type.%20CLAUDE.md%20requires%20type%20annotations%20on%20every%20function%2C%20including%20inner%20closures.%20%60Message%60%20is%20importable%20from%20%60starlette.types%60%2C%20which%20is%20already%20imported%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20async%20def%20inner_send%28message%3A%20Message%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.get%28%22type%22%29%20%3D%3D%20%22http.response.start%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20info%5B%22status_code%22%5D%20%3D%20message.get%28%22status%22%2C%20500%29%0A%20%20%20%20%20%20%20%20%20%20%20%20await%20send%28message%29%0A%60%60%60%0A%0AAlso%20add%20%60Message%60%20to%20the%20existing%20%60starlette.types%60%20import%20line%3A%0A%60%60%60python%0Afrom%20starlette.types%20import%20ASGIApp%2C%20Message%2C%20Receive%2C%20Scope%2C%20Send%0A%60%60%60%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D49bdce28-7cb1-4d77-a7a8-6bbbab6aa631%29%29%0A%0A&repo=ibbybuilds%2Faegra"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmiddleware%2Flogger_middleware.py%3A36-39%0A**Missing%20type%20annotations%20on%20%60inner_send%60**%0A%0A%60inner_send%60%20is%20defined%20without%20a%20type%20annotation%20for%20%60message%60%20or%20a%20return%20type.%20CLAUDE.md%20requires%20type%20annotations%20on%20every%20function%2C%20including%20inner%20closures.%20%60Message%60%20is%20importable%20from%20%60starlette.types%60%2C%20which%20is%20already%20imported%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20async%20def%20inner_send%28message%3A%20Message%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.get%28%22type%22%29%20%3D%3D%20%22http.response.start%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20info%5B%22status_code%22%5D%20%3D%20message.get%28%22status%22%2C%20500%29%0A%20%20%20%20%20%20%20%20%20%20%20%20await%20send%28message%29%0A%60%60%60%0A%0AAlso%20add%20%60Message%60%20to%20the%20existing%20%60starlette.types%60%20import%20line%3A%0A%60%60%60python%0Afrom%20starlette.types%20import%20ASGIApp%2C%20Message%2C%20Receive%2C%20Scope%2C%20Send%0A%60%60%60%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D49bdce28-7cb1-4d77-a7a8-6bbbab6aa631%29%29%0A%0A"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmiddleware%2Flogger_middleware.py%3A36-39%0A**Missing%20type%20annotations%20on%20%60inner_send%60**%0A%0A%60inner_send%60%20is%20defined%20without%20a%20type%20annotation%20for%20%60message%60%20or%20a%20return%20type.%20CLAUDE.md%20requires%20type%20annotations%20on%20every%20function%2C%20including%20inner%20closures.%20%60Message%60%20is%20importable%20from%20%60starlette.types%60%2C%20which%20is%20already%20imported%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20async%20def%20inner_send%28message%3A%20Message%29%20-%3E%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20message.get%28%22type%22%29%20%3D%3D%20%22http.response.start%22%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20info%5B%22status_code%22%5D%20%3D%20message.get%28%22status%22%2C%20500%29%0A%20%20%20%20%20%20%20%20%20%20%20%20await%20send%28message%29%0A%60%60%60%0A%0AAlso%20add%20%60Message%60%20to%20the%20existing%20%60starlette.types%60%20import%20line%3A%0A%60%60%60python%0Afrom%20starlette.types%20import%20ASGIApp%2C%20Message%2C%20Receive%2C%20Scope%2C%20Send%0A%60%60%60%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D49bdce28-7cb1-4d77-a7a8-6bbbab6aa631%29%29%0A%0A&repo=ibbybuilds%2Faegra"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<sub>Reviews (4): Last reviewed commit: ["fix(tests): improve e2e prometheus metri..."](https://github.com/ibbybuilds/aegra/commit/7a74fde5d8a5a8de00c38fda81944a5f9003355c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27586620)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=49bdce28-7cb1-4d77-a7a8-6bbbab6aa631))

<!-- /greptile_comment -->