### PR TITLE
feat(cli): add --debug-port and --wait-for-client options to dev command

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -56,6 +56,9 @@ What it does:
 | `--env-file` / `-e` | `.env` | Path to `.env` file |
 | `--file` / `-f` | Auto-detected | Path to `docker-compose.yml` |
 | `--no-db-check` | — | Skip database readiness check |
+| `--debug-port` | — | When set, run the server under `debugpy` and listen on this port (enables remote debugging) |
+| `--wait-for-client` | `false` | When used with `--debug-port`, `debugpy` will wait for a debugger client to attach before starting the app |
+| `--debug-host` | - | Host for the debugger to bind to (defaults to loopback). Binding to a non-loopback address is unsafe. |
 
 ---
 

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.2"
+version = "0.9.3"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.2"
+version = "0.9.3"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -26,6 +26,9 @@ dependencies = [
     # Server (always included)
     "aegra-api~=0.9.0",
 ]
+
+[project.optional-dependencies]
+debug = ["debugpy>=1.8"]
 
 [project.scripts]
 aegra = "aegra_cli.cli:cli"

--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -1,5 +1,7 @@
 """Aegra CLI - Command-line interface for managing self-hosted agent deployments."""
 
+import importlib.util
+import ipaddress
 import json
 import os
 import shutil
@@ -211,6 +213,25 @@ def ensure_docker_files(project_path: Path, slug: str) -> Path:
     type=click.Path(exists=True, path_type=Path),
     help="Path to docker-compose.yml file for PostgreSQL.",
 )
+@click.option(
+    "--debug-port",
+    default=None,
+    type=int,
+    help="Port for debugger to listen on (no debugger if not specified).",
+    show_default=True,
+)
+@click.option(
+    "--debug-host",
+    default=None,
+    help="Host for debugger to bind to (127.0.0.1 if not specified).",
+    show_default=True,
+)
+@click.option(
+    "--wait-for-client",
+    is_flag=True,
+    default=False,
+    help="Break and wait for a debugger client to attach before starting.",
+)
 @click.pass_context
 def dev(
     ctx: click.Context,
@@ -221,6 +242,9 @@ def dev(
     env_file: Path | None,
     no_db_check: bool,
     compose_file: Path | None,
+    debug_port: int | None,
+    debug_host: str | None,
+    wait_for_client: bool,
 ) -> None:
     """Run the development server with hot reload.
 
@@ -243,6 +267,12 @@ def dev(
 
         aegra dev --no-db-check          # Start without database check
     """
+    # Validate debug options: --wait-for-client only makes sense with --debug-port
+    if wait_for_client and debug_port is None:
+        raise click.UsageError("--wait-for-client requires --debug-port to be set")
+    if debug_host is not None and debug_port is None:
+        raise click.UsageError("--debug-host requires --debug-port to be set")
+
     # Discover or validate config file
     if config_file is not None:
         # User specified a config file explicitly
@@ -323,6 +353,12 @@ def dev(
     ]
     if loaded_env:
         info_lines.append(f"[cyan]Env:[/cyan] {loaded_env}")
+    if debug_port is not None:
+        info_lines.append(f"[cyan]Debug port:[/cyan] {debug_port}")
+        if debug_host is not None:
+            info_lines.append(f"[cyan]Debug host:[/cyan] {debug_host}")
+        if wait_for_client:
+            info_lines.append("[cyan]Wait for client to attach:[/cyan] True")
     info_lines.append("\n[dim]Press Ctrl+C to stop the server[/dim]")
 
     console.print(
@@ -333,17 +369,61 @@ def dev(
         )
     )
 
-    cmd = [
-        sys.executable,
-        "-m",
-        "uvicorn",
-        app,
-        "--host",
-        host,
-        "--port",
-        str(port),
-        "--reload",
-    ]
+    # Build command. If debug_port is provided, wrap uvicorn with debugpy.
+    cmd_uvicorn = ["-m", "uvicorn", app, "--host", host, "--port", str(port), "--reload"]
+
+    if debug_port is not None:
+        if importlib.util.find_spec("debugpy") is None:
+            console.print(
+                "[bold red]Error:[/bold red] debugpy is not installed.\n"
+                "Install it with: [cyan]pip install 'aegra-cli[debug]'[/cyan]"
+            )
+            sys.exit(1)
+
+        console.print(
+            "[yellow]Note:[/yellow] debugpy is active. Hot-reload will disconnect the debugger "
+            "on each file change — reattach after every reload."
+        )
+
+        # Always bind debugpy to the debug host (default loopback) regardless of --host
+        listen = debug_port
+        is_loopback = True
+
+        # If debug_host is specified, warn if it's not loopback. Also handle ip v4 and v6 addresses
+        if debug_host is not None:
+            try:
+                address = ipaddress.ip_address(debug_host)
+                if address.version == 4:
+                    listen = f"{debug_host}:{debug_port}"
+                else:
+                    listen = f"[{debug_host}]:{debug_port}"
+                is_loopback = address.is_loopback
+            except ValueError:
+                if debug_host in ("localhost"):
+                    listen = f"{debug_host}:{debug_port}"
+                else:
+                    console.print(
+                        "[yellow]Warning:[/yellow] Invalid debug host specified. "
+                        "Falling back to loopback binding for debugpy."
+                    )
+
+        if not is_loopback:
+            console.print(
+                Panel(
+                    "[bold red]Warning:[/bold red] Debug host is non-loopback and exposes an "
+                    "unauthenticated debug server!\n"
+                    "[dim]Binding debugpy to a non-loopback address can allow remote code "
+                    "execution. Use only if you understand the risk.[/dim]",
+                    title="[bold red]Debug Exposure Warning[/bold red]",
+                    border_style="red",
+                )
+            )
+        cmd = [sys.executable, "-m", "debugpy", "--listen", listen]
+        if wait_for_client:
+            cmd.append("--wait-for-client")
+        cmd.extend(cmd_uvicorn)
+    else:
+        cmd = [sys.executable] + cmd_uvicorn
 
     process = None
     try:

--- a/libs/aegra-cli/tests/test_cli.py
+++ b/libs/aegra-cli/tests/test_cli.py
@@ -260,6 +260,192 @@ class TestDevCommand:
                 assert result.exit_code == 0
                 assert "Loaded environment from" in result.output
 
+    def test_dev_with_debug_port_wraps_debugpy(self, cli_runner: CliRunner, tmp_path: Path) -> None:
+        """Test that providing --debug-port wraps uvicorn with debugpy listen."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with (
+                patch("importlib.util.find_spec", return_value=object()),
+                patch("aegra_cli.cli.subprocess.Popen") as mock_popen,
+            ):
+                mock_popen.return_value = create_mock_popen(0)
+                result = cli_runner.invoke(cli, ["dev", "--no-db-check", "--debug-port", "5678"])
+
+                assert result.exit_code == 0
+                mock_popen.assert_called_once()
+                call_args = mock_popen.call_args[0][0]
+                # Ensure debugpy is used and listening on given port bound to loopback
+                assert "debugpy" in call_args
+                assert "--listen" in call_args
+                assert "5678" in " ".join(map(str, call_args))
+                # Ensure uvicorn still present
+                assert "uvicorn" in call_args
+                assert "--reload" in call_args
+
+    def test_dev_with_ipv6_debug_host_formats_listen(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Test that providing an IPv6 debug host (::1) is accepted and bracketed."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with (
+                patch("importlib.util.find_spec", return_value=object()),
+                patch("aegra_cli.cli.subprocess.Popen") as mock_popen,
+            ):
+                mock_popen.return_value = create_mock_popen(0)
+                result = cli_runner.invoke(
+                    cli, ["dev", "--no-db-check", "--debug-port", "5678", "--debug-host", "::1"]
+                )
+
+                assert result.exit_code == 0
+                mock_popen.assert_called_once()
+                call_args = mock_popen.call_args[0][0]
+                # Ensure debugpy listen uses bracketed IPv6 literal
+                assert "--listen" in call_args
+                joined = " ".join(map(str, call_args))
+                assert "[::1]:5678" in joined
+
+    def test_dev_with_localhost_debug_host_formats_listen(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Test that providing a localhost debug host is accepted and formatted correctly."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with (
+                patch("importlib.util.find_spec", return_value=object()),
+                patch("aegra_cli.cli.subprocess.Popen") as mock_popen,
+            ):
+                mock_popen.return_value = create_mock_popen(0)
+                result = cli_runner.invoke(
+                    cli,
+                    ["dev", "--no-db-check", "--debug-port", "5678", "--debug-host", "localhost"],
+                )
+
+                assert result.exit_code == 0
+                mock_popen.assert_called_once()
+                call_args = mock_popen.call_args[0][0]
+                # Ensure debugpy listen uses bracketed IPv6 literal
+                assert "--listen" in call_args
+                joined = " ".join(map(str, call_args))
+                assert "localhost:5678" in joined
+
+    def test_dev_with_invalid_debug_host_warns_and_falls_back_to_loopback(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Test that an invalid debug host prints a warning and keeps loopback binding."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with (
+                patch("importlib.util.find_spec", return_value=object()),
+                patch("aegra_cli.cli.subprocess.Popen") as mock_popen,
+            ):
+                mock_popen.return_value = create_mock_popen(0)
+                result = cli_runner.invoke(
+                    cli,
+                    [
+                        "dev",
+                        "--no-db-check",
+                        "--debug-port",
+                        "5678",
+                        "--debug-host",
+                        "not-a-valid-host",
+                    ],
+                )
+
+                assert result.exit_code == 0
+                assert "Invalid debug host specified" in result.output
+                mock_popen.assert_called_once()
+                call_args = mock_popen.call_args[0][0]
+                listen_idx = call_args.index("--listen")
+                assert call_args[listen_idx + 1] == 5678
+                assert "not-a-valid-host:5678" not in " ".join(map(str, call_args))
+
+    def test_dev_debug_host_non_loopback_warns(self, cli_runner: CliRunner, tmp_path: Path) -> None:
+        """Test that using a non-loopback --debug-host prints a warning panel."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with (
+                patch("importlib.util.find_spec", return_value=object()),
+                patch("aegra_cli.cli.subprocess.Popen") as mock_popen,
+            ):
+                mock_popen.return_value = create_mock_popen(0)
+                result = cli_runner.invoke(
+                    cli,
+                    [
+                        "dev",
+                        "--no-db-check",
+                        "--debug-port",
+                        "5678",
+                        "--debug-host",
+                        "0.0.0.0",
+                    ],
+                )
+
+                assert result.exit_code == 0
+                assert "Debug Exposure Warning" in result.output
+
+    def test_dev_with_wait_for_client_adds_flag(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Test that --wait-for-client adds the debugpy wait flag."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with (
+                patch("importlib.util.find_spec", return_value=object()),
+                patch("aegra_cli.cli.subprocess.Popen") as mock_popen,
+            ):
+                mock_popen.return_value = create_mock_popen(0)
+                result = cli_runner.invoke(
+                    cli, ["dev", "--no-db-check", "--debug-port", "5678", "--wait-for-client"]
+                )
+
+                assert result.exit_code == 0
+                call_args = mock_popen.call_args[0][0]
+                assert "--wait-for-client" in call_args
+
+    def test_dev_debugpy_not_installed_shows_error(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Test that missing debugpy yields an instructive error message."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with patch("importlib.util.find_spec", return_value=None):
+                result = cli_runner.invoke(cli, ["dev", "--no-db-check", "--debug-port", "5678"])
+
+                assert result.exit_code == 1
+                assert "debugpy is not installed" in result.output
+
+    def test_dev_wait_for_client_without_debug_port_errors(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Test that using --wait-for-client without --debug-port errors fast with UsageError."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            result = cli_runner.invoke(cli, ["dev", "--no-db-check", "--wait-for-client"])
+
+            assert result.exit_code != 0
+            assert "--wait-for-client requires --debug-port" in result.output
+
+    def test_dev_debug_host_without_debug_port_errors(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Test that using --debug-host without --debug-port errors fast with UsageError."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            result = cli_runner.invoke(cli, ["dev", "--no-db-check", "--debug-host", "0.0.0.0"])
+
+            assert result.exit_code != 0
+            assert "--debug-host requires --debug-port" in result.output
+
 
 class TestUpCommand:
     """Tests for the up command."""

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -94,7 +94,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },
@@ -102,6 +102,11 @@ dependencies = [
     { name = "jinja2" },
     { name = "python-dotenv" },
     { name = "rich" },
+]
+
+[package.optional-dependencies]
+debug = [
+    { name = "debugpy" },
 ]
 
 [package.dev-dependencies]
@@ -116,10 +121,12 @@ dev = [
 requires-dist = [
     { name = "aegra-api", editable = "libs/aegra-api" },
     { name = "click", specifier = ">=8.1.7" },
+    { name = "debugpy", marker = "extra == 'debug'", specifier = ">=1.8" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "rich", specifier = ">=13.0" },
 ]
+provides-extras = ["debug"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -554,6 +561,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
     { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
     { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
+]
+
+[[package]]
+name = "debugpy"
+version = "1.8.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/57/7f34f4736bfb6e00f2e4c96351b07805d83c9a7b33d28580ae01374430f7/debugpy-1.8.20-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:4ae3135e2089905a916909ef31922b2d733d756f66d87345b3e5e52b7a55f13d", size = 2550686, upload-time = "2026-01-29T23:03:42.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/b193a3975ca34458f6f0e24aaf5c3e3da72f5401f6054c0dfd004b41726f/debugpy-1.8.20-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:88f47850a4284b88bd2bfee1f26132147d5d504e4e86c22485dfa44b97e19b4b", size = 4310588, upload-time = "2026-01-29T23:03:43.314Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/55/f14deb95eaf4f30f07ef4b90a8590fc05d9e04df85ee379712f6fb6736d7/debugpy-1.8.20-cp312-cp312-win32.whl", hash = "sha256:4057ac68f892064e5f98209ab582abfee3b543fb55d2e87610ddc133a954d390", size = 5331372, upload-time = "2026-01-29T23:03:45.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/39/2bef246368bd42f9bd7cba99844542b74b84dacbdbea0833e610f384fee8/debugpy-1.8.20-cp312-cp312-win_amd64.whl", hash = "sha256:a1a8f851e7cf171330679ef6997e9c579ef6dd33c9098458bd9986a0f4ca52e3", size = 5372835, upload-time = "2026-01-29T23:03:47.245Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/fc500524cc6f104a9d049abc85a0a8b3f0d14c0a39b9c140511c61e5b40b/debugpy-1.8.20-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5dff4bb27027821fdfcc9e8f87309a28988231165147c31730128b1c983e282a", size = 2539560, upload-time = "2026-01-29T23:03:48.738Z" },
+    { url = "https://files.pythonhosted.org/packages/90/83/fb33dcea789ed6018f8da20c5a9bc9d82adc65c0c990faed43f7c955da46/debugpy-1.8.20-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:84562982dd7cf5ebebfdea667ca20a064e096099997b175fe204e86817f64eaf", size = 4293272, upload-time = "2026-01-29T23:03:50.169Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/25/b1e4a01bfb824d79a6af24b99ef291e24189080c93576dfd9b1a2815cd0f/debugpy-1.8.20-cp313-cp313-win32.whl", hash = "sha256:da11dea6447b2cadbf8ce2bec59ecea87cc18d2c574980f643f2d2dfe4862393", size = 5331208, upload-time = "2026-01-29T23:03:51.547Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f7/a0b368ce54ffff9e9028c098bd2d28cfc5b54f9f6c186929083d4c60ba58/debugpy-1.8.20-cp313-cp313-win_amd64.whl", hash = "sha256:eb506e45943cab2efb7c6eafdd65b842f3ae779f020c82221f55aca9de135ed7", size = 5372930, upload-time = "2026-01-29T23:03:53.585Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2e/f6cb9a8a13f5058f0a20fe09711a7b726232cd5a78c6a7c05b2ec726cff9/debugpy-1.8.20-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9c74df62fc064cd5e5eaca1353a3ef5a5d50da5eb8058fcef63106f7bebe6173", size = 2538066, upload-time = "2026-01-29T23:03:54.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/56/6ddca50b53624e1ca3ce1d1e49ff22db46c47ea5fb4c0cc5c9b90a616364/debugpy-1.8.20-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:077a7447589ee9bc1ff0cdf443566d0ecf540ac8aa7333b775ebcb8ce9f4ecad", size = 4269425, upload-time = "2026-01-29T23:03:56.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d9/d64199c14a0d4c476df46c82470a3ce45c8d183a6796cfb5e66533b3663c/debugpy-1.8.20-cp314-cp314-win32.whl", hash = "sha256:352036a99dd35053b37b7803f748efc456076f929c6a895556932eaf2d23b07f", size = 5331407, upload-time = "2026-01-29T23:03:58.481Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d9/1f07395b54413432624d61524dfd98c1a7c7827d2abfdb8829ac92638205/debugpy-1.8.20-cp314-cp314-win_amd64.whl", hash = "sha256:a98eec61135465b062846112e5ecf2eebb855305acc1dfbae43b72903b8ab5be", size = 5372521, upload-time = "2026-01-29T23:03:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
<!-- Provide a clear description of your changes -->

This pull request adds support for remote debugging to the `dev` command in the Aegra CLI by introducing new options for running the server under `debugpy`. It also includes updates to the documentation and comprehensive tests for the new debugging features.


## Type of Change
<!-- Check the relevant option -->
- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->
None

## Changes Made
<!-- List the main changes -->
- Added `--debug-port` and `--wait-for-client` options to the `dev` CLI command, allowing the server to be run under `debugpy` for remote debugging and optionally wait for a debugger client to attach before starting. 
- Modified the process startup logic in `cli.py` to wrap the `uvicorn` server with `debugpy` when `--debug-port` is specified, including error handling for missing `debugpy` and conditional addition of the `--wait-for-client` flag.
- Improved CLI output to display debugging-related information when these options are used.
- Updated the CLI reference documentation to describe the new `--debug-port` and `--wait-for-client` options. 

## Testing
<!-- Describe how you tested your changes -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist
<!-- Ensure all items are checked before requesting review -->
- [ ] Code follows project style (Ruff formatting)
- [ ] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`)
- [ ] All tests pass (`make test`)
- [ ] Documentation updated (if needed)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] PR title follows Conventional Commits format

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Notes
<!-- Any additional information for reviewers -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI options to run the dev server under a debugger: --debug-port, --debug-host, and --wait-for-client
* **Improvements**
  * Clear error when debugging tooling is missing; warning shown for non-loopback debug hosts; startup output displays debug settings
* **Tests**
  * Added CLI tests for debug-mode behavior, wait-for-client, host exposure warning, and missing-tool error
* **Chores**
  * Package versions bumped to 0.9.3; optional debug dependency declared for debug installs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `--debug-port` and `--wait-for-client` options to the `dev` command, wrapping uvicorn with `debugpy` when a port is supplied, with a graceful error when `debugpy` is not installed. The implementation is clean and tests cover the main scenarios; two minor polish items remain (UX ordering of the debugpy check and test patch scope).

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style/improvement suggestions with no correctness impact

Prior P1 concerns (silent no-op, unreachable branch, reload advisory) were addressed in previous review rounds. The two remaining comments are non-blocking: info-panel ordering is a UX polish issue and the global find_spec patch is unlikely to cause test failures in practice. Feature logic and tests are correct.

No files require special attention

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The `debugpy` listen address inherits the `--host` value — users should be aware that passing `--host 0.0.0.0 --debug-port <port>` exposes the debug port on all interfaces, but this is consistent with the existing host flag behaviour and not a defect introduced by this PR.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-cli/src/aegra_cli/cli.py | Adds --debug-port/--wait-for-client options; debugpy check happens after info panel is printed (minor UX ordering issue); logic is otherwise correct |
| libs/aegra-cli/tests/test_cli.py | Three new tests cover the happy path, --wait-for-client flag, and missing-debugpy error; global find_spec patch could silently shadow other module lookups during invoke |
| docs/reference/cli.mdx | Two new option rows added to the dev command table; descriptions are accurate and complete |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[aegra dev --debug-port PORT] --> B{debug_port set?}
    B -- No --> C[Build uvicorn cmd]
    B -- Yes --> D{debugpy installed?}
    D -- No --> E[Print error & exit 1]
    D -- Yes --> F[Print reload advisory]
    F --> G{--wait-for-client?}
    G -- Yes --> H["cmd = [python, -m, debugpy, --listen, host:port, --wait-for-client, -m, uvicorn, ...]"]
    G -- No --> I["cmd = [python, -m, debugpy, --listen, host:port, -m, uvicorn, ...]"]
    C --> J["cmd = [python, -m, uvicorn, ...]"]
    H --> K[subprocess.Popen]
    I --> K
    J --> K
    K --> L[Wait for process to exit]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-cli%2Fsrc%2Faegra_cli%2Fcli.py%3A342-376%0A**Info%20panel%20rendered%20before%20%60debugpy%60%20availability%20check**%0A%0AThe%20info%20panel%20that%20says%20%22Debug%20port%3A%205678%22%20is%20printed%20at%20line%20~348%2C%20but%20the%20%60importlib.util.find_spec%28%22debugpy%22%29%60%20check%20only%20runs%20at%20line%20~360.%20If%20%60debugpy%60%20is%20not%20installed%20the%20user%20sees%20a%20panel%20announcing%20the%20debug%20port%20is%20configured%2C%20immediately%20followed%20by%20an%20error%20saying%20%60debugpy%60%20is%20not%20installed%20%E2%80%94%20which%20is%20confusing.%0A%0AMoving%20the%20%60find_spec%60%20check%20before%20the%20%60console.print%28Panel%28...%29%29%60%20call%20would%20give%20a%20cleaner%20failure%20path.%0A%0A%60%60%60python%0A%20%20%20%20%23%20Check%20debugpy%20before%20printing%20the%20info%20panel%0A%20%20%20%20if%20debug_port%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20if%20importlib.util.find_spec%28%22debugpy%22%29%20is%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20console.print%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%5Bbold%20red%5DError%3A%5B%2Fbold%20red%5D%20debugpy%20is%20not%20installed.%5Cn%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Install%20it%20with%3A%20%5Bcyan%5Dpip%20install%20debugpy%5B%2Fcyan%5D%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20sys.exit%281%29%0A%0A%20%20%20%20%23%20Build%20info%20panel%20content%0A%20%20%20%20info_lines%20%3D%20%5B...%5D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-cli%2Ftests%2Ftest_cli.py%3A268-270%0A**Global%20%60find_spec%60%20patch%20may%20shadow%20non-%60debugpy%60%20lookups**%0A%0A%60patch%28%22importlib.util.find_spec%22%2C%20return_value%3Dobject%28%29%29%60%20replaces%20the%20function%20for%20the%20entire%20duration%20of%20the%20test.%20Any%20call%20to%20%60find_spec%60%20made%20by%20Click%20internals%20or%20other%20code%20paths%20during%20the%20invoke%20will%20also%20return%20%60object%28%29%60%20instead%20of%20the%20real%20result.%20This%20same%20pattern%20is%20used%20in%20the%20other%20debug%20test.%0A%0AScope%20the%20mock%20to%20%60%22debugpy%22%60%20only%20with%20a%20%60side_effect%60%3A%0A%0A%60%60%60python%0Aoriginal_find_spec%20%3D%20importlib.util.find_spec%0A%0Adef%20fake_find_spec%28name%3A%20str%29%20-%3E%20object%20%7C%20None%3A%0A%20%20%20%20if%20name%20%3D%3D%20%22debugpy%22%3A%0A%20%20%20%20%20%20%20%20return%20object%28%29%0A%20%20%20%20return%20original_find_spec%28name%29%0A%0Awith%20patch%28%22importlib.util.find_spec%22%2C%20side_effect%3Dfake_find_spec%29%3A%0A%20%20%20%20...%0A%60%60%60%0A%0A&repo=ibbybuilds%2Faegra"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-cli%2Fsrc%2Faegra_cli%2Fcli.py%3A342-376%0A**Info%20panel%20rendered%20before%20%60debugpy%60%20availability%20check**%0A%0AThe%20info%20panel%20that%20says%20%22Debug%20port%3A%205678%22%20is%20printed%20at%20line%20~348%2C%20but%20the%20%60importlib.util.find_spec%28%22debugpy%22%29%60%20check%20only%20runs%20at%20line%20~360.%20If%20%60debugpy%60%20is%20not%20installed%20the%20user%20sees%20a%20panel%20announcing%20the%20debug%20port%20is%20configured%2C%20immediately%20followed%20by%20an%20error%20saying%20%60debugpy%60%20is%20not%20installed%20%E2%80%94%20which%20is%20confusing.%0A%0AMoving%20the%20%60find_spec%60%20check%20before%20the%20%60console.print%28Panel%28...%29%29%60%20call%20would%20give%20a%20cleaner%20failure%20path.%0A%0A%60%60%60python%0A%20%20%20%20%23%20Check%20debugpy%20before%20printing%20the%20info%20panel%0A%20%20%20%20if%20debug_port%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20if%20importlib.util.find_spec%28%22debugpy%22%29%20is%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20console.print%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%5Bbold%20red%5DError%3A%5B%2Fbold%20red%5D%20debugpy%20is%20not%20installed.%5Cn%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Install%20it%20with%3A%20%5Bcyan%5Dpip%20install%20debugpy%5B%2Fcyan%5D%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20sys.exit%281%29%0A%0A%20%20%20%20%23%20Build%20info%20panel%20content%0A%20%20%20%20info_lines%20%3D%20%5B...%5D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-cli%2Ftests%2Ftest_cli.py%3A268-270%0A**Global%20%60find_spec%60%20patch%20may%20shadow%20non-%60debugpy%60%20lookups**%0A%0A%60patch%28%22importlib.util.find_spec%22%2C%20return_value%3Dobject%28%29%29%60%20replaces%20the%20function%20for%20the%20entire%20duration%20of%20the%20test.%20Any%20call%20to%20%60find_spec%60%20made%20by%20Click%20internals%20or%20other%20code%20paths%20during%20the%20invoke%20will%20also%20return%20%60object%28%29%60%20instead%20of%20the%20real%20result.%20This%20same%20pattern%20is%20used%20in%20the%20other%20debug%20test.%0A%0AScope%20the%20mock%20to%20%60%22debugpy%22%60%20only%20with%20a%20%60side_effect%60%3A%0A%0A%60%60%60python%0Aoriginal_find_spec%20%3D%20importlib.util.find_spec%0A%0Adef%20fake_find_spec%28name%3A%20str%29%20-%3E%20object%20%7C%20None%3A%0A%20%20%20%20if%20name%20%3D%3D%20%22debugpy%22%3A%0A%20%20%20%20%20%20%20%20return%20object%28%29%0A%20%20%20%20return%20original_find_spec%28name%29%0A%0Awith%20patch%28%22importlib.util.find_spec%22%2C%20side_effect%3Dfake_find_spec%29%3A%0A%20%20%20%20...%0A%60%60%60%0A%0A"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=1" height="20"></a> <a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-cli%2Fsrc%2Faegra_cli%2Fcli.py%3A342-376%0A**Info%20panel%20rendered%20before%20%60debugpy%60%20availability%20check**%0A%0AThe%20info%20panel%20that%20says%20%22Debug%20port%3A%205678%22%20is%20printed%20at%20line%20~348%2C%20but%20the%20%60importlib.util.find_spec%28%22debugpy%22%29%60%20check%20only%20runs%20at%20line%20~360.%20If%20%60debugpy%60%20is%20not%20installed%20the%20user%20sees%20a%20panel%20announcing%20the%20debug%20port%20is%20configured%2C%20immediately%20followed%20by%20an%20error%20saying%20%60debugpy%60%20is%20not%20installed%20%E2%80%94%20which%20is%20confusing.%0A%0AMoving%20the%20%60find_spec%60%20check%20before%20the%20%60console.print%28Panel%28...%29%29%60%20call%20would%20give%20a%20cleaner%20failure%20path.%0A%0A%60%60%60python%0A%20%20%20%20%23%20Check%20debugpy%20before%20printing%20the%20info%20panel%0A%20%20%20%20if%20debug_port%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20if%20importlib.util.find_spec%28%22debugpy%22%29%20is%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20console.print%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%5Bbold%20red%5DError%3A%5B%2Fbold%20red%5D%20debugpy%20is%20not%20installed.%5Cn%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22Install%20it%20with%3A%20%5Bcyan%5Dpip%20install%20debugpy%5B%2Fcyan%5D%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20sys.exit%281%29%0A%0A%20%20%20%20%23%20Build%20info%20panel%20content%0A%20%20%20%20info_lines%20%3D%20%5B...%5D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-cli%2Ftests%2Ftest_cli.py%3A268-270%0A**Global%20%60find_spec%60%20patch%20may%20shadow%20non-%60debugpy%60%20lookups**%0A%0A%60patch%28%22importlib.util.find_spec%22%2C%20return_value%3Dobject%28%29%29%60%20replaces%20the%20function%20for%20the%20entire%20duration%20of%20the%20test.%20Any%20call%20to%20%60find_spec%60%20made%20by%20Click%20internals%20or%20other%20code%20paths%20during%20the%20invoke%20will%20also%20return%20%60object%28%29%60%20instead%20of%20the%20real%20result.%20This%20same%20pattern%20is%20used%20in%20the%20other%20debug%20test.%0A%0AScope%20the%20mock%20to%20%60%22debugpy%22%60%20only%20with%20a%20%60side_effect%60%3A%0A%0A%60%60%60python%0Aoriginal_find_spec%20%3D%20importlib.util.find_spec%0A%0Adef%20fake_find_spec%28name%3A%20str%29%20-%3E%20object%20%7C%20None%3A%0A%20%20%20%20if%20name%20%3D%3D%20%22debugpy%22%3A%0A%20%20%20%20%20%20%20%20return%20object%28%29%0A%20%20%20%20return%20original_find_spec%28name%29%0A%0Awith%20patch%28%22importlib.util.find_spec%22%2C%20side_effect%3Dfake_find_spec%29%3A%0A%20%20%20%20...%0A%60%60%60%0A%0A&repo=ibbybuilds%2Faegra"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<sub>Reviews (2): Last reviewed commit: ["feat(cli): add --debug-port and --wait-f..."](https://github.com/ibbybuilds/aegra/commit/1750f4b61c6a9ea6bfd30f5976a4c242cc26a014) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27879558)</sub>

<!-- /greptile_comment -->