### PR TITLE
fix(cli): make sure that debug-port is sent as string to debugpy 

### DIFF
--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -386,7 +386,7 @@ def dev(
         )
 
         # Always bind debugpy to the debug host (default loopback) regardless of --host
-        listen = debug_port
+        listen = str(debug_port)
         is_loopback = True
 
         # If debug_host is specified, warn if it's not loopback. Also handle ip v4 and v6 addresses

--- a/libs/aegra-cli/tests/test_cli.py
+++ b/libs/aegra-cli/tests/test_cli.py
@@ -278,7 +278,8 @@ class TestDevCommand:
                 # Ensure debugpy is used and listening on given port bound to loopback
                 assert "debugpy" in call_args
                 assert "--listen" in call_args
-                assert "5678" in " ".join(map(str, call_args))
+                listen_idx = call_args.index("--listen")
+                assert call_args[listen_idx + 1] == "5678"
                 # Ensure uvicorn still present
                 assert "uvicorn" in call_args
                 assert "--reload" in call_args
@@ -361,7 +362,7 @@ class TestDevCommand:
                 mock_popen.assert_called_once()
                 call_args = mock_popen.call_args[0][0]
                 listen_idx = call_args.index("--listen")
-                assert call_args[listen_idx + 1] == 5678
+                assert call_args[listen_idx + 1] == "5678"
                 assert "not-a-valid-host:5678" not in " ".join(map(str, call_args))
 
     def test_dev_debug_host_non_loopback_warns(self, cli_runner: CliRunner, tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

I made a mistake in https://github.com/aegra/aegra/pull/304. When the `debug-port` argument is used alone, we send an integer to debugpy, but debugpy expects a string. That results in the following error.

<!-- Provide a clear description of your changes -->
```
TypeError: expected str, bytes or os.PathLike object, not int
```

The workaround is using `--debug-host 127.0.0.1` (the default value)

This PR solves the problem by casting debug-port to string.

## Type of Change
<!-- Check the relevant option -->
- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->

## Changes Made
<!-- List the main changes -->
- Cast debug-port argument before sending it to debugpy

## Testing
<!-- Describe how you tested your changes -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist
<!-- Ensure all items are checked before requesting review -->
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected debug port handling in the development command to ensure the `--debug-port` argument works correctly with the debugger configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->