### PR TITLE
chore: bump version to 0.9.3

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.2"
+    "version": "0.9.3"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.2"
+version = "0.9.3"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.2"
+version = "0.9.3"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -96,7 +96,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary
- Bump both `aegra-api` and `aegra-cli` from 0.9.2 to 0.9.3
- Update lockfile

## Changes since 0.9.2
- feat(observability): optional Prometheus /metrics endpoint (#301)
- chore: repository transferred to aegra/aegra org (#309)

## Test plan
- [ ] CI passes
- [ ] After merge, trigger `release.yml` workflow to verify PyPI trusted publishers work under the new org

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated library package versions to 0.9.3.

* **Documentation**
  * Bumped the published API/OpenAPI specification version to 0.9.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->