### PR TITLE
fix(observability): emit langfuse_session_id in metadata for CallbackHandler compatibility

### DIFF
--- a/libs/aegra-api/src/aegra_api/observability/otel.py
+++ b/libs/aegra-api/src/aegra_api/observability/otel.py
@@ -36,6 +36,7 @@ class OpenTelemetryProvider(ObservabilityProvider):
 
         # Defining the list of active targets
         self._active_targets: list[BaseOtelTarget] = self._resolve_targets()
+        self._has_langfuse = any(isinstance(target, LangfuseTarget) for target in self._active_targets)
 
         if self._active_targets or settings.observability.OTEL_CONSOLE_EXPORT:
             self._enabled = True
@@ -122,13 +123,21 @@ class OpenTelemetryProvider(ObservabilityProvider):
         if not self.is_enabled():
             return {}
 
-        meta = {
+        meta: dict[str, Any] = {
             "run_id": run_id,
             "thread_id": thread_id,
             "session_id": thread_id,
         }
         if user_identity:
             meta["user_id"] = user_identity
+
+        if self._has_langfuse:
+            # Langfuse CallbackHandler only promotes langfuse_* prefixed keys
+            # to trace-level fields; plain session_id stays in generic metadata.
+            meta["langfuse_session_id"] = thread_id
+            if user_identity:
+                meta["langfuse_user_id"] = user_identity
+
         return meta
 
 

--- a/libs/aegra-api/src/aegra_api/observability/otel.py
+++ b/libs/aegra-api/src/aegra_api/observability/otel.py
@@ -74,6 +74,15 @@ class OpenTelemetryProvider(ObservabilityProvider):
             self._has_langfuse = True
         self._enabled = True
 
+        if self._tracer_provider is not None:
+            try:
+                exporter = target.get_exporter()
+                if exporter:
+                    self._tracer_provider.add_span_processor(BatchSpanProcessor(exporter))
+                    logger.info(f"Observability: Attached target '{target.name}'")
+            except Exception as e:
+                logger.error(f"Observability: Failed to attach target '{target.name}': {e}")
+
     def setup(self) -> None:
         """Initializes the Global Tracer Provider. Runs once."""
         if self._tracer_provider:

--- a/libs/aegra-api/src/aegra_api/observability/otel.py
+++ b/libs/aegra-api/src/aegra_api/observability/otel.py
@@ -70,6 +70,8 @@ class OpenTelemetryProvider(ObservabilityProvider):
     def add_custom_target(self, target: BaseOtelTarget) -> None:
         """Allow registering custom targets dynamically."""
         self._active_targets.append(target)
+        if isinstance(target, LangfuseTarget):
+            self._has_langfuse = True
         self._enabled = True
 
     def setup(self) -> None:

--- a/libs/aegra-api/tests/unit/test_observability/test_otel.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_otel.py
@@ -97,6 +97,25 @@ class TestOpenTelemetryProviderInit:
             assert provider.is_enabled() is True
             assert mock_target in provider._active_targets
 
+    def test_add_custom_target_attaches_exporter_after_setup(self) -> None:
+        """Test that adding a target after setup() wires its exporter immediately."""
+        with patch("aegra_api.observability.otel.settings") as mock_settings:
+            mock_settings.observability.OTEL_TARGETS = ""
+            mock_settings.observability.OTEL_CONSOLE_EXPORT = True
+
+            provider = OpenTelemetryProvider()
+            provider.setup()
+
+            mock_target = MagicMock(spec=BaseOtelTarget)
+            mock_target.name = "Late"
+            mock_exporter = MagicMock()
+            mock_target.get_exporter.return_value = mock_exporter
+
+            provider.add_custom_target(mock_target)
+
+            mock_target.get_exporter.assert_called_once()
+            assert provider._tracer_provider is not None
+
 
 class TestOpenTelemetryProviderSetup:
     """Tests for the setup() method and tracer configuration."""

--- a/libs/aegra-api/tests/unit/test_observability/test_otel.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_otel.py
@@ -261,7 +261,7 @@ class TestOpenTelemetryProviderRuntime:
                 "user_id": "user-789",
             }
 
-    def test_get_metadata_includes_langfuse_keys_when_langfuse_active(self):
+    def test_get_metadata_includes_langfuse_keys_when_langfuse_active(self) -> None:
         """Test that langfuse_* keys are emitted only when Langfuse target is active."""
         with patch("aegra_api.observability.otel.settings") as mock_settings:
             mock_settings.observability.OTEL_TARGETS = "LANGFUSE"
@@ -274,7 +274,20 @@ class TestOpenTelemetryProviderRuntime:
             assert meta["langfuse_session_id"] == "thread-456"
             assert meta["langfuse_user_id"] == "user-789"
 
-    def test_get_metadata_excludes_langfuse_keys_when_langfuse_inactive(self):
+    def test_get_metadata_langfuse_without_user_identity(self) -> None:
+        """Test that langfuse_session_id is present but langfuse_user_id absent when user_identity is None."""
+        with patch("aegra_api.observability.otel.settings") as mock_settings:
+            mock_settings.observability.OTEL_TARGETS = "LANGFUSE"
+            mock_settings.observability.OTEL_CONSOLE_EXPORT = False
+
+            provider = OpenTelemetryProvider()
+
+            meta = provider.get_metadata(run_id="run-123", thread_id="thread-456")
+
+            assert meta["langfuse_session_id"] == "thread-456"
+            assert "langfuse_user_id" not in meta
+
+    def test_get_metadata_excludes_langfuse_keys_when_langfuse_inactive(self) -> None:
         """Test that langfuse_* keys are NOT emitted when only non-Langfuse targets are active."""
         with patch("aegra_api.observability.otel.settings") as mock_settings:
             mock_settings.observability.OTEL_TARGETS = ""

--- a/libs/aegra-api/tests/unit/test_observability/test_otel.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_otel.py
@@ -261,6 +261,32 @@ class TestOpenTelemetryProviderRuntime:
                 "user_id": "user-789",
             }
 
+    def test_get_metadata_includes_langfuse_keys_when_langfuse_active(self):
+        """Test that langfuse_* keys are emitted only when Langfuse target is active."""
+        with patch("aegra_api.observability.otel.settings") as mock_settings:
+            mock_settings.observability.OTEL_TARGETS = "LANGFUSE"
+            mock_settings.observability.OTEL_CONSOLE_EXPORT = False
+
+            provider = OpenTelemetryProvider()
+
+            meta = provider.get_metadata(run_id="run-123", thread_id="thread-456", user_identity="user-789")
+
+            assert meta["langfuse_session_id"] == "thread-456"
+            assert meta["langfuse_user_id"] == "user-789"
+
+    def test_get_metadata_excludes_langfuse_keys_when_langfuse_inactive(self):
+        """Test that langfuse_* keys are NOT emitted when only non-Langfuse targets are active."""
+        with patch("aegra_api.observability.otel.settings") as mock_settings:
+            mock_settings.observability.OTEL_TARGETS = ""
+            mock_settings.observability.OTEL_CONSOLE_EXPORT = True
+
+            provider = OpenTelemetryProvider()
+
+            meta = provider.get_metadata(run_id="run-123", thread_id="thread-456", user_identity="user-789")
+
+            assert "langfuse_session_id" not in meta
+            assert "langfuse_user_id" not in meta
+
     def test_get_metadata_empty_when_disabled(self):
         """Test metadata returns empty dict when disabled."""
         with patch("aegra_api.observability.otel.settings") as mock_settings:


### PR DESCRIPTION
## Description

  Langfuse CallbackHandler only promotes `langfuse_*` prefixed metadata keys to trace-level fields. Aegra was emitting plain `session_id` which stayed in generic metadata, leaving the dedicated `session_id` field NULL on callback-originated traces.

  ## Type of Change

  - [x] `fix`: Bug fix

  ## Related Issues

  Closes #311

  ## Changes Made

  - Added `_has_langfuse` flag to `OpenTelemetryProvider`, computed once at init
  - When Langfuse target is active, `get_metadata()` emits `langfuse_session_id` and `langfuse_user_id` alongside the existing generic keys
  - When Langfuse is not active, metadata stays unchanged — no polluting Phoenix/Generic targets

  ## Testing

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] E2E tests added/updated
  - [ ] Manual testing performed

  ## Checklist

  - [x] Code follows project style (Ruff formatting)
  - [x] All linting checks pass (`make lint`)
  - [ ] Type checking passes (`make type-check`)
  - [x] All tests pass (`make test`)
  - [ ] Documentation updated (if needed)
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] PR title follows Conventional Commits format

  ## Additional Notes

  Two tracing paths coexist when users add their own `langfuse.langchain.CallbackHandler` to LLM callbacks:

  1. **OTEL path** (Aegra → Langfuse via OTLP) — already sets `langfuse.session.id` as a span attribute on the root span. Works correctly.
  2. **CallbackHandler path** (user's direct Langfuse integration) — reads `langfuse_session_id` from LangChain run config metadata. Was broken because we only emitted `session_id`.

  This fix addresses path 2 without affecting path 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Langfuse observability: when Langfuse is enabled, session IDs are automatically included and user IDs are included when available; newly added observability targets become active immediately.
* **Tests**
  * Added unit tests validating Langfuse metadata is emitted only when configured and that metadata includes user ID conditionally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->