### PR TITLE
chore: update all references from ibbybuilds/aegra to aegra/aegra

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,7 +255,7 @@ git push origin feat/my-feature
 
 ```bash
 # Add upstream remote (once)
-git remote add upstream https://github.com/ibbybuilds/aegra.git
+git remote add upstream https://github.com/aegra/aegra.git
 
 # Update your fork
 git fetch upstream

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 <p align="center">
   <a href="https://pypi.org/project/aegra-api/"><img src="https://img.shields.io/pypi/v/aegra-api?label=aegra-api&color=blue" alt="PyPI API"></a>
   <a href="https://pypi.org/project/aegra-cli/"><img src="https://img.shields.io/pypi/v/aegra-cli?label=aegra-cli&color=blue" alt="PyPI CLI"></a>
-  <a href="https://github.com/ibbybuilds/aegra/actions/workflows/ci.yml"><img src="https://github.com/ibbybuilds/aegra/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://app.codecov.io/gh/ibbybuilds/aegra"><img src="https://codecov.io/gh/ibbybuilds/aegra/graph/badge.svg" alt="Codecov"></a>
+  <a href="https://github.com/aegra/aegra/actions/workflows/ci.yml"><img src="https://github.com/aegra/aegra/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://app.codecov.io/gh/aegra/aegra"><img src="https://codecov.io/gh/aegra/aegra/graph/badge.svg" alt="Codecov"></a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/ibbybuilds/aegra/stargazers"><img src="https://img.shields.io/github/stars/ibbybuilds/aegra" alt="GitHub stars"></a>
-  <a href="https://github.com/ibbybuilds/aegra/blob/main/LICENSE"><img src="https://img.shields.io/github/license/ibbybuilds/aegra" alt="License"></a>
+  <a href="https://github.com/aegra/aegra/stargazers"><img src="https://img.shields.io/github/stars/aegra/aegra" alt="GitHub stars"></a>
+  <a href="https://github.com/aegra/aegra/blob/main/LICENSE"><img src="https://img.shields.io/github/license/aegra/aegra" alt="License"></a>
   <a href="https://discord.com/invite/D5M3ZPS25e"><img src="https://img.shields.io/badge/Discord-Join-7289DA?logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://patreon.com/aegra"><img src="https://img.shields.io/badge/Sponsor-EA4AAA?logo=github-sponsors&logoColor=white" alt="Sponsor"></a>
 </p>
@@ -52,7 +52,7 @@ uv run aegra dev         # Start PostgreSQL + dev server
 ### From Source
 
 ```bash
-git clone https://github.com/ibbybuilds/aegra.git
+git clone https://github.com/aegra/aegra.git
 cd aegra
 cp .env.example .env
 # Add your OPENAI_API_KEY to .env
@@ -139,8 +139,8 @@ aegra version           # Show version info
 ## 💬 Community & Support
 
 - **[Discord](https://discord.com/invite/D5M3ZPS25e)** - Chat with the community
-- **[GitHub Discussions](https://github.com/ibbybuilds/aegra/discussions)** - Ask questions, share ideas
-- **[GitHub Issues](https://github.com/ibbybuilds/aegra/issues)** - Report bugs
+- **[GitHub Discussions](https://github.com/aegra/aegra/discussions)** - Ask questions, share ideas
+- **[GitHub Issues](https://github.com/aegra/aegra/issues)** - Report bugs
 
 ## 🏗️ Built With
 
@@ -153,7 +153,7 @@ aegra version           # Show version info
 
 ## 🤝 Contributing
 
-We welcome contributions! See [Contributing guide](https://docs.aegra.dev/guides/contributing) and check out [good first issues](https://github.com/ibbybuilds/aegra/labels/good%20first%20issue).
+We welcome contributions! See [Contributing guide](https://docs.aegra.dev/guides/contributing) and check out [good first issues](https://github.com/aegra/aegra/labels/good%20first%20issue).
 
 ## 💖 Support the Project
 
@@ -171,10 +171,10 @@ Apache 2.0 - see [LICENSE](LICENSE).
   <strong>⭐ Star us if Aegra helps you escape vendor lock-in ⭐</strong>
 </p>
 
-<a href="https://www.star-history.com/#ibbybuilds/aegra&Date">
+<a href="https://www.star-history.com/#aegra/aegra&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ibbybuilds/aegra&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ibbybuilds/aegra&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ibbybuilds/aegra&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=aegra/aegra&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=aegra/aegra&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=aegra/aegra&type=Date" />
   </picture>
 </a>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -23,7 +23,7 @@
   ],
   "topbarCtaButton": {
     "name": "GitHub",
-    "url": "https://github.com/ibbybuilds/aegra"
+    "url": "https://github.com/aegra/aegra"
   },
   "navigation": {
     "tabs": [
@@ -100,7 +100,7 @@
     ]
   },
   "footerSocials": {
-    "github": "https://github.com/ibbybuilds/aegra",
+    "github": "https://github.com/aegra/aegra",
     "discord": "https://discord.com/invite/D5M3ZPS25e"
   },
   "feedback": {

--- a/docs/feature-support.mdx
+++ b/docs/feature-support.mdx
@@ -127,4 +127,4 @@ description: "What Aegra supports today, what's coming soon, and what's not yet 
 
 ## Request a feature
 
-Missing something? Open an issue on [GitHub](https://github.com/ibbybuilds/aegra/issues) or start a discussion on [Discord](https://discord.com/invite/D5M3ZPS25e).
+Missing something? Open an issue on [GitHub](https://github.com/aegra/aegra/issues) or start a discussion on [Discord](https://discord.com/invite/D5M3ZPS25e).

--- a/docs/guides/contributing.mdx
+++ b/docs/guides/contributing.mdx
@@ -15,7 +15,7 @@ description: "Setup guide, code standards, and development workflow for Aegra co
 ### First time setup
 
 ```bash
-git clone https://github.com/ibbybuilds/aegra.git
+git clone https://github.com/aegra/aegra.git
 cd aegra
 
 # Option A: Using Make (installs dependencies + git hooks)
@@ -284,5 +284,5 @@ Before creating a PR:
 
 ## Get help
 
-- **GitHub** — [Open an issue](https://github.com/ibbybuilds/aegra/issues) for bugs or feature requests.
+- **GitHub** — [Open an issue](https://github.com/aegra/aegra/issues) for bugs or feature requests.
 - **Discord** — [Join the community](https://discord.com/invite/D5M3ZPS25e) for questions and discussion.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -28,7 +28,7 @@ The CLI prompts you for a location, a template (simple-chatbot or react-agent), 
 Clone the repository and run directly:
 
 ```bash
-git clone https://github.com/ibbybuilds/aegra.git
+git clone https://github.com/aegra/aegra.git
 cd aegra
 cp .env.example .env
 # Add your OPENAI_API_KEY to .env

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -40,5 +40,5 @@ Aegra is a production-ready server for running LangGraph agents with full persis
 ## Optional
 
 - [API reference](openapi.json): OpenAPI specification for all endpoints.
-- [GitHub](https://github.com/ibbybuilds/aegra): Source code, issues, and contributions.
+- [GitHub](https://github.com/aegra/aegra): Source code, issues, and contributions.
 - [Discord](https://discord.com/invite/D5M3ZPS25e): Community support and discussion.

--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -184,4 +184,4 @@ A few features from LangSmith Deployments are not yet supported in Aegra. See th
 ## Get help
 
 - **Discord** — [Join the community](https://discord.com/invite/D5M3ZPS25e) for questions and discussion.
-- **GitHub** — [Open an issue](https://github.com/ibbybuilds/aegra/issues) for bugs or feature requests.
+- **GitHub** — [Open an issue](https://github.com/aegra/aegra/issues) for bugs or feature requests.

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -189,7 +189,7 @@ Use `runtime.execution_runtime` to check whether the factory is being called for
 | Manage resource lifecycle (MCP, DB) | `ServerRuntime[T]` + async context manager | Factory graphs only |
 | Filter tools by user permissions | `ServerRuntime` (`.user`) in factory | Factory graphs only |
 
-For a complete example combining both layers, see [`examples/factory/`](https://github.com/ibbybuilds/aegra/tree/main/examples/factory).
+For a complete example combining both layers, see [`examples/factory/`](https://github.com/aegra/aegra/tree/main/examples/factory).
 
 ## `auth`
 

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -53,10 +53,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/ibbybuilds/aegra"
-Documentation = "https://github.com/ibbybuilds/aegra#readme"
-Repository = "https://github.com/ibbybuilds/aegra"
-Issues = "https://github.com/ibbybuilds/aegra/issues"
+Homepage = "https://github.com/aegra/aegra"
+Documentation = "https://github.com/aegra/aegra#readme"
+Repository = "https://github.com/aegra/aegra"
+Issues = "https://github.com/aegra/aegra/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/libs/aegra-api/src/aegra_api/config.py
+++ b/libs/aegra-api/src/aegra_api/config.py
@@ -37,7 +37,7 @@ class StoreIndexConfig(TypedDict, total=False):
     """Configuration for vector embeddings in store.
 
     Enables semantic similarity search using pgvector.
-    See: https://github.com/ibbybuilds/aegra/issues/104
+    See: https://github.com/aegra/aegra/issues/104
     """
 
     dims: int

--- a/libs/aegra-api/tests/integration/test_api/test_threads_history.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_history.py
@@ -204,7 +204,7 @@ def test_history_invalid_limit(client: TestClient, mock_langgraph):
 
 # ------------------------------------------------------------------
 # Regression: `before` parameter must not double-wrap RunnableConfig
-# See: https://github.com/ibbybuilds/aegra/issues/274
+# See: https://github.com/aegra/aegra/issues/274
 # ------------------------------------------------------------------
 
 

--- a/libs/aegra-api/tests/integration/test_services/test_graph_factory_integration.py
+++ b/libs/aegra-api/tests/integration/test_services/test_graph_factory_integration.py
@@ -630,7 +630,7 @@ class TestGetGraphWithContext:
 class TestFactoryNotCalledAtStartup:
     """Verify that factory graphs are classified but NOT invoked at load time.
 
-    Regression test for https://github.com/ibbybuilds/aegra/issues/245:
+    Regression test for https://github.com/aegra/aegra/issues/245:
     dynamic graph factories were called with ``user=None`` during server
     startup for schema extraction, causing the first request to get a graph
     compiled without user context.

--- a/libs/aegra-api/tests/unit/test_services/test_graph_streaming_events_mode.py
+++ b/libs/aegra-api/tests/unit/test_services/test_graph_streaming_events_mode.py
@@ -1,7 +1,7 @@
 """Test stream_mode='events' functionality.
 
 Tests for issue #99: stream_mode="events" does not work
-https://github.com/ibbybuilds/aegra/issues/99
+https://github.com/aegra/aegra/issues/99
 """
 
 from unittest.mock import MagicMock

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -440,7 +440,7 @@ class TestLangGraphServiceGraphs:
     async def test_load_graph_from_file_with_dataclass(self, tmp_path: Path) -> None:
         """Test that a graph module containing a dataclass loads without errors.
 
-        Regression test for: https://github.com/ibbybuilds/aegra/issues/197
+        Regression test for: https://github.com/aegra/aegra/issues/197
         Dataclasses require the module to be in sys.modules during class creation.
         """
         graph_file = tmp_path / "dc_graph.py"

--- a/libs/aegra-cli/README.md
+++ b/libs/aegra-cli/README.md
@@ -16,7 +16,7 @@ pip install aegra-cli
 
 ```bash
 # Clone the repository
-git clone https://github.com/ibbybuilds/aegra.git
+git clone https://github.com/aegra/aegra.git
 cd aegra
 
 # Install all workspace packages

--- a/libs/aegra-cli/src/aegra_cli/templates/react-agent/README.md.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/react-agent/README.md.template
@@ -1,6 +1,6 @@
 # $project_name
 
-Built with [Aegra](https://github.com/ibbybuilds/aegra) -- a self-hosted LangSmith Deployments alternative.
+Built with [Aegra](https://github.com/aegra/aegra) -- a self-hosted LangSmith Deployments alternative.
 
 ## Setup
 

--- a/libs/aegra-cli/src/aegra_cli/templates/simple-chatbot/README.md.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/simple-chatbot/README.md.template
@@ -1,6 +1,6 @@
 # $project_name
 
-Built with [Aegra](https://github.com/ibbybuilds/aegra) -- a self-hosted LangSmith Deployments alternative.
+Built with [Aegra](https://github.com/aegra/aegra) -- a self-hosted LangSmith Deployments alternative.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- Updated all 34 occurrences of `ibbybuilds/aegra` to `aegra/aegra` across 18 files
- Covers README badges, pyproject.toml metadata, docs, clone instructions, issue links in test comments, and CLI templates

## Files changed
- `README.md` — badges, clone URL, discussions/issues links, star-history chart
- `libs/aegra-api/pyproject.toml` — PyPI homepage, docs, repository, issues URLs
- `docs/docs.json` — Mintlify topbar and footer GitHub links
- `docs/` (6 files) — clone URLs, issue links, examples link
- `CONTRIBUTING.md` — upstream remote URL
- `libs/aegra-cli/README.md` — clone URL
- `libs/aegra-cli/src/aegra_cli/templates/` (2 files) — generated project README links
- Source/test comments (4 files) — issue reference URLs

## Test plan
- [x] `grep -rn ibbybuilds` returns zero results
- [ ] CI passes (no functional changes, only URL strings)
- [ ] Verify README badges render correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all GitHub repository references and links throughout project documentation, installation guides, contribution guides, and configuration files to reflect the current repository location.
  * Updated package metadata, CI/CD badge URLs, and all project template links to maintain consistency.
  * Updated community support channel and issue tracking links across all user-facing documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->