### PR TITLE
chore: bump version to 0.9.4

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.3"
+    "version": "0.9.4"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.3"
+version = "0.9.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.3"
+version = "0.9.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -96,7 +96,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary
Bump both `aegra-api` and `aegra-cli` from 0.9.3 to 0.9.4.

## Changes since 0.9.3

### New features
- **#304** (`feat(cli)`): `aegra dev` now supports `--debug-port`, `--debug-host`, and `--wait-for-client` for remote debugging via `debugpy`. Optional install: `pip install 'aegra-cli[debug]'`. Binds to loopback by default; non-loopback hosts trigger a safety warning panel.
- **#300** (`feat(middleware)`): New `LOG_EXCLUDE_PATHS` env var suppresses access logs for successful (2xx/3xx) requests to matching path prefixes (e.g. `/health,/metrics`). Error responses (4xx/5xx) are always logged.

### Bug fixes
- **#268** (`fix(graph)`): Normalize `AIMessage`/`ToolMessage` to chunk types in `messages-tuple` stream mode. Previously, non-streaming LLMs (e.g. GigaChat with `streaming=False`) emitted `"type": "ai"` while streaming LLMs emitted `"type": "AIMessageChunk"` for the same stream mode. Now always emits chunk types for a consistent wire format. Only affects `stream_mode: ["messages-tuple"]` — accumulating `messages` mode and REST endpoints are untouched.

## Test plan
- [ ] CI passes
- [ ] After merge, trigger `release.yml` workflow to publish both packages to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version to 0.9.4 across documentation and package configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->