### PR TITLE
fix: restore checkpoint-based fork/resume (POST /runs and /state)

### DIFF
--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -391,11 +391,17 @@ async def update_thread_state(
 
     When `values` is provided, creates a new checkpoint with the updated state.
     Use `as_node` to attribute the update to a specific graph node. When
-    `values` is null, this endpoint acts as a POST-based alternative to the
-    GET state endpoint (useful when passing complex checkpoint/subgraph
-    parameters in the request body).
+    `values` is null AND `as_node` is not provided, this endpoint acts as a
+    POST-based alternative to the GET state endpoint (useful when passing
+    complex checkpoint/subgraph parameters in the request body).
+
+    When `values` is null AND `as_node` is provided (e.g. ``as_node="__copy__"``
+    as LangGraph Studio sends for "Re-run from here"), this creates a new
+    checkpoint derived from the supplied ``checkpoint_id`` without applying
+    any state change — used to anchor a subsequent run as a fork of that
+    checkpoint rather than of the thread's latest state.
     """
-    if request.values is None:
+    if request.values is None and request.as_node is None:
         return await get_thread_state(
             thread_id=thread_id,
             subgraphs=request.subgraphs or False,

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -35,7 +35,7 @@ class RunExecution(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    input_data: dict[str, Any] = Field(default_factory=dict)
+    input_data: dict[str, Any] | None = None
     config: dict[str, Any] = Field(default_factory=dict)
     context: dict[str, Any] = Field(default_factory=dict)
     stream_mode: str | list[str] | None = None

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -82,8 +82,10 @@ class RunCreate(BaseModel):
                 raise ValueError("Cannot specify both 'input' and 'command' - they are mutually exclusive")
         if self.input is None and self.command is None:
             if self.checkpoint is not None:
-                # Allow checkpoint-only requests by treating input as empty dict
-                self.input = {}
+                # Keep input as None so LangGraph resumes from the checkpoint.
+                # Coercing to {} makes Pregel treat it as fresh input and restart
+                # from __start__ instead of continuing from next=[...].
+                pass
             else:
                 raise ValueError("Must specify either 'input' or 'command'")
         return self

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -224,7 +224,7 @@ async def _prepare_run(
         identity=RunIdentity(run_id=run_id, thread_id=thread_id, graph_id=assistant.graph_id),
         user=user,
         execution=RunExecution(
-            input_data=request.input or {},
+            input_data=request.input,  # preserve None so LangGraph resumes from checkpoint
             config=config,
             context=context,
             stream_mode=request.stream_mode,

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -621,6 +621,55 @@ class TestThreadUpdateState:
         assert resp.status_code == 400
         assert "no associated graph" in resp.json()["detail"]
 
+    def test_update_state_copy_checkpoint_with_as_node(self):
+        """values=None + as_node must create a copy checkpoint via aupdate_state.
+
+        Regression test: LangGraph Studio posts {"values": null,
+        "as_node": "__copy__", "checkpoint_id": X} to anchor a "Re-run
+        from here" fork at checkpoint X. Previously the handler short-
+        circuited to get_thread_state whenever values was None, so no
+        new checkpoint was created and subsequent runs forked from the
+        thread's latest checkpoint instead of X.
+        """
+        app = create_test_app(include_runs=False, include_threads=True)
+        thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt):
+                return thread
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        mock_agent = AsyncMock()
+        mock_agent.aupdate_state.return_value = {"configurable": {"checkpoint_id": "copy-cp", "checkpoint_ns": ""}}
+        mock_agent.with_config = Mock(return_value=mock_agent)
+
+        with patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_get_service:
+            mock_service = mock_get_service.return_value
+            mock_service.get_graph = create_get_graph_mock(return_value=mock_agent)
+
+            resp = client.post(
+                "/threads/test-123/state",
+                json={
+                    "values": None,
+                    "as_node": "__copy__",
+                    "checkpoint_id": "original-cp",
+                },
+            )
+
+            assert resp.status_code == 200
+            result = resp.json()
+            assert result["checkpoint"]["checkpoint_id"] == "copy-cp"
+
+            # aupdate_state must be invoked with the Studio-supplied checkpoint_id
+            # so the copy is anchored to the correct parent.
+            mock_agent.aupdate_state.assert_called_once()
+            cfg, values, *_ = mock_agent.aupdate_state.call_args[0]
+            assert values is None
+            assert cfg["configurable"]["checkpoint_id"] == "original-cp"
+            assert mock_agent.aupdate_state.call_args[1]["as_node"] == "__copy__"
+
 
 class TestThreadStateCheckpoint:
     """Test GET /threads/{thread_id}/state/{checkpoint_id} endpoint"""

--- a/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
@@ -8,15 +8,22 @@ from aegra_api.models.runs import RunCreate
 class TestRunCreateValidation:
     """Tests for RunCreate input/command validation."""
 
-    def test_allows_checkpoint_only_payload(self):
-        """Ensure checkpoint-only payloads are accepted and default input to empty dict."""
+    def test_checkpoint_only_payload_preserves_none_input(self):
+        """Checkpoint-only payloads must keep input as None so LangGraph resumes
+        from the checkpoint instead of restarting the graph from __start__.
+
+        Regression test: previously the validator coerced input to ``{}`` which
+        LangGraph Pregel treats as "new input" and re-enters __start__, ignoring
+        the checkpoint's ``next=[...]``.
+        """
         run_create = RunCreate(
             assistant_id="agent",
             checkpoint={"checkpoint_id": "chk-1", "checkpoint_ns": ""},
         )
 
-        assert run_create.input == {}
+        assert run_create.input is None
         assert run_create.command is None
+        assert run_create.checkpoint == {"checkpoint_id": "chk-1", "checkpoint_ns": ""}
 
     def test_rejects_payload_without_input_command_or_checkpoint(self):
         """Ensure payloads with no input, command, or checkpoint are rejected."""

--- a/libs/aegra-api/tests/unit/test_services/test_run_job.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_job.py
@@ -23,7 +23,7 @@ class TestRunIdentity:
 class TestRunExecution:
     def test_defaults(self) -> None:
         execution = RunExecution()
-        assert execution.input_data == {}
+        assert execution.input_data is None
         assert execution.config == {}
         assert execution.context == {}
         assert execution.stream_mode is None
@@ -121,5 +121,5 @@ class TestRunJob:
             identity=RunIdentity(run_id="r1", thread_id="t1", graph_id="g1"),
             user=User(identity="u1"),
         )
-        assert job.execution.input_data == {}
+        assert job.execution.input_data is None
         assert job.behavior.subgraphs is False


### PR DESCRIPTION
## Description

Two related bugs prevent callers from forking a thread at a specific checkpoint — the payload shape the official LangGraph SDK emits, and the shape LangGraph Studio's "Re-run from here" button relies on. With either bug, the graph silently restarts from `__start__` or forks from the thread's latest checkpoint instead of the one the caller selected.

### Bug 1 — `POST /threads/{id}/runs` coerces `input=None` → `{}`

`RunCreate.validate_input_command_exclusivity` sets `self.input = {}` when only `checkpoint` is provided, and `_prepare_run` re-coerces via `input_data=request.input or {}` when building the `RunExecution`. LangGraph Pregel treats `input={}` as a fresh empty input and re-enters `__start__` with `source="input"` instead of resuming from the checkpoint's `next=[...]` with `source="fork"`.

### Bug 2 — `POST /threads/{id}/state` ignores `as_node` when `values=null`

LangGraph Studio's "Re-run from here" issues `{"values": null, "as_node": "__copy__", "checkpoint_id": X}` before starting the run. The handler short-circuits to `get_thread_state` whenever `values` is `None`, so no copy checkpoint is ever created. The subsequent `/runs` call then forks from the thread's *actual* latest checkpoint — i.e. clicking "Re-run from here" on any node silently resumes from wherever the thread was last stuck.

## Type of Change

- [x] `fix`: Bug fix

## Related Issues

Fixes #320

## Changes Made

**Bug 1** (commit `17a6414`)
- `models/runs.py`: validator no longer coerces `input` to `{}` when only `checkpoint` is provided.
- `models/run_job.py`: widen `RunExecution.input_data` to `dict | None` so `None` survives the frozen Pydantic model.
- `services/run_preparation.py`: pass `request.input` through unchanged instead of `request.input or {}`.
- Unit tests updated to match the new default plus a regression test covering checkpoint-only payloads.

**Bug 2** (commit `7d77bd6`)
- `api/threads.py`: only short-circuit `POST /state` to `get_thread_state` when *both* `values` and `as_node` are `None`. When `as_node` is set (e.g. `"__copy__"`), fall through to `aupdate_state(config, None, as_node=...)` so a new copy checkpoint is written at the supplied `checkpoint_id`.
- Integration test added covering the Studio `__copy__` flow.

## Testing

- [x] Unit tests added/updated (`test_runcreate_validation.py`, `test_run_job.py`)
- [x] Integration tests added/updated (`test_threads_crud.py::TestThreadUpdateState::test_update_state_copy_checkpoint_with_as_node`)
- [ ] E2E tests added/updated
- [x] Manual testing performed

### Verified locally against a 3-node graph `A → B → C`

**Bug 1** — fork from the mid-run checkpoint where `next=['B']`, `trace=['A']`:

- Before: final `trace=['A','A','B','C']` (A ran twice), new checkpoint `source="input"`, `next=['__start__']`.
- After: final `trace=['A','B','C']`, new checkpoint `source="fork"`, `next=['B']`.

**Bug 2** — Studio's two-step flow (`POST /state` with `as_node="__copy__"` at step-1's checkpoint, then `POST /runs` against the latest):

- Before: `/state` returned current thread state, no new checkpoint. Follow-up run anchored at step-3 (the thread's latest) — `trace=['A','A','B','C']`.
- After: `/state` wrote a new copy checkpoint at step-2 (`source="fork"`, `next=['B']`, `trace=['A']`). Follow-up run anchored at the copy — `trace=['A','B','C']`.

`make lint`, `make type-check`, and `make test` pass locally (1165 api unit + 179 cli unit + integration tests).

## Checklist

- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check` — no new diagnostics introduced)
- [x] All tests pass (`make test`)
- [ ] Documentation updated (if needed)
- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits format

## Additional Notes

- Bug 2 was discovered after #320 was filed. Happy to split it into its own issue/PR if you'd prefer — the two commits stand alone and can be reviewed independently.
- The `RunExecution.input_data` type widening (`dict` → `dict | None`) is required because the model is `frozen=True` and round-trips through JSONB via `to_execution_params()`; without it, Pydantic rejects the `None` that has to flow through to `graph.astream()`.