### PR TITLE
fix(api): SSE keepalive and transport-layer disconnect handling

### DIFF
--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -183,6 +183,8 @@ async for chunk in client.runs.stream(
 | `"cancel"` (default) | Cancel the run when client disconnects |
 | `"continue"` | Run continues in the background; reconnect later to get results |
 
+The server sends SSE keepalive comments (`: heartbeat`) every `KEEPALIVE_INTERVAL_SECS` (default 5s), so idle proxies (Nginx 60s, AWS ALB, Cloudflare) won't drop long-running silent agents — for example, a graph node holding an upstream WebSocket without emitting events. The wire-format matches LangGraph Platform, so existing SSE clients (the LangGraph SDK, browser `EventSource`, `httpx-sse`) silently ignore these lines per the W3C spec. Only a real client disconnect — not an idle proxy timeout — triggers automatic cancellation.
+
 ## Background runs
 
 For long-running tasks, you can create a run in the background and check on it later:

--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -183,7 +183,7 @@ async for chunk in client.runs.stream(
 | `"cancel"` (default) | Cancel the run when client disconnects |
 | `"continue"` | Run continues in the background; reconnect later to get results |
 
-The server sends SSE keepalive comments (`: heartbeat`) every `KEEPALIVE_INTERVAL_SECS` (default 5s), so idle proxies (Nginx 60s, AWS ALB, Cloudflare) won't drop long-running silent agents — for example, a graph node holding an upstream WebSocket without emitting events. The wire-format matches LangGraph Platform, so existing SSE clients (the LangGraph SDK, browser `EventSource`, `httpx-sse`) silently ignore these lines per the W3C spec. Only a real client disconnect — not an idle proxy timeout — triggers automatic cancellation.
+The server sends SSE keepalive comments (`: heartbeat`) every `KEEPALIVE_INTERVAL_SECS` (default 5s, truncated to whole seconds, minimum 1s), so idle proxies (Nginx 60s, AWS ALB, Cloudflare) won't drop long-running silent agents — for example, a graph node holding an upstream WebSocket without emitting events. The wire-format matches LangGraph Platform, so existing SSE clients (the LangGraph SDK, browser `EventSource`, `httpx-sse`) silently ignore these lines per the W3C spec. Only a real client disconnect — not an idle proxy timeout — triggers automatic cancellation.
 
 ## Background runs
 

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "uvicorn>=0.35.0",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.12.0",
+    "sse-starlette>=3.3.4,<4.0.0",
 
     # LangGraph
     "langgraph>=1.0.3",

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -2,23 +2,26 @@
 
 import asyncio
 import contextlib
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, MutableMapping
 from datetime import UTC, datetime
+from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sse_starlette import EventSourceResponse
 
 from aegra_api.core.active_runs import active_runs
 from aegra_api.core.auth_deps import auth_dependency, get_current_user
 from aegra_api.core.auth_handlers import build_auth_context, handle_event
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import _get_session_maker, get_session
-from aegra_api.core.sse import create_end_event, get_sse_headers
+from aegra_api.core.sse import create_end_event, get_sse_headers, heartbeat_factory, sse_to_bytes
 from aegra_api.models import Run, RunCreate, RunStatus, User
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
+from aegra_api.services.broker import broker_manager
 from aegra_api.services.run_preparation import _prepare_run
 from aegra_api.services.run_waiters import TERMINAL_STATES, encode_output, heartbeat_wait_body
 from aegra_api.services.streaming_service import streaming_service
@@ -81,7 +84,7 @@ async def create_and_stream_run(
     request: RunCreate,
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
-) -> StreamingResponse:
+) -> EventSourceResponse:
     """Create a new run and stream its execution via SSE.
 
     Returns a `text/event-stream` response with Server-Sent Events. Each
@@ -91,6 +94,10 @@ async def create_and_stream_run(
     Set `on_disconnect` to `"continue"` if the run should keep executing
     after the client disconnects (default is `"cancel"`). Use `stream_mode`
     to control which event types are emitted.
+
+    A periodic SSE keepalive comment is sent every
+    ``KEEPALIVE_INTERVAL_SECS`` so idle proxies don't drop long-running
+    silent nodes (e.g. agents holding an upstream WebSocket).
     """
     run_id, run, _job = await _prepare_run(session, thread_id, request, user, initial_status="pending")
 
@@ -99,13 +106,23 @@ async def create_and_stream_run(
     # set on_disconnect="continue" if they want the task to continue.
     cancel_on_disconnect = (request.on_disconnect or "cancel").lower() == "cancel"
 
-    return StreamingResponse(
-        streaming_service.stream_run_execution(
-            run,
-            None,
-            cancel_on_disconnect=cancel_on_disconnect,
-        ),
-        media_type="text/event-stream",
+    async def _cancel_on_client_close(_msg: MutableMapping[str, Any]) -> None:
+        try:
+            await broker_manager.request_cancel(run_id, "cancel")
+        except Exception:
+            # Swallow to avoid cascading the failure through sse-starlette's
+            # task group. If the broker is unreachable we can't stop the run;
+            # it will either complete normally (result persists to Postgres)
+            # or be reaped when its worker lease expires.
+            logger.exception("Failed to cancel run on client disconnect", run_id=run_id)
+
+    close_handler = _cancel_on_client_close if cancel_on_disconnect else None
+
+    return EventSourceResponse(
+        sse_to_bytes(streaming_service.stream_run_execution(run, None)),
+        ping=settings.app.sse_ping_interval_secs,
+        ping_message_factory=heartbeat_factory,
+        client_close_handler_callable=close_handler,
         headers={
             **get_sse_headers(),
             "Location": f"/threads/{thread_id}/runs/{run_id}/stream",
@@ -337,13 +354,16 @@ async def stream_run(
     _stream_mode: str | None = Query(None, description="Override the stream mode for this connection."),
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
-) -> StreamingResponse:
+) -> EventSourceResponse:
     """Stream an existing run's execution via SSE.
 
     Attach to a run that was created without streaming (e.g. via the create
     endpoint) to receive its events in real time. If the run has already
     finished, a single `end` event is emitted. Use the `Last-Event-ID`
     header to resume from a specific event after a disconnect.
+
+    A periodic SSE keepalive comment is sent every
+    ``KEEPALIVE_INTERVAL_SECS`` so idle proxies don't drop attached streams.
     """
     logger.info(f"[stream_run] fetch for stream run_id={run_id} thread_id={thread_id} user={user.identity}")
     run_orm = await session.scalar(
@@ -357,6 +377,9 @@ async def stream_run(
         raise HTTPException(404, f"Run '{run_id}' not found")
 
     logger.info(f"[stream_run] status={run_orm.status} user={user.identity} thread_id={thread_id} run_id={run_id}")
+    # No client_close_handler_callable: this is a reconnect-style endpoint, so
+    # a single client disconnecting must not cancel the shared run — other
+    # consumers may still be attached via /join or another /stream.
     # If already terminal and no Last-Event-ID, just emit end.
     # If Last-Event-ID is present, fall through to stream_run_execution
     # which will replay missed events from the buffer before ending.
@@ -367,9 +390,10 @@ async def stream_run(
             yield create_end_event(status=final_status)
 
         logger.info(f"[stream_run] starting terminal stream run_id={run_id} status={run_orm.status}")
-        return StreamingResponse(
-            generate_final(),
-            media_type="text/event-stream",
+        return EventSourceResponse(
+            sse_to_bytes(generate_final()),
+            ping=settings.app.sse_ping_interval_secs,
+            ping_message_factory=heartbeat_factory,
             headers={
                 **get_sse_headers(),
                 "Location": f"/threads/{thread_id}/runs/{run_id}/stream",
@@ -382,9 +406,10 @@ async def stream_run(
     # Build a lightweight Pydantic Run from ORM for streaming context (IDs already strings)
     run_model = Run.model_validate(run_orm)
 
-    return StreamingResponse(
-        streaming_service.stream_run_execution(run_model, last_event_id, cancel_on_disconnect=False),
-        media_type="text/event-stream",
+    return EventSourceResponse(
+        sse_to_bytes(streaming_service.stream_run_execution(run_model, last_event_id)),
+        ping=settings.app.sse_ping_interval_secs,
+        ping_message_factory=heartbeat_factory,
         headers={
             **get_sse_headers(),
             "Location": f"/threads/{thread_id}/runs/{run_id}/stream",

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -2,13 +2,14 @@
 
 import asyncio
 import contextlib
-from collections.abc import AsyncIterator, MutableMapping
+from collections.abc import AsyncGenerator, MutableMapping
 from datetime import UTC, datetime
 from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import StreamingResponse
+from redis import RedisError
 from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette import EventSourceResponse
@@ -19,7 +20,7 @@ from aegra_api.core.auth_handlers import build_auth_context, handle_event
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import _get_session_maker, get_session
-from aegra_api.core.sse import create_end_event, get_sse_headers, heartbeat_factory, sse_to_bytes
+from aegra_api.core.sse import create_end_event, get_sse_headers, make_sse_response, sse_to_bytes
 from aegra_api.models import Run, RunCreate, RunStatus, User
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
 from aegra_api.services.broker import broker_manager
@@ -118,20 +119,17 @@ async def create_and_stream_run(
     async def _cancel_on_client_close(_msg: MutableMapping[str, Any]) -> None:
         try:
             await broker_manager.request_cancel(run_id, "cancel")
-        except Exception:
-            # Swallow to avoid cascading the failure through sse-starlette's
-            # task group. If the broker is unreachable we can't stop the run;
-            # it will either complete normally (result persists to Postgres)
-            # or be reaped when its worker lease expires.
+        except (RedisError, OSError):
+            # Swallow infra/transport failures so sse-starlette's task group
+            # tears down cleanly. Programmer errors (TypeError, AttributeError,
+            # ...) propagate. The lease reaper picks up unreachable runs.
             logger.exception("Failed to cancel run on client disconnect", run_id=run_id)
 
     close_handler = _cancel_on_client_close if cancel_on_disconnect else None
 
-    return EventSourceResponse(
+    return make_sse_response(
         sse_to_bytes(streaming_service.stream_run_execution(run, None)),
-        ping=settings.app.sse_ping_interval_secs,
-        ping_message_factory=heartbeat_factory,
-        client_close_handler_callable=close_handler,
+        close_handler=close_handler,
         headers={
             **get_sse_headers(),
             "Location": f"/threads/{thread_id}/runs/{run_id}/stream",
@@ -399,14 +397,12 @@ async def stream_run(
     if run_orm.status in TERMINAL_STATES and not last_event_id:
         final_status = "error" if run_orm.status == "error" else run_orm.status
 
-        async def generate_final() -> AsyncIterator[str]:
+        async def generate_final() -> AsyncGenerator[str, None]:
             yield create_end_event(status=final_status)
 
         logger.info(f"[stream_run] starting terminal stream run_id={run_id} status={run_orm.status}")
-        return EventSourceResponse(
+        return make_sse_response(
             sse_to_bytes(generate_final()),
-            ping=settings.app.sse_ping_interval_secs,
-            ping_message_factory=heartbeat_factory,
             headers={
                 **get_sse_headers(),
                 "Location": f"/threads/{thread_id}/runs/{run_id}/stream",
@@ -419,10 +415,8 @@ async def stream_run(
     # Build a lightweight Pydantic Run from ORM for streaming context (IDs already strings)
     run_model = Run.model_validate(run_orm)
 
-    return EventSourceResponse(
+    return make_sse_response(
         sse_to_bytes(streaming_service.stream_run_execution(run_model, last_event_id)),
-        ping=settings.app.sse_ping_interval_secs,
-        ping_message_factory=heartbeat_factory,
         headers={
             **get_sse_headers(),
             "Location": f"/threads/{thread_id}/runs/{run_id}/stream",

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -123,6 +123,7 @@ async def create_and_stream_run(
             # Swallow infra/transport failures so sse-starlette's task group
             # tears down cleanly. Programmer errors (TypeError, AttributeError,
             # ...) propagate. The lease reaper picks up unreachable runs.
+            # OSError covers ConnectionError/TimeoutError (3.11+ subclasses).
             logger.exception("Failed to cancel run on client disconnect", run_id=run_id)
 
     close_handler = _cancel_on_client_close if cancel_on_disconnect else None

--- a/libs/aegra-api/src/aegra_api/api/stateless_runs.py
+++ b/libs/aegra-api/src/aegra_api/api/stateless_runs.py
@@ -218,18 +218,30 @@ async def stateless_stream_run(
     inner_close_handler = response.client_close_handler_callable
 
     async def _wrapped_iterator() -> AsyncIterator[bytes]:
+        completed = False
         try:
             async for chunk in original_iterator:
                 yield chunk
+            completed = True
         finally:
             aclose = getattr(original_iterator, "aclose", None)
             if aclose is not None:
                 await aclose()
-            try:
-                await _delete_thread_by_id(thread_id, user.identity)
-            except Exception:
-                logger.exception(
-                    "Failed to delete ephemeral thread after stream",
+            if completed:
+                try:
+                    await _delete_thread_by_id(thread_id, user.identity)
+                except Exception:
+                    logger.exception(
+                        "Failed to delete ephemeral thread after stream",
+                        thread_id=thread_id,
+                    )
+            else:
+                # Early client disconnect: deleting the thread here would
+                # cancel the still-running background execution (via
+                # _delete_thread_by_id) and break the on_disconnect="continue"
+                # contract. Mirror stateless_wait_for_run and keep the thread.
+                logger.info(
+                    "Client disconnected before stream completed, keeping ephemeral thread",
                     thread_id=thread_id,
                 )
 

--- a/libs/aegra-api/src/aegra_api/api/stateless_runs.py
+++ b/libs/aegra-api/src/aegra_api/api/stateless_runs.py
@@ -7,13 +7,15 @@ explicitly sets ``on_completion="keep"``).
 """
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from uuid import uuid4
 
 import structlog
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
+from redis import RedisError
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette import EventSourceResponse
 
@@ -27,18 +29,24 @@ from aegra_api.core.auth_deps import auth_dependency, get_current_user
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import _get_session_maker, get_session
-from aegra_api.core.sse import heartbeat_factory
+from aegra_api.core.sse import make_sse_response
 from aegra_api.models import Run, RunCreate, User
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
+from aegra_api.services.broker import broker_manager
 from aegra_api.services.executor import executor
 from aegra_api.services.streaming_service import streaming_service
-from aegra_api.settings import settings
 
 router = APIRouter(tags=["Stateless Runs"], dependencies=auth_dependency)
 logger = structlog.getLogger(__name__)
 
 # Strong references to fire-and-forget cleanup tasks to prevent GC
 _background_cleanup_tasks: set[asyncio.Task[None]] = set()
+
+# Transient infra/transport failures we tolerate during ephemeral-thread
+# cleanup. Programmer errors (TypeError, AttributeError, ...) propagate.
+# Centralized so a future addition (e.g. ``httpx.RequestError`` if
+# cleanup grows HTTP calls) is a one-line change.
+_CLEANUP_ERRORS: tuple[type[BaseException], ...] = (RedisError, SQLAlchemyError, OSError)
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +80,7 @@ async def _delete_thread_by_id(thread_id: str, user_id: str) -> None:
                     await task
                 except asyncio.CancelledError:
                     pass
-                except Exception:
+                except _CLEANUP_ERRORS:
                     logger.exception("Error awaiting cancelled task during thread cleanup", run_id=run_id)
 
         # Delete thread (cascade deletes runs via FK)
@@ -97,13 +105,81 @@ async def _cleanup_after_background_run(run_id: str, thread_id: str, user_id: st
         await executor.wait_for_completion(run_id, timeout=3600.0)
     except (asyncio.CancelledError, TimeoutError):
         pass
-    except Exception:
+    except _CLEANUP_ERRORS:
         logger.exception("Error waiting for background run", run_id=run_id)
 
     try:
         await _delete_thread_by_id(thread_id, user_id)
-    except Exception:
+    except _CLEANUP_ERRORS:
         logger.exception("Failed to delete ephemeral thread", thread_id=thread_id, run_id=run_id)
+
+
+def _run_finished(run_id: str) -> bool:
+    """Best-effort check: did the run already publish its end event locally?
+
+    Both broker backends set ``_finished`` whenever ``put(end)``
+    (producer-side) or ``aiter()`` reading the end event (consumer-side)
+    runs in this process. From the calling instance's perspective:
+
+      - In-memory (dev): producer and consumer share this process, so
+        any ``end`` event reliably flips the flag.
+      - Redis (prod): if the run was picked up by a worker on another
+        instance, this process never called ``put()`` — the flag flips
+        only after our local pub/sub subscriber drains the end event.
+        A slow-client abort that races ahead of the drain leaves the
+        flag False even though the run itself terminated.
+
+    Returning False errs on keeping the thread. The broker cleanup task
+    removes the broker dict entry after an hour, but it does NOT delete
+    the ephemeral thread row from Postgres — leaving an unmatched abort
+    here leaks an empty ephemeral thread until an external sweeper
+    reaps it (TODO: see follow-up ticket for the orphan-thread sweeper).
+
+    A missing broker (None) also returns False — the safe answer for
+    "run not started" and "broker dict entry already swept".
+    """
+    broker = broker_manager.get_broker(run_id)
+    return broker is not None and broker.is_finished()
+
+
+def _extract_run_id_from_headers(headers: Mapping[str, str]) -> str | None:
+    """Pull ``run_id`` from a streaming response's ``Content-Location``.
+
+    Both ``wait_for_run`` and ``create_and_stream_run`` set
+    ``Content-Location: /threads/{thread_id}/runs/{run_id}`` with the same
+    format; we currently call this only from the stream endpoint, where
+    slow-client cleanup needs the run_id to consult the broker.
+
+    Starlette's ``Headers``/``MutableHeaders`` is case-insensitive on
+    ``.get`` and stores keys lowercase per the ASGI spec, so the
+    lowercase lookup is the canonical path. The capitalized fallback
+    covers plain ``dict`` callers (e.g. unit tests constructing headers
+    directly) — cheap defense vs the silent "always returns None" bug
+    if someone ever bypasses Starlette normalization. Failing to parse
+    disables the slow-client cleanup branch — not fatal.
+    """
+    location = headers.get("content-location") or headers.get("Content-Location") or ""
+    if not location:
+        return None
+    parts = location.strip("/").split("/")
+    if len(parts) >= 4 and parts[0] == "threads" and parts[2] == "runs":
+        return parts[3]
+    return None
+
+
+async def _delete_thread_with_log(thread_id: str, user_id: str, *, reason: str) -> None:
+    """Delete an ephemeral thread, logging infra failures."""
+    try:
+        await _delete_thread_by_id(thread_id, user_id)
+    except _CLEANUP_ERRORS:
+        logger.exception(reason, thread_id=thread_id)
+
+
+def _schedule_thread_cleanup(thread_id: str, user_id: str, *, reason: str) -> None:
+    """Fire-and-forget delete keyed off ``_background_cleanup_tasks``."""
+    task = asyncio.create_task(_delete_thread_with_log(thread_id, user_id, reason=reason))
+    _background_cleanup_tasks.add(task)
+    task.add_done_callback(_background_cleanup_tasks.discard)
 
 
 # ---------------------------------------------------------------------------
@@ -131,7 +207,7 @@ async def stateless_wait_for_run(
         if should_delete:
             try:
                 await _delete_thread_by_id(thread_id, user.identity)
-            except Exception:
+            except _CLEANUP_ERRORS:
                 logger.exception(
                     "Failed to delete ephemeral thread after wait error",
                     thread_id=thread_id,
@@ -141,7 +217,14 @@ async def stateless_wait_for_run(
     if not should_delete:
         return response
 
-    # Wrap the body_iterator so cleanup happens after the stream ends
+    # Wrap the body_iterator so cleanup happens after the stream ends.
+    # The slow-client cleanup branch is intentionally omitted here: in
+    # prod-mode the wait endpoint never iterates the broker locally
+    # (heartbeat_wait_body polls executor state, not events), so the
+    # consumer-instance broker stays out of the local cache and
+    # ``_run_finished`` would always return False cross-instance.
+    # Stream endpoint keeps the slow-client branch where the consumer
+    # actually subscribes to the broker.
     original_iterator = response.body_iterator
 
     async def _wrapped_iterator() -> AsyncIterator[bytes]:
@@ -155,13 +238,9 @@ async def stateless_wait_for_run(
             if aclose is not None:
                 await aclose()
             if completed:
-                try:
-                    await _delete_thread_by_id(thread_id, user.identity)
-                except Exception:
-                    logger.exception(
-                        "Failed to delete ephemeral thread after wait",
-                        thread_id=thread_id,
-                    )
+                await _delete_thread_with_log(
+                    thread_id, user.identity, reason="Failed to delete ephemeral thread after wait"
+                )
             else:
                 logger.info(
                     "Client disconnected before stream completed, keeping ephemeral thread",
@@ -199,7 +278,7 @@ async def stateless_stream_run(
         if should_delete:
             try:
                 await _delete_thread_by_id(thread_id, user.identity)
-            except Exception:
+            except _CLEANUP_ERRORS:
                 logger.exception(
                     "Failed to delete ephemeral thread after stream setup error",
                     thread_id=thread_id,
@@ -209,13 +288,14 @@ async def stateless_stream_run(
     if not should_delete:
         return response
 
-    # Wrap the body_iterator so cleanup happens after the stream ends.
-    # The inner EventSourceResponse is never served directly — we only
-    # steal its iterator and close-handler, then re-wrap in a new
-    # EventSourceResponse so the outer ping/listen-for-disconnect tasks
-    # run against the cleaned-up iterator.
+    # The inner EventSourceResponse is never ASGI-served — its background
+    # ping/listen-for-disconnect tasks are only spawned inside __call__,
+    # which we never invoke. We borrow its iterator + close-handler here
+    # and build a fresh outer response so those background tasks run
+    # against the cleanup-wrapped iterator instead.
     original_iterator = response.body_iterator
     inner_close_handler = response.client_close_handler_callable
+    run_id = _extract_run_id_from_headers(response.headers)
 
     async def _wrapped_iterator() -> AsyncIterator[bytes]:
         completed = False
@@ -228,29 +308,31 @@ async def stateless_stream_run(
             if aclose is not None:
                 await aclose()
             if completed:
-                try:
-                    await _delete_thread_by_id(thread_id, user.identity)
-                except Exception:
-                    logger.exception(
-                        "Failed to delete ephemeral thread after stream",
-                        thread_id=thread_id,
-                    )
+                await _delete_thread_with_log(
+                    thread_id, user.identity, reason="Failed to delete ephemeral thread after stream"
+                )
+            elif run_id is not None and _run_finished(run_id):
+                # Slow-client / dead-proxy abort after the run already
+                # finished: there's nothing left to resume, so schedule a
+                # deferred delete instead of leaking the ephemeral thread.
+                _schedule_thread_cleanup(
+                    thread_id,
+                    user.identity,
+                    reason="Failed to delete ephemeral thread after slow-client abort",
+                )
             else:
-                # Early client disconnect: deleting the thread here would
-                # cancel the still-running background execution (via
-                # _delete_thread_by_id) and break the on_disconnect="continue"
-                # contract. Mirror stateless_wait_for_run and keep the thread.
+                # Early client disconnect with the run still active:
+                # _delete_thread_by_id would cancel the background execution
+                # and break the on_disconnect="continue" contract.
                 logger.info(
                     "Client disconnected before stream completed, keeping ephemeral thread",
                     thread_id=thread_id,
                 )
 
-    return EventSourceResponse(
+    return make_sse_response(
         _wrapped_iterator(),
         status_code=response.status_code,
-        ping=settings.app.sse_ping_interval_secs,
-        ping_message_factory=heartbeat_factory,
-        client_close_handler_callable=inner_close_handler,
+        close_handler=inner_close_handler,
         headers=dict(response.headers),
     )
 
@@ -278,7 +360,7 @@ async def stateless_create_run(
         if should_delete:
             try:
                 await _delete_thread_by_id(thread_id, user.identity)
-            except Exception:
+            except _CLEANUP_ERRORS:
                 logger.exception(
                     "Failed to delete ephemeral thread after create error",
                     thread_id=thread_id,

--- a/libs/aegra-api/src/aegra_api/api/stateless_runs.py
+++ b/libs/aegra-api/src/aegra_api/api/stateless_runs.py
@@ -132,8 +132,15 @@ def _run_finished(run_id: str) -> bool:
     Returning False errs on keeping the thread. The broker cleanup task
     removes the broker dict entry after an hour, but it does NOT delete
     the ephemeral thread row from Postgres — leaving an unmatched abort
-    here leaks an empty ephemeral thread until an external sweeper
-    reaps it (TODO: see follow-up ticket for the orphan-thread sweeper).
+    here leaks an empty ephemeral thread.
+
+    TODO(orphan-thread-sweeper): file as a follow-up issue. The sweeper
+    should periodically delete ephemeral threads (flagged via
+    ``is_ephemeral`` column or metadata) where no run is in
+    pending/running status and ``updated_at`` is older than a configured
+    retention window. Triggering condition for accumulation: prod-mode
+    Redis broker + slow-client / dead-proxy aborts that race ahead of
+    the local pub/sub subscriber draining the run's end event.
 
     A missing broker (None) also returns False — the safe answer for
     "run not started" and "broker dict entry already swept".

--- a/libs/aegra-api/src/aegra_api/api/stateless_runs.py
+++ b/libs/aegra-api/src/aegra_api/api/stateless_runs.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sse_starlette import EventSourceResponse
 
 from aegra_api.api.runs import (
     create_and_stream_run,
@@ -26,10 +27,12 @@ from aegra_api.core.auth_deps import auth_dependency, get_current_user
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import _get_session_maker, get_session
+from aegra_api.core.sse import heartbeat_factory
 from aegra_api.models import Run, RunCreate, User
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
 from aegra_api.services.executor import executor
 from aegra_api.services.streaming_service import streaming_service
+from aegra_api.settings import settings
 
 router = APIRouter(tags=["Stateless Runs"], dependencies=auth_dependency)
 logger = structlog.getLogger(__name__)
@@ -178,7 +181,7 @@ async def stateless_stream_run(
     request: RunCreate,
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
-) -> StreamingResponse:
+) -> EventSourceResponse:
     """Create a stateless run and stream its execution.
 
     Generates an ephemeral thread, delegates to the threaded
@@ -206,15 +209,19 @@ async def stateless_stream_run(
     if not should_delete:
         return response
 
-    # Wrap the body_iterator so cleanup happens after the stream ends
+    # Wrap the body_iterator so cleanup happens after the stream ends.
+    # The inner EventSourceResponse is never served directly — we only
+    # steal its iterator and close-handler, then re-wrap in a new
+    # EventSourceResponse so the outer ping/listen-for-disconnect tasks
+    # run against the cleaned-up iterator.
     original_iterator = response.body_iterator
+    inner_close_handler = response.client_close_handler_callable
 
-    async def _wrapped_iterator() -> AsyncIterator[str | bytes]:
+    async def _wrapped_iterator() -> AsyncIterator[bytes]:
         try:
             async for chunk in original_iterator:
                 yield chunk
         finally:
-            # Close the underlying iterator if it supports aclose()
             aclose = getattr(original_iterator, "aclose", None)
             if aclose is not None:
                 await aclose()
@@ -226,10 +233,12 @@ async def stateless_stream_run(
                     thread_id=thread_id,
                 )
 
-    return StreamingResponse(
+    return EventSourceResponse(
         _wrapped_iterator(),
         status_code=response.status_code,
-        media_type=response.media_type,
+        ping=settings.app.sse_ping_interval_secs,
+        ping_message_factory=heartbeat_factory,
+        client_close_handler_callable=inner_close_handler,
         headers=dict(response.headers),
     )
 

--- a/libs/aegra-api/src/aegra_api/core/sse.py
+++ b/libs/aegra-api/src/aegra_api/core/sse.py
@@ -2,15 +2,33 @@
 
 import json
 import re
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
+
+from sse_starlette import ServerSentEvent
 
 from aegra_api.core.serializers import GeneralSerializer
 
 # Global serializer instance
 _serializer = GeneralSerializer()
+
+# Cached SSE keepalive payload: ``: heartbeat\r\n\r\n`` (15 bytes).
+# Matches langgraph-api's wire-format so tcpdump/logs line up with LangGraph
+# Platform, and avoids per-tick datetime formatting that sse-starlette's
+# default ping does.
+_HEARTBEAT_EVENT = ServerSentEvent(comment="heartbeat")
+
+
+def heartbeat_factory() -> ServerSentEvent:
+    """Ping factory for ``EventSourceResponse(ping_message_factory=...)``.
+
+    Returns the same cached ``ServerSentEvent`` on every call — the encoded
+    payload is identical on every tick, so there's no reason to allocate.
+    """
+    return _HEARTBEAT_EVENT
+
 
 # Some LLMs stream tool_call_chunks.args with literal \uXXXX sequences
 # instead of actual Unicode characters. After json.dumps these become \\uXXXX (double-escaped).
@@ -50,6 +68,17 @@ def get_sse_headers() -> dict[str, str]:
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Headers": "Last-Event-ID",
     }
+
+
+async def sse_to_bytes(inner: AsyncIterator[str]) -> AsyncIterator[bytes]:
+    """Adapt an ``AsyncIterator[str]`` of pre-formatted SSE messages to bytes.
+
+    ``sse_starlette.EventSourceResponse`` wraps plain strings as *new* SSE
+    events (double-encoding them). Pass bytes through its iterator so our
+    already-formatted messages reach the wire untouched.
+    """
+    async for chunk in inner:
+        yield chunk.encode("utf-8")
 
 
 def format_sse_message(

--- a/libs/aegra-api/src/aegra_api/core/sse.py
+++ b/libs/aegra-api/src/aegra_api/core/sse.py
@@ -1,15 +1,17 @@
 """Server-Sent Events utilities and formatting"""
 
+import contextlib
 import json
 import re
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Mapping, MutableMapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from sse_starlette import ServerSentEvent
+from sse_starlette import EventSourceResponse, ServerSentEvent
 
 from aegra_api.core.serializers import GeneralSerializer
+from aegra_api.settings import settings
 
 # Global serializer instance
 _serializer = GeneralSerializer()
@@ -70,15 +72,43 @@ def get_sse_headers() -> dict[str, str]:
     }
 
 
-async def sse_to_bytes(inner: AsyncIterator[str]) -> AsyncIterator[bytes]:
-    """Adapt an ``AsyncIterator[str]`` of pre-formatted SSE messages to bytes.
+async def sse_to_bytes(inner: AsyncGenerator[str, None]) -> AsyncGenerator[bytes, None]:
+    """Adapt an ``AsyncGenerator[str]`` of pre-formatted SSE messages to bytes.
 
     ``sse_starlette.EventSourceResponse`` wraps plain strings as *new* SSE
     events (double-encoding them). Pass bytes through its iterator so our
     already-formatted messages reach the wire untouched.
+
+    Wraps ``inner`` in ``contextlib.aclosing`` so its ``finally`` blocks
+    (broker cleanup, replay-buffer release) fire deterministically even
+    when sse-starlette aborts us mid-stream on cancel.
     """
-    async for chunk in inner:
-        yield chunk.encode("utf-8")
+    async with contextlib.aclosing(inner) as managed:
+        async for chunk in managed:
+            yield chunk.encode("utf-8")
+
+
+def make_sse_response(
+    body: AsyncIterator[bytes],
+    *,
+    headers: Mapping[str, str],
+    close_handler: Callable[[MutableMapping[str, Any]], Awaitable[None]] | None = None,
+    status_code: int = 200,
+) -> EventSourceResponse:
+    """Construct an ``EventSourceResponse`` with our shared SSE defaults.
+
+    Centralizes ping interval + heartbeat factory so every SSE endpoint
+    emits identical wire-format keepalives. ``settings`` is read at call
+    time so live overrides (e.g. tests, env reloads) take effect.
+    """
+    return EventSourceResponse(
+        body,
+        status_code=status_code,
+        ping=settings.app.sse_ping_interval_secs,
+        ping_message_factory=heartbeat_factory,
+        client_close_handler_callable=close_handler,
+        headers=dict(headers),
+    )
 
 
 def format_sse_message(

--- a/libs/aegra-api/src/aegra_api/services/streaming_service.py
+++ b/libs/aegra-api/src/aegra_api/services/streaming_service.py
@@ -85,9 +85,14 @@ class StreamingService:
         self,
         run: Run,
         last_event_id: str | None = None,
-        cancel_on_disconnect: bool = False,
     ) -> AsyncIterator[str]:
-        """Stream run execution with unified producer-consumer pattern."""
+        """Stream run execution with unified producer-consumer pattern.
+
+        Cancellation on client disconnect is handled at the transport layer
+        via ``EventSourceResponse(client_close_handler_callable=...)`` — the
+        generator only propagates ``CancelledError`` cleanup without side
+        effects on the broker.
+        """
         run_id = run.run_id
         try:
             # Replay stored events first
@@ -108,8 +113,6 @@ class StreamingService:
 
         except asyncio.CancelledError:
             logger.debug(f"Stream cancelled for run {run_id}")
-            if cancel_on_disconnect:
-                await broker_manager.request_cancel(run_id, "cancel")
             raise
         except Exception as e:
             logger.error(f"Error in stream_run_execution for run {run_id}: {e}")

--- a/libs/aegra-api/src/aegra_api/services/streaming_service.py
+++ b/libs/aegra-api/src/aegra_api/services/streaming_service.py
@@ -1,7 +1,7 @@
 """Streaming service for orchestrating SSE streaming."""
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any
 
 import structlog
@@ -85,7 +85,7 @@ class StreamingService:
         self,
         run: Run,
         last_event_id: str | None = None,
-    ) -> AsyncIterator[str]:
+    ) -> AsyncGenerator[str, None]:
         """Stream run execution with unified producer-consumer pattern.
 
         Cancellation on client disconnect is handled at the transport layer
@@ -115,8 +115,14 @@ class StreamingService:
             logger.debug(f"Stream cancelled for run {run_id}")
             raise
         except Exception as e:
-            logger.error(f"Error in stream_run_execution for run {run_id}: {e}")
-            yield create_error_event(str(e))
+            # Swallow rather than re-raise: this is the SSE producer for
+            # an active connection. Re-raising would surface a 500 mid-
+            # stream, which clients can't reconnect to. We instead emit a
+            # structured error event so consumers can react cleanly.
+            # str(e) is suppressed on the wire because Python exception
+            # messages can leak file paths, internal IDs, and frame hints.
+            logger.exception("stream execution failed", run_id=run_id)
+            yield create_error_event({"error": type(e).__name__, "message": "execution failed"})
 
     async def _replay_stored_events(self, run_id: str, last_event_id: str | None) -> AsyncIterator[tuple[str, str]]:
         """Replay stored events from the broker's replay buffer.

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -61,6 +61,18 @@ class AppSettings(EnvBase):
     ENV_MODE: UpperStr = "LOCAL"
     DEBUG: bool = False
 
+    @computed_field
+    @property
+    def sse_ping_interval_secs(self) -> int:
+        """Integer ping interval for ``EventSourceResponse``.
+
+        sse-starlette accepts only ``int`` seconds; the underlying setting is
+        ``float`` to support sub-second heartbeats in the legacy JSON-wait
+        endpoints and in tests. Clamp to ``>= 1`` so 0/negative floats can't
+        produce a zero ping interval.
+        """
+        return max(1, int(self.KEEPALIVE_INTERVAL_SECS))
+
     # Logging
     LOG_LEVEL: UpperStr = "INFO"
     LOG_VERBOSITY: LowerStr = "verbose"

--- a/libs/aegra-api/tests/e2e/test_runs/test_worker_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_worker_e2e.py
@@ -230,12 +230,18 @@ async def test_sse_client_disconnect_cancels_via_redis() -> None:
         if len(parts) >= 4 and parts[2] == "runs":
             run_id = parts[3]
 
-        chunks_seen = 0
-        async for _chunk in response.aiter_bytes():
-            chunks_seen += 1
-            if chunks_seen >= 2:
+        # Disconnect after the first complete SSE frame. ``aiter_bytes``
+        # chunk boundaries are HTTP-transport-defined (chunked encoding
+        # may coalesce frames or split one across many), so keying off
+        # ``chunks_seen >= N`` is timing-flaky. Buffer until we see the
+        # frame terminator (``\n\n`` per our format_sse_message wire
+        # format) — that's deterministic across transports.
+        buffered = b""
+        async for chunk in response.aiter_bytes():
+            buffered += chunk
+            if b"\n\n" in buffered:
                 break
-        elog("Disconnecting after chunks", {"chunks_seen": chunks_seen, "run_id": run_id})
+        elog("Disconnecting after first SSE frame", {"bytes_seen": len(buffered), "run_id": run_id})
         # Drop out of the `async with` to close the connection — that's
         # the http.disconnect that fires the close handler.
 

--- a/libs/aegra-api/tests/e2e/test_runs/test_worker_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_worker_e2e.py
@@ -10,12 +10,15 @@ asyncio tasks.  They exercise:
   - Cancel propagation via Redis pub/sub to worker
   - Stateless run execution via worker
   - Stream reconnection after worker produces events
+  - SSE client disconnect → cross-instance cancel via Redis pub/sub
 """
 
 import asyncio
 
+import httpx
 import pytest
 
+from aegra_api.settings import settings
 from tests.e2e._utils import check_and_skip_if_geo_blocked, elog, get_e2e_client
 
 
@@ -180,3 +183,77 @@ async def test_worker_stream_produces_events() -> None:
     assert len(events) > 0, "Expected at least one stream event"
     assert "metadata" in event_types, "Expected metadata event in stream"
     assert any(e in event_types for e in ("values", "updates")), "Expected values or updates event"
+
+
+@pytest.mark.e2e
+@pytest.mark.prod_only
+@pytest.mark.asyncio
+async def test_sse_client_disconnect_cancels_via_redis() -> None:
+    """SSE client disconnect propagates cancel through Redis pub/sub.
+
+    Default ``on_disconnect="cancel"`` wires
+    ``client_close_handler_callable`` to ``broker_manager.request_cancel``
+    which, in prod mode, publishes on a Redis cancel channel any worker
+    can receive. Closing the HTTP stream mid-flight must drive the run
+    to ``interrupted`` even when the worker that picked it up is on a
+    different instance.
+
+    Uses raw httpx so we control connection close timing precisely; the
+    SDK's stream helper drains to completion and won't reproduce the
+    abort.
+    """
+    sdk_client = get_e2e_client()
+    thread = await sdk_client.threads.create()
+    thread_id = thread["thread_id"]
+    elog("Thread", thread)
+
+    server_url = settings.app.SERVER_URL.rstrip("/")
+    payload = {
+        "assistant_id": "agent",
+        "input": {"messages": [{"role": "user", "content": "Write a very long essay about computing history."}]},
+        "stream_mode": ["values"],
+    }
+
+    run_id: str | None = None
+    async with (
+        httpx.AsyncClient(timeout=httpx.Timeout(30.0, read=30.0)) as http,
+        http.stream(
+            "POST",
+            f"{server_url}/threads/{thread_id}/runs/stream",
+            json=payload,
+            headers={"Accept": "text/event-stream"},
+        ) as response,
+    ):
+        assert response.status_code == 200, f"stream failed: {response.status_code}"
+        location = response.headers.get("content-location", "")
+        parts = location.strip("/").split("/")
+        if len(parts) >= 4 and parts[2] == "runs":
+            run_id = parts[3]
+
+        chunks_seen = 0
+        async for _chunk in response.aiter_bytes():
+            chunks_seen += 1
+            if chunks_seen >= 2:
+                break
+        elog("Disconnecting after chunks", {"chunks_seen": chunks_seen, "run_id": run_id})
+        # Drop out of the `async with` to close the connection — that's
+        # the http.disconnect that fires the close handler.
+
+    assert run_id is not None, "Could not extract run_id from stream response headers"
+
+    # Cancel propagates via Redis pub/sub; allow worker some time to react
+    # and persist the status update.
+    final_status: str = "pending"
+    for _ in range(30):
+        await asyncio.sleep(0.5)
+        run = await sdk_client.runs.get(thread_id=thread_id, run_id=run_id)
+        check_and_skip_if_geo_blocked(run)
+        final_status = run["status"]
+        if final_status in ("interrupted", "success", "error"):
+            break
+
+    elog("Final run state", {"run_id": run_id, "status": final_status})
+    assert final_status == "interrupted", (
+        f"Expected interrupted after SSE disconnect, got {final_status}. "
+        "Cross-instance cancel via Redis pub/sub may have regressed."
+    )

--- a/libs/aegra-api/tests/e2e/test_streaming/test_streaming_error_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_streaming/test_streaming_error_e2e.py
@@ -30,6 +30,10 @@ def parse_sse_event(chunk: str) -> dict | None:
     event_data = {}
 
     for line in lines:
+        # SSE comment lines (W3C §9.2.6): must be ignored. sse-starlette emits
+        # `: heartbeat` every KEEPALIVE_INTERVAL_SECS as an idle keepalive.
+        if line.startswith(":"):
+            continue
         if line.startswith("event: "):
             event_data["event"] = line.replace("event: ", "").strip()
         elif line.startswith("data: "):
@@ -42,6 +46,38 @@ def parse_sse_event(chunk: str) -> dict | None:
             event_data["id"] = line.replace("id: ", "").strip()
 
     return event_data if event_data else None
+
+
+class TestParseSseEvent:
+    """Unit tests for the local ``parse_sse_event`` helper.
+
+    Not marked ``e2e`` — pure function, runs in the default suite. Covers the
+    heartbeat-comment path because ``sse-starlette`` now emits
+    ``: heartbeat\\r\\n\\r\\n`` on every ping, so the parser must ignore it
+    per the W3C EventSource spec §9.2.6.
+    """
+
+    def test_heartbeat_comment_returns_none(self) -> None:
+        assert parse_sse_event(": heartbeat") is None
+
+    def test_heartbeat_mixed_with_event_parses_event_only(self) -> None:
+        chunk = ': heartbeat\nevent: values\ndata: {"x": 1}\nid: evt-1'
+        assert parse_sse_event(chunk) == {
+            "event": "values",
+            "data": {"x": 1},
+            "id": "evt-1",
+        }
+
+    def test_empty_chunk_returns_none(self) -> None:
+        assert parse_sse_event("") is None
+        assert parse_sse_event("   \n  ") is None
+
+    def test_plain_event_still_parses(self) -> None:
+        chunk = 'event: end\ndata: {"status":"success"}'
+        assert parse_sse_event(chunk) == {
+            "event": "end",
+            "data": {"status": "success"},
+        }
 
 
 @pytest.mark.e2e

--- a/libs/aegra-api/tests/integration/test_api/test_stateless_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_stateless_runs_crud.py
@@ -380,15 +380,19 @@ class TestStatelessCreateRun:
         override_session_dependency(app, Session)
         client = make_client(app)
 
-        resp = client.post(
-            "/runs",
-            json={
-                "assistant_id": "asst-123",
-                "input": {"msg": "hi"},
-                "config": {"configurable": {"key": "val"}},
-                "context": {"key": "val"},
-            },
-        )
+        # Mock _delete_thread_by_id: assistant lookup raises 404, the cleanup
+        # path opens its own DB session via _get_session_maker which is not
+        # initialized in this test harness.
+        with patch("aegra_api.api.stateless_runs._delete_thread_by_id", new_callable=AsyncMock):
+            resp = client.post(
+                "/runs",
+                json={
+                    "assistant_id": "asst-123",
+                    "input": {"msg": "hi"},
+                    "config": {"configurable": {"key": "val"}},
+                    "context": {"key": "val"},
+                },
+            )
         # Validation conflict is removed; request proceeds to assistant lookup
         assert resp.status_code == 404
 

--- a/libs/aegra-api/tests/integration/test_sse_keepalive.py
+++ b/libs/aegra-api/tests/integration/test_sse_keepalive.py
@@ -1,0 +1,234 @@
+"""Integration tests for SSE keepalive and client-disconnect handling.
+
+Regression cover for a production bug where agents that opened upstream
+WebSockets (e.g. Sberdevices voice gateway) and held them silently for
+~60s were softly interrupted by Aegra. Root cause: the SSE response had
+no keepalive; an idle proxy dropped the HTTP connection, Starlette turned
+that into ``CancelledError`` inside the streaming generator, and the
+generator's ``cancel_on_disconnect`` branch fired ``request_cancel``.
+
+The fix migrated SSE to ``sse_starlette.EventSourceResponse`` (periodic
+``: heartbeat`` comment) and moved cancel-on-disconnect into
+``client_close_handler_callable`` so only a real ``http.disconnect`` ASGI
+event triggers cancellation.
+
+These tests exercise the exact wiring used by the real endpoints:
+``streaming_service.stream_run_execution`` → ``sse_to_bytes`` →
+``EventSourceResponse``.
+"""
+
+import asyncio
+import contextlib
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from sse_starlette import EventSourceResponse
+
+from aegra_api.core.sse import get_sse_headers, heartbeat_factory, sse_to_bytes
+from aegra_api.models import Run
+from aegra_api.services import streaming_service as streaming_service_module
+from aegra_api.services.broker import BrokerManager, RunBroker
+
+Scope = dict[str, Any]
+Message = dict[str, Any]
+
+
+def _make_run(run_id: str) -> Run:
+    now = datetime.now(UTC)
+    return Run(
+        run_id=run_id,
+        thread_id=str(uuid4()),
+        assistant_id=str(uuid4()),
+        status="running",
+        user_id="test-user",
+        input={},
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.fixture
+def run_id() -> str:
+    return str(uuid4())
+
+
+@pytest.fixture
+def local_broker_manager(monkeypatch: pytest.MonkeyPatch) -> BrokerManager:
+    """Fresh BrokerManager patched into the streaming service module."""
+    manager = BrokerManager()
+    monkeypatch.setattr(streaming_service_module, "broker_manager", manager)
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_keepalive_pings_during_silent_broker(run_id: str, local_broker_manager: BrokerManager) -> None:
+    """Silent brokers must still produce ping bytes so idle proxies don't drop us.
+
+    Without sse-starlette's ``_ping`` task, a proxy with a 60s idle timeout
+    closes the HTTP connection when the graph node blocks on an upstream
+    WebSocket without emitting events — the exact prod scenario this fix
+    addresses.
+    """
+    broker = RunBroker(run_id)
+    local_broker_manager._brokers[run_id] = broker
+    run = _make_run(run_id)
+
+    app = FastAPI()
+
+    @app.get("/stream")
+    async def _stream() -> EventSourceResponse:
+        return EventSourceResponse(
+            sse_to_bytes(streaming_service_module.streaming_service.stream_run_execution(run)),
+            ping=1,  # fast ping for test speed
+            ping_message_factory=heartbeat_factory,
+            headers=get_sse_headers(),
+        )
+
+    collected = bytearray()
+
+    async def _collect() -> None:
+        transport = httpx.ASGITransport(app=app)
+        async with (
+            httpx.AsyncClient(transport=transport, base_url="http://test") as client,
+            client.stream("GET", "/stream", timeout=10.0) as resp,
+        ):
+            assert resp.status_code == 200
+            async for chunk in resp.aiter_bytes():
+                collected.extend(chunk)
+
+    async def _drive_broker() -> None:
+        # Stay silent long enough for at least two ping intervals,
+        # then end the stream so the response finishes cleanly.
+        await asyncio.sleep(2.5)
+        await broker.put("evt-1", ("end", {"status": "success"}))
+
+    await asyncio.gather(_collect(), _drive_broker())
+
+    body = bytes(collected)
+    heartbeat_hits = body.count(b": heartbeat")
+    assert heartbeat_hits >= 2, f"Expected >= 2 heartbeat comments during silence, got {heartbeat_hits}. Body={body!r}"
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_triggers_close_handler(run_id: str, local_broker_manager: BrokerManager) -> None:
+    """A real ``http.disconnect`` must fire ``client_close_handler_callable``.
+
+    This is where ``cancel_on_disconnect`` now lives — it no longer depends
+    on ``CancelledError`` inside the generator, so a proxy idle-drop can't
+    be misread as a real client disconnect.
+
+    We drive the ASGI protocol directly because ``httpx.ASGITransport`` does
+    not synthesize an ``http.disconnect`` when the client context closes —
+    it just cancels the app task, which produces ``CancelledError`` (the
+    exact false-positive the fix aims to prevent).
+    """
+    broker = RunBroker(run_id)
+    local_broker_manager._brokers[run_id] = broker
+    run = _make_run(run_id)
+
+    handler_call_count = 0
+
+    async def _on_close(_msg: Message) -> None:
+        nonlocal handler_call_count
+        handler_call_count += 1
+
+    response = EventSourceResponse(
+        sse_to_bytes(streaming_service_module.streaming_service.stream_run_execution(run)),
+        ping=60,  # don't let ping interfere
+        client_close_handler_callable=_on_close,
+        headers=get_sse_headers(),
+    )
+
+    # Push an event so the stream produces at least one body chunk
+    await broker.put("evt-1", ("values", {"x": 1}))
+
+    scope: Scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/stream",
+        "raw_path": b"/stream",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "server": ("test", 80),
+        "client": ("testclient", 50000),
+        "state": {},
+    }
+
+    client_messages: asyncio.Queue[Message] = asyncio.Queue()
+    await client_messages.put({"type": "http.request", "body": b"", "more_body": False})
+
+    async def _receive() -> Message:
+        return await client_messages.get()
+
+    sent: list[Message] = []
+    first_body_seen = asyncio.Event()
+
+    async def _send(msg: Message) -> None:
+        sent.append(msg)
+        if msg["type"] == "http.response.body" and msg.get("body"):
+            first_body_seen.set()
+
+    async def _disconnect_after_first_body() -> None:
+        await asyncio.wait_for(first_body_seen.wait(), timeout=3.0)
+        await client_messages.put({"type": "http.disconnect"})
+
+    disconnect_task = asyncio.create_task(_disconnect_after_first_body())
+    try:
+        await asyncio.wait_for(response(scope, _receive, _send), timeout=5.0)
+    finally:
+        disconnect_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await disconnect_task
+
+    assert handler_call_count == 1, (
+        f"http.disconnect should fire client_close_handler_callable exactly once; got {handler_call_count}"
+    )
+    # Response started + at least one body chunk flushed before disconnect
+    assert any(m["type"] == "http.response.start" for m in sent)
+    assert any(m["type"] == "http.response.body" and m.get("body") for m in sent)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_no_longer_requests_cancel(run_id: str, local_broker_manager: BrokerManager) -> None:
+    """``stream_run_execution`` must not call ``request_cancel`` on cancellation.
+
+    Pre-fix, a CancelledError inside the generator triggered
+    ``broker_manager.request_cancel`` when ``cancel_on_disconnect=True``.
+    With the new transport-layer disconnect handling, that side-effect was
+    removed; cancellation of the generator is now side-effect-free.
+    """
+    broker = RunBroker(run_id)
+    local_broker_manager._brokers[run_id] = broker
+    run = _make_run(run_id)
+
+    cancel_requests: list[str] = []
+
+    async def _record_cancel(rid: str, _action: str) -> None:
+        cancel_requests.append(rid)
+
+    local_broker_manager.request_cancel = _record_cancel  # type: ignore[method-assign]
+
+    gen = streaming_service_module.streaming_service.stream_run_execution(run)
+
+    # Let the generator get into its live-events loop, then cancel the task
+    async def _drain() -> None:
+        async for _ in gen:
+            pass
+
+    task = asyncio.create_task(_drain())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cancel_requests == [], (
+        f"Cancellation of the generator must not trigger request_cancel; got {cancel_requests}"
+    )

--- a/libs/aegra-api/tests/integration/test_sse_keepalive.py
+++ b/libs/aegra-api/tests/integration/test_sse_keepalive.py
@@ -94,16 +94,18 @@ async def test_keepalive_pings_during_silent_broker(run_id: str, local_broker_ma
         transport = httpx.ASGITransport(app=app)
         async with (
             httpx.AsyncClient(transport=transport, base_url="http://test") as client,
-            client.stream("GET", "/stream", timeout=10.0) as resp,
+            client.stream("GET", "/stream", timeout=12.0) as resp,
         ):
             assert resp.status_code == 200
             async for chunk in resp.aiter_bytes():
                 collected.extend(chunk)
 
     async def _drive_broker() -> None:
-        # Stay silent long enough for at least two ping intervals,
-        # then end the stream so the response finishes cleanly.
-        await asyncio.sleep(2.5)
+        # Stay silent long enough that at least two ping intervals fire even
+        # when ASGI startup eats a noticeable slice at the beginning (CI can
+        # be slow). ping=1, sleep=4.0 → ~3 expected heartbeats, asserting >=2
+        # leaves ~2s of safety margin.
+        await asyncio.sleep(4.0)
         await broker.put("evt-1", ("end", {"status": "success"}))
 
     await asyncio.gather(_collect(), _drive_broker())
@@ -222,13 +224,20 @@ async def test_cancelled_error_no_longer_requests_cancel(
 
     gen = streaming_service_module.streaming_service.stream_run_execution(run)
 
-    # Let the generator get into its live-events loop, then cancel the task
+    # Drive the generator to the exact state we want to cancel in: inside
+    # its live-events loop, blocked on the next broker event. Feeding one
+    # event and waiting for ``_drain`` to consume it guarantees the loop
+    # is running (not a fixed sleep, which could fire before the generator
+    # has even started on a loaded CI machine).
+    entered_loop = asyncio.Event()
+
     async def _drain() -> None:
         async for _ in gen:
-            pass
+            entered_loop.set()
 
     task = asyncio.create_task(_drain())
-    await asyncio.sleep(0.1)
+    await broker.put("evt-1", ("values", {"x": 1}))
+    await asyncio.wait_for(entered_loop.wait(), timeout=2.0)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task

--- a/libs/aegra-api/tests/integration/test_sse_keepalive.py
+++ b/libs/aegra-api/tests/integration/test_sse_keepalive.py
@@ -197,7 +197,11 @@ async def test_client_disconnect_triggers_close_handler(run_id: str, local_broke
 
 
 @pytest.mark.asyncio
-async def test_cancelled_error_no_longer_requests_cancel(run_id: str, local_broker_manager: BrokerManager) -> None:
+async def test_cancelled_error_no_longer_requests_cancel(
+    run_id: str,
+    local_broker_manager: BrokerManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """``stream_run_execution`` must not call ``request_cancel`` on cancellation.
 
     Pre-fix, a CancelledError inside the generator triggered
@@ -214,7 +218,7 @@ async def test_cancelled_error_no_longer_requests_cancel(run_id: str, local_brok
     async def _record_cancel(rid: str, _action: str) -> None:
         cancel_requests.append(rid)
 
-    local_broker_manager.request_cancel = _record_cancel  # type: ignore[method-assign]
+    monkeypatch.setattr(local_broker_manager, "request_cancel", _record_cancel)
 
     gen = streaming_service_module.streaming_service.stream_run_execution(run)
 

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -124,10 +124,14 @@ class TestRunsStreamingEndpoints:
         """
         thread_id = "t"
         run_id = str(uuid4())
-        kwargs: dict[str, object] = {"assistant_id": "test-assistant", "input": {}}
-        if on_disconnect is not None:
-            kwargs["on_disconnect"] = on_disconnect
-        request = RunCreate(**kwargs)  # type: ignore[arg-type]
+        if on_disconnect is None:
+            request = RunCreate(assistant_id="test-assistant", input={})
+        else:
+            request = RunCreate(
+                assistant_id="test-assistant",
+                input={},
+                on_disconnect=on_disconnect,
+            )
 
         async def _fake_stream() -> AsyncGenerator:
             yield "data"

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+from redis import RedisError
 
 from aegra_api.api.runs import create_and_stream_run, stream_run
 from aegra_api.core.orm import Assistant as AssistantORM
@@ -149,7 +150,8 @@ class TestRunsStreamingEndpoints:
             patch("aegra_api.api.runs.broker_manager.request_cancel", new_callable=AsyncMock) as mock_cancel,
         ):
             mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
-            mock_session.scalar.return_value = sample_assistant
+            # First scalar = thread ownership check (None = new thread); second = assistant
+            mock_session.scalar.side_effect = [None, sample_assistant]
 
             response = await create_and_stream_run(thread_id, request, mock_user, mock_session)
 
@@ -198,11 +200,12 @@ class TestRunsStreamingEndpoints:
             patch(
                 "aegra_api.api.runs.broker_manager.request_cancel",
                 new_callable=AsyncMock,
-                side_effect=RuntimeError("broker down"),
+                side_effect=RedisError("broker down"),
             ),
         ):
             mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
-            mock_session.scalar.return_value = sample_assistant
+            # First scalar = thread ownership check (None = new thread); second = assistant
+            mock_session.scalar.side_effect = [None, sample_assistant]
 
             response = await create_and_stream_run(thread_id, request, mock_user, mock_session)
             handler = response.client_close_handler_callable

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -98,6 +98,115 @@ class TestRunsStreamingEndpoints:
             mock_create_task.assert_called_once()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "on_disconnect,expect_handler,expect_request_cancel",
+        [
+            (None, True, True),  # default → cancel
+            ("cancel", True, True),
+            ("continue", False, False),
+        ],
+    )
+    async def test_create_and_stream_run_disconnect_handler_wiring(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+        sample_assistant: AssistantORM,
+        on_disconnect: str | None,
+        expect_handler: bool,
+        expect_request_cancel: bool,
+    ) -> None:
+        """``client_close_handler_callable`` is wired only when on_disconnect cancels.
+
+        Invokes the handler manually with a fake ``http.disconnect`` message
+        and verifies it routes to ``broker_manager.request_cancel``. Regression
+        for the transport-layer cancel wiring introduced alongside the
+        EventSourceResponse migration.
+        """
+        thread_id = "t"
+        run_id = str(uuid4())
+        kwargs: dict[str, object] = {"assistant_id": "test-assistant", "input": {}}
+        if on_disconnect is not None:
+            kwargs["on_disconnect"] = on_disconnect
+        request = RunCreate(**kwargs)  # type: ignore[arg-type]
+
+        async def _fake_stream() -> AsyncGenerator:
+            yield "data"
+
+        with (
+            patch("aegra_api.services.run_preparation._validate_resume_command", new_callable=AsyncMock),
+            patch("aegra_api.services.run_preparation.get_langgraph_service") as mock_lg_service,
+            patch("aegra_api.services.run_preparation.resolve_assistant_id", return_value="test-assistant"),
+            patch("aegra_api.services.run_preparation.update_thread_metadata", new_callable=AsyncMock),
+            patch("aegra_api.services.run_preparation.set_thread_status", new_callable=AsyncMock),
+            patch("aegra_api.services.run_preparation.uuid4", return_value=run_id),
+            patch("aegra_api.api.runs.asyncio.create_task"),
+            patch("aegra_api.api.runs.active_runs", {}),
+            patch("aegra_api.api.runs.streaming_service.stream_run_execution", return_value=_fake_stream()),
+            patch("aegra_api.api.runs.broker_manager.request_cancel", new_callable=AsyncMock) as mock_cancel,
+        ):
+            mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
+            mock_session.scalar.return_value = sample_assistant
+
+            response = await create_and_stream_run(thread_id, request, mock_user, mock_session)
+
+            handler = response.client_close_handler_callable
+            if not expect_handler:
+                assert handler is None
+                return
+
+            assert handler is not None
+            await handler({"type": "http.disconnect"})
+            if expect_request_cancel:
+                mock_cancel.assert_awaited_once_with(run_id, "cancel")
+            else:
+                mock_cancel.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_create_and_stream_run_handler_swallows_broker_errors(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+        sample_assistant: AssistantORM,
+    ) -> None:
+        """Broker failures in disconnect handler are logged, not re-raised.
+
+        If the broker is unreachable when a client disconnects, the handler
+        must not propagate the exception into sse-starlette's task group —
+        otherwise the response teardown path breaks and the run leaks.
+        """
+        thread_id = "t"
+        run_id = str(uuid4())
+        request = RunCreate(assistant_id="test-assistant", input={})
+
+        async def _fake_stream() -> AsyncGenerator:
+            yield "data"
+
+        with (
+            patch("aegra_api.services.run_preparation._validate_resume_command", new_callable=AsyncMock),
+            patch("aegra_api.services.run_preparation.get_langgraph_service") as mock_lg_service,
+            patch("aegra_api.services.run_preparation.resolve_assistant_id", return_value="test-assistant"),
+            patch("aegra_api.services.run_preparation.update_thread_metadata", new_callable=AsyncMock),
+            patch("aegra_api.services.run_preparation.set_thread_status", new_callable=AsyncMock),
+            patch("aegra_api.services.run_preparation.uuid4", return_value=run_id),
+            patch("aegra_api.api.runs.asyncio.create_task"),
+            patch("aegra_api.api.runs.active_runs", {}),
+            patch("aegra_api.api.runs.streaming_service.stream_run_execution", return_value=_fake_stream()),
+            patch(
+                "aegra_api.api.runs.broker_manager.request_cancel",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("broker down"),
+            ),
+        ):
+            mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
+            mock_session.scalar.return_value = sample_assistant
+
+            response = await create_and_stream_run(thread_id, request, mock_user, mock_session)
+            handler = response.client_close_handler_callable
+            assert handler is not None
+            # Must not raise even though the broker side-effect blows up
+            await handler({"type": "http.disconnect"})
+
+    @pytest.mark.asyncio
     async def test_stream_run_success(self, mock_user: User, mock_session: AsyncMock) -> None:
         """Test reconnecting to existing run stream."""
         thread_id = "test-thread"

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -253,6 +253,61 @@ class TestRunsStreamingEndpoints:
             assert call_args[0][1] == "evt-1"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "run_status,last_event_id",
+        [
+            ("running", None),  # active branch
+            ("success", None),  # terminal branch
+        ],
+    )
+    async def test_stream_run_never_wires_close_handler(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+        run_status: str,
+        last_event_id: str | None,
+    ) -> None:
+        """``stream_run`` (reconnect) must never wire ``client_close_handler_callable``.
+
+        The endpoint is a reconnect-style join: multiple clients can attach
+        to the same run. A single client disconnecting must NOT cancel the
+        shared run — hence the endpoint deliberately omits the close handler.
+        Covers both the terminal branch (early return with ``end`` event) and
+        the active branch (live streaming via broker).
+        """
+        thread_id = "test-thread"
+        run_id = "run-42"
+
+        run_orm = RunORM(
+            run_id=run_id,
+            thread_id=thread_id,
+            assistant_id="agent",
+            user_id=mock_user.identity,
+            status=run_status,
+            input={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        mock_session.scalar.return_value = run_orm
+
+        async def _fake_stream() -> AsyncGenerator:
+            yield "data"
+
+        with patch(
+            "aegra_api.api.runs.streaming_service.stream_run_execution",
+            return_value=_fake_stream(),
+        ):
+            response = await stream_run(
+                thread_id,
+                run_id,
+                last_event_id=last_event_id,
+                user=mock_user,
+                session=mock_session,
+            )
+
+        assert response.client_close_handler_callable is None
+
+    @pytest.mark.asyncio
     async def test_stream_run_not_found(self, mock_user: User, mock_session: AsyncMock) -> None:
         """Test streaming non-existent run."""
         mock_session.scalar.return_value = None

--- a/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
@@ -1,6 +1,7 @@
 """Unit tests for stateless (thread-free) run endpoints."""
 
 import asyncio
+import contextlib
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -490,6 +491,48 @@ class TestStatelessStreamRun:
             await stateless_stream_run(request, mock_user, mock_session)
 
         mock_delete.assert_called_once_with("eph-thread-err", mock_user.identity)
+
+    @pytest.mark.asyncio
+    async def test_early_disconnect_keeps_thread(self, mock_user: User, mock_session: AsyncMock) -> None:
+        """Client disconnect before stream completion must NOT delete the thread.
+
+        Regression: deleting the thread here would cancel active runs via
+        ``_delete_thread_by_id`` and break the ``on_disconnect="continue"``
+        contract. The wrapper must mirror ``stateless_wait_for_run`` and only
+        delete on normal completion.
+        """
+        request = RunCreate(assistant_id="agent", input={"msg": "hi"}, on_disconnect="continue")
+
+        async def _fake_body() -> AsyncIterator[bytes]:
+            yield b"event: metadata\n\n"
+            # Client disconnect — outer EventSourceResponse cancels the iterator
+            raise asyncio.CancelledError
+
+        mock_response = EventSourceResponse(
+            _fake_body(),
+            headers={"Location": "/threads/t/runs/r/stream"},
+        )
+
+        with (
+            patch("aegra_api.api.stateless_runs.uuid4", return_value="eph-thread-disc"),
+            patch(
+                "aegra_api.api.stateless_runs.create_and_stream_run",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+            patch(
+                "aegra_api.api.stateless_runs._delete_thread_by_id",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            result = await stateless_stream_run(request, mock_user, mock_session)
+
+            # Drain until CancelledError bubbles up from the iterator
+            with contextlib.suppress(asyncio.CancelledError):
+                async for _chunk in result.body_iterator:
+                    pass
+
+        mock_delete.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_stream_cleanup_failure_is_logged_not_raised(self, mock_user: User, mock_session: AsyncMock) -> None:

--- a/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi.responses import StreamingResponse
+from sse_starlette import EventSourceResponse
 
 from aegra_api.api.stateless_runs import (
     _cleanup_after_background_run,
@@ -402,13 +403,14 @@ class TestStatelessStreamRun:
         """Delegates to create_and_stream_run and wraps iterator for cleanup."""
         request = RunCreate(assistant_id="agent", input={"msg": "hi"})
 
-        async def _fake_body() -> AsyncIterator[str]:
-            yield "event: data\n\n"
+        async def _fake_body() -> AsyncIterator[bytes]:
+            yield b"event: data\n\n"
 
-        mock_response = StreamingResponse(
+        inner_close_handler = AsyncMock()
+        mock_response = EventSourceResponse(
             _fake_body(),
-            media_type="text/event-stream",
             headers={"Location": "/threads/t/runs/r/stream"},
+            client_close_handler_callable=inner_close_handler,
         )
 
         with (
@@ -425,12 +427,14 @@ class TestStatelessStreamRun:
         ):
             result = await stateless_stream_run(request, mock_user, mock_session)
 
-            # Should be a StreamingResponse (possibly wrapped)
-            assert isinstance(result, StreamingResponse)
+            assert isinstance(result, EventSourceResponse)
             mock_stream.assert_called_once_with("eph-thread-4", request, mock_user, mock_session)
+            # Outer response must re-expose the inner close handler so real
+            # http.disconnect still cancels the run.
+            assert result.client_close_handler_callable is inner_close_handler
 
             # Consume the iterator to trigger cleanup (must be inside mock context)
-            chunks: list[str] = []
+            chunks: list[bytes] = []
             async for chunk in result.body_iterator:
                 chunks.append(chunk)
 
@@ -442,13 +446,10 @@ class TestStatelessStreamRun:
         """Returns original response unchanged when on_completion='keep'."""
         request = RunCreate(assistant_id="agent", input={"msg": "hi"}, on_completion="keep")
 
-        async def _fake_body() -> AsyncIterator[str]:
-            yield "event: data\n\n"
+        async def _fake_body() -> AsyncIterator[bytes]:
+            yield b"event: data\n\n"
 
-        mock_response = StreamingResponse(
-            _fake_body(),
-            media_type="text/event-stream",
-        )
+        mock_response = EventSourceResponse(_fake_body())
 
         with (
             patch("aegra_api.api.stateless_runs.uuid4", return_value="eph-thread-5"),
@@ -495,13 +496,10 @@ class TestStatelessStreamRun:
         """If _delete_thread_by_id raises during stream cleanup, it is logged but not propagated."""
         request = RunCreate(assistant_id="agent", input={"msg": "hi"})
 
-        async def _fake_body() -> AsyncIterator[str]:
-            yield "event: data\n\n"
+        async def _fake_body() -> AsyncIterator[bytes]:
+            yield b"event: data\n\n"
 
-        mock_response = StreamingResponse(
-            _fake_body(),
-            media_type="text/event-stream",
-        )
+        mock_response = EventSourceResponse(_fake_body())
 
         with (
             patch("aegra_api.api.stateless_runs.uuid4", return_value="eph-thread-cleanup"),
@@ -519,7 +517,7 @@ class TestStatelessStreamRun:
             result = await stateless_stream_run(request, mock_user, mock_session)
 
             # Consuming the iterator should not raise despite cleanup failure
-            chunks: list[str] = []
+            chunks: list[bytes] = []
             async for chunk in result.body_iterator:
                 chunks.append(chunk)
 

--- a/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
@@ -2,16 +2,18 @@
 
 import asyncio
 import contextlib
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from fastapi.responses import StreamingResponse
+from redis import RedisError
 from sse_starlette import EventSourceResponse
 
 from aegra_api.api.stateless_runs import (
+    _background_cleanup_tasks,
     _cleanup_after_background_run,
     _delete_thread_by_id,
     stateless_create_run,
@@ -21,6 +23,39 @@ from aegra_api.api.stateless_runs import (
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.models import Run, RunCreate, User
+
+
+def _raise_immediately(exc: BaseException) -> Iterator[None]:
+    """Generator that raises ``exc`` on first iteration. Backs ``_FailingTask.__await__``."""
+    raise exc
+    yield  # pragma: no cover - unreachable, makes this a generator
+
+
+class _FailingTask:
+    """Minimal awaitable stand-in for an asyncio.Task that raises on await.
+
+    Mimics ``done()``/``cancel()`` so ``_delete_thread_by_id`` enters the
+    ``await task`` branch, then raises the configured exception when
+    awaited. ``asyncio.Future.set_exception`` flips ``done()`` to True up
+    front, which would skip the await branch entirely — hence this stub.
+
+    ``__await__`` returns the iterator from ``_raise_immediately`` rather
+    than being a generator function itself: keeps the body small and
+    obvious instead of relying on the ``raise; yield`` quirk to coerce
+    Python into treating the method as a generator.
+    """
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def done(self) -> bool:
+        return False
+
+    def cancel(self) -> None:
+        return None
+
+    def __await__(self) -> Iterator[None]:
+        return _raise_immediately(self._exc)
 
 
 class TestDeleteThreadById:
@@ -148,14 +183,9 @@ class TestDeleteThreadById:
         mock_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
         mock_maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        # Use a Future that raises CancelledError when awaited
-        fut = asyncio.get_event_loop().create_future()
-        fut.cancel()
-
-        mock_task = MagicMock()
-        mock_task.done.return_value = False
-        mock_task.cancel.return_value = None
-        mock_task.__await__ = fut.__await__
+        # asyncio.Future is a real awaitable; the source calls .cancel()
+        # then awaits — the await raises CancelledError.
+        fut: asyncio.Future[None] = asyncio.get_event_loop().create_future()
 
         with (
             patch("aegra_api.api.stateless_runs._get_session_maker", return_value=mock_maker),
@@ -163,14 +193,23 @@ class TestDeleteThreadById:
                 "aegra_api.api.stateless_runs.streaming_service.cancel_run",
                 new_callable=AsyncMock,
             ),
-            patch("aegra_api.api.stateless_runs.active_runs", {run_id: mock_task}),
+            patch("aegra_api.api.stateless_runs.active_runs", {run_id: fut}),
         ):
             # Should not raise — CancelledError is caught
             await _delete_thread_by_id(thread_id, user_id)
 
     @pytest.mark.asyncio
-    async def test_logs_exception_on_task_await_error(self, mock_session: AsyncMock) -> None:
-        """Generic exception from awaiting a task is logged but not re-raised."""
+    async def test_logs_infra_error_on_task_await(self, mock_session: AsyncMock) -> None:
+        """Defensive: infra-class errors on ``await task`` are logged, not re-raised.
+
+        Real ``asyncio.Task`` always raises ``CancelledError`` after
+        ``task.cancel()``, so this RedisError flow is reachable only if
+        ``active_runs`` ever holds a non-Task awaitable (e.g. a custom
+        wrapper or a future). Test guards the narrow ``(RedisError,
+        SQLAlchemyError, OSError)`` tuple from accidental widening —
+        complements ``test_propagates_programmer_error`` which asserts
+        non-infra exceptions still propagate.
+        """
         thread_id = str(uuid4())
         user_id = "test-user"
         run_id = str(uuid4())
@@ -194,25 +233,63 @@ class TestDeleteThreadById:
         mock_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
         mock_maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        # Use a Future that raises RuntimeError when awaited
-        fut = asyncio.get_event_loop().create_future()
-        fut.set_exception(RuntimeError("task exploded"))
-
-        mock_task = MagicMock()
-        mock_task.done.return_value = False
-        mock_task.cancel.return_value = None
-        mock_task.__await__ = fut.__await__
-
         with (
             patch("aegra_api.api.stateless_runs._get_session_maker", return_value=mock_maker),
             patch(
                 "aegra_api.api.stateless_runs.streaming_service.cancel_run",
                 new_callable=AsyncMock,
             ),
-            patch("aegra_api.api.stateless_runs.active_runs", {run_id: mock_task}),
+            patch(
+                "aegra_api.api.stateless_runs.active_runs",
+                {run_id: _FailingTask(RedisError("redis hiccup"))},
+            ),
         ):
-            # Should not raise — exception is logged
+            # Should not raise — RedisError is in the narrow cleanup tuple
             await _delete_thread_by_id(thread_id, user_id)
+
+    @pytest.mark.asyncio
+    async def test_propagates_programmer_error(self, mock_session: AsyncMock) -> None:
+        """Programmer errors (RuntimeError, AttributeError, ...) on ``await task`` propagate.
+
+        Regression for the narrow-tuple cleanup: per CLAUDE.md and the
+        review comment, broker/cancel paths must not swallow random
+        programmer errors — those signal real bugs and need to surface.
+        """
+        thread_id = str(uuid4())
+        user_id = "test-user"
+        run_id = str(uuid4())
+
+        active_run = RunORM(
+            run_id=run_id,
+            thread_id=thread_id,
+            user_id=user_id,
+            status="running",
+            input={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [active_run]
+        mock_session.scalars.return_value = mock_scalars
+
+        mock_maker = MagicMock()
+        mock_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_maker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with (  # noqa: SIM117
+            patch("aegra_api.api.stateless_runs._get_session_maker", return_value=mock_maker),
+            patch(
+                "aegra_api.api.stateless_runs.streaming_service.cancel_run",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "aegra_api.api.stateless_runs.active_runs",
+                {run_id: _FailingTask(RuntimeError("task exploded"))},
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="task exploded"):
+                await _delete_thread_by_id(thread_id, user_id)
 
 
 class TestCleanupAfterBackgroundRun:
@@ -533,6 +610,183 @@ class TestStatelessStreamRun:
                     pass
 
         mock_delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_slow_client_disconnect_with_finished_run_schedules_cleanup(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Slow-client / dead-proxy abort after the run finished must clean up.
+
+        Regression for the leak described in review: ``completed = False``
+        is also reached when sse-starlette aborts the body iterator on a
+        send-timeout. If the broker reports the run finished, there's
+        nothing left to resume — the wrapper must schedule a deferred
+        delete instead of leaking the ephemeral thread.
+        """
+        request = RunCreate(assistant_id="agent", input={"msg": "hi"})
+
+        async def _fake_body() -> AsyncIterator[bytes]:
+            yield b"event: metadata\n\n"
+            # Mid-stream abort, but by this point the broker reports finished.
+            raise asyncio.CancelledError
+
+        mock_response = EventSourceResponse(
+            _fake_body(),
+            headers={"Content-Location": "/threads/eph-thread-slow/runs/run-finished"},
+        )
+
+        finished_broker = MagicMock()
+        finished_broker.is_finished.return_value = True
+
+        with (
+            patch("aegra_api.api.stateless_runs.uuid4", return_value="eph-thread-slow"),
+            patch(
+                "aegra_api.api.stateless_runs.create_and_stream_run",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+            patch(
+                "aegra_api.api.stateless_runs.broker_manager.get_broker",
+                return_value=finished_broker,
+            ),
+            patch(
+                "aegra_api.api.stateless_runs._delete_thread_by_id",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            # Snapshot the cleanup-task set BEFORE running the scenario so
+            # we only await tasks created by this test, not stragglers from
+            # prior tests in the same session (which may belong to a
+            # defunct event loop).
+            tasks_before = set(_background_cleanup_tasks)
+
+            result = await stateless_stream_run(request, mock_user, mock_session)
+
+            with contextlib.suppress(asyncio.CancelledError):
+                async for _chunk in result.body_iterator:
+                    pass
+
+            new_tasks = [task for task in _background_cleanup_tasks if task not in tasks_before]
+            if new_tasks:
+                await asyncio.gather(*new_tasks, return_exceptions=True)
+
+        mock_delete.assert_called_once_with("eph-thread-slow", mock_user.identity)
+
+    @pytest.mark.asyncio
+    async def test_slow_client_disconnect_with_active_run_keeps_thread(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Slow-client abort while the run is still active must NOT clean up.
+
+        Symmetric to ``test_slow_client_disconnect_with_finished_run_schedules_cleanup``:
+        when ``broker.is_finished()`` is False (run still running), the
+        wrapper must keep the thread so the caller can still resume.
+        Otherwise we'd cancel-via-deletion an in-flight execution and
+        break the ``on_disconnect="continue"`` contract.
+        """
+        request = RunCreate(assistant_id="agent", input={"msg": "hi"}, on_disconnect="continue")
+
+        async def _fake_body() -> AsyncIterator[bytes]:
+            yield b"event: metadata\n\n"
+            raise asyncio.CancelledError
+
+        mock_response = EventSourceResponse(
+            _fake_body(),
+            headers={"Content-Location": "/threads/eph-thread-active/runs/run-active"},
+        )
+
+        active_broker = MagicMock()
+        active_broker.is_finished.return_value = False  # run still in flight
+
+        with (
+            patch("aegra_api.api.stateless_runs.uuid4", return_value="eph-thread-active"),
+            patch(
+                "aegra_api.api.stateless_runs.create_and_stream_run",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+            patch(
+                "aegra_api.api.stateless_runs.broker_manager.get_broker",
+                return_value=active_broker,
+            ),
+            patch(
+                "aegra_api.api.stateless_runs._delete_thread_by_id",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            tasks_before = set(_background_cleanup_tasks)
+
+            result = await stateless_stream_run(request, mock_user, mock_session)
+
+            with contextlib.suppress(asyncio.CancelledError):
+                async for _chunk in result.body_iterator:
+                    pass
+
+            new_tasks = [task for task in _background_cleanup_tasks if task not in tasks_before]
+            if new_tasks:
+                await asyncio.gather(*new_tasks, return_exceptions=True)
+
+        mock_delete.assert_not_called()
+        assert not new_tasks, "Should not schedule cleanup when run still active"
+
+    @pytest.mark.asyncio
+    async def test_slow_client_disconnect_without_run_id_keeps_thread(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Missing Content-Location header → slow-client cleanup branch is skipped.
+
+        ``_extract_run_id_from_headers`` returns None when it can't parse
+        the header. The wrapper falls through to the keep-thread branch
+        rather than guessing — failing closed avoids false-positive
+        deletions that would race with the still-running execution.
+        """
+        request = RunCreate(assistant_id="agent", input={"msg": "hi"}, on_disconnect="continue")
+
+        async def _fake_body() -> AsyncIterator[bytes]:
+            yield b"event: metadata\n\n"
+            raise asyncio.CancelledError
+
+        # No Content-Location → run_id extraction returns None.
+        mock_response = EventSourceResponse(_fake_body(), headers={})
+
+        with (
+            patch("aegra_api.api.stateless_runs.uuid4", return_value="eph-thread-noid"),
+            patch(
+                "aegra_api.api.stateless_runs.create_and_stream_run",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ),
+            patch(
+                "aegra_api.api.stateless_runs.broker_manager.get_broker",
+            ) as mock_get_broker,
+            patch(
+                "aegra_api.api.stateless_runs._delete_thread_by_id",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            tasks_before = set(_background_cleanup_tasks)
+
+            result = await stateless_stream_run(request, mock_user, mock_session)
+
+            with contextlib.suppress(asyncio.CancelledError):
+                async for _chunk in result.body_iterator:
+                    pass
+
+            new_tasks = [task for task in _background_cleanup_tasks if task not in tasks_before]
+            if new_tasks:
+                await asyncio.gather(*new_tasks, return_exceptions=True)
+
+        mock_delete.assert_not_called()
+        # Without a run_id we must not consult the broker — the slow-client
+        # branch is gated on `run_id is not None` precisely to skip this.
+        mock_get_broker.assert_not_called()
+        assert not new_tasks, "Should not schedule cleanup when run_id unavailable"
 
     @pytest.mark.asyncio
     async def test_stream_cleanup_failure_is_logged_not_raised(self, mock_user: User, mock_session: AsyncMock) -> None:

--- a/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
@@ -25,10 +25,22 @@ from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.models import Run, RunCreate, User
 
 
-def _raise_immediately(exc: BaseException) -> Iterator[None]:
-    """Generator that raises ``exc`` on first iteration. Backs ``_FailingTask.__await__``."""
-    raise exc
-    yield  # pragma: no cover - unreachable, makes this a generator
+class _RaisingIter:
+    """Iterator that raises a configured exception on first ``__next__``.
+
+    Used as the ``__await__`` return value for ``_FailingTask``. Plain
+    iterator class (not a generator) so there's no unreachable ``yield``
+    statement for static analyzers (CodeQL) to flag.
+    """
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    def __iter__(self) -> "_RaisingIter":
+        return self
+
+    def __next__(self) -> None:
+        raise self._exc
 
 
 class _FailingTask:
@@ -38,11 +50,6 @@ class _FailingTask:
     ``await task`` branch, then raises the configured exception when
     awaited. ``asyncio.Future.set_exception`` flips ``done()`` to True up
     front, which would skip the await branch entirely — hence this stub.
-
-    ``__await__`` returns the iterator from ``_raise_immediately`` rather
-    than being a generator function itself: keeps the body small and
-    obvious instead of relying on the ``raise; yield`` quirk to coerce
-    Python into treating the method as a generator.
     """
 
     def __init__(self, exc: BaseException) -> None:
@@ -55,7 +62,7 @@ class _FailingTask:
         return None
 
     def __await__(self) -> Iterator[None]:
-        return _raise_immediately(self._exc)
+        return _RaisingIter(self._exc)
 
 
 class TestDeleteThreadById:

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -73,6 +73,37 @@ class TestAppSettingsServerURL:
         assert app.PORT == 2026
 
 
+class TestSsePingIntervalSecs:
+    """``sse_ping_interval_secs`` derives an int ping value from the float setting."""
+
+    def _clear(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KEEPALIVE_INTERVAL_SECS", raising=False)
+
+    def test_default_matches_default_keepalive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear(monkeypatch)
+        app = AppSettings(_env_file=None)
+
+        assert app.KEEPALIVE_INTERVAL_SECS == 5
+        assert app.sse_ping_interval_secs == 5
+
+    def test_truncates_floats_to_int(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """sse-starlette requires int seconds; fractional part is dropped."""
+        self._clear(monkeypatch)
+        monkeypatch.setenv("KEEPALIVE_INTERVAL_SECS", "10.9")
+        app = AppSettings(_env_file=None)
+
+        assert app.sse_ping_interval_secs == 10
+
+    def test_clamps_sub_second_to_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Sub-second heartbeats (used by legacy JSON endpoints and tests)
+        must not yield a zero ping interval that would flood the client."""
+        self._clear(monkeypatch)
+        monkeypatch.setenv("KEEPALIVE_INTERVAL_SECS", "0.5")
+        app = AppSettings(_env_file=None)
+
+        assert app.sse_ping_interval_secs == 1
+
+
 class TestDatabaseURLSupport:
     """Test that DATABASE_URL is used directly for computed URLs."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "redis", extra = ["hiredis"] },
     { name = "sqlalchemy" },
+    { name = "sse-starlette" },
     { name = "structlog" },
     { name = "uvicorn" },
 ]
@@ -75,6 +76,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "redis", extras = ["hiredis"], specifier = ">=5.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "sse-starlette", specifier = ">=3.3.4,<4.0.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
 ]
@@ -2292,15 +2294,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.2.0"
+version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/8d/00d280c03ffd39aaee0e86ec81e2d3b9253036a0f93f51d10503adef0e65/sse_starlette-3.2.0.tar.gz", hash = "sha256:8127594edfb51abe44eac9c49e59b0b01f1039d0c7461c6fd91d4e03b70da422", size = 27253, upload-time = "2026-01-17T13:11:05.62Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/7f/832f015020844a8b8f7a9cbc103dd76ba8e3875004c41e08440ea3a2b41a/sse_starlette-3.2.0-py3-none-any.whl", hash = "sha256:5876954bd51920fc2cd51baee47a080eb88a37b5b784e615abb0b283f801cdbf", size = 12763, upload-time = "2026-01-17T13:11:03.775Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

  Production agents with long silent graph nodes (e.g. holding an upstream WebSocket for ~60s) were being
  interrupted by Aegra. The SSE response had no keepalive, so idle proxies dropped the connection; Starlette turned
  that into a `CancelledError` inside the streaming generator, and the generator's `cancel_on_disconnect` branch
  fired `broker_manager.request_cancel` — misreading a proxy idle-drop as a real client disconnect.

  This PR fixes it by migrating SSE to `sse_starlette.EventSourceResponse` with a `: heartbeat` ping (byte-for-byte
  identical to `langgraph-api==0.8.0`) and moving cancel-on-disconnect from the generator to the transport layer, so
   only a real ASGI `http.disconnect` cancels the run.

  ## Type of Change

  - [ ] `feat`: New feature
  - [x] `fix`: Bug fix
  - [ ] `docs`: Documentation changes
  - [ ] `style`: Code style/formatting
  - [ ] `refactor`: Code refactoring
  - [ ] `perf`: Performance improvement
  - [ ] `test`: Tests added/updated
  - [ ] `chore`: Maintenance (dependencies, build, etc.)
  - [ ] `ci`: CI/CD changes

  ## Related Issues

  <!-- link here if there's a tracking issue -->

  ## Changes Made

  - Migrated 3 SSE endpoints (`POST /threads/{id}/runs/stream`, `GET /threads/{id}/runs/{rid}/stream`, `POST
  /runs/stream`) from `StreamingResponse` to `sse_starlette.EventSourceResponse`. `/wait` and `/join` keep their
  `\n`-byte JSON heartbeat — different content-type contract.
  - Emit `: heartbeat` comment frames via `ping_message_factory`, byte-for-byte identical to `langgraph-api==0.8.0`.
   Interval configurable via `KEEPALIVE_INTERVAL_SECS` (default 5s). Added `sse_ping_interval_secs` computed field
  with `max(1, int(...))` clamping (sse-starlette requires int).
  - Removed `cancel_on_disconnect` from `streaming_service.stream_run_execution`; the generator's `CancelledError`
  handler is now side-effect-free. Cancellation is wired through
  `EventSourceResponse.client_close_handler_callable`, firing only on real ASGI `http.disconnect`.
  - The reconnect endpoint `GET /threads/{id}/runs/{rid}/stream` deliberately omits `client_close_handler_callable`
  — a single client disconnecting must not cancel the shared run, since other consumers (`/join` or another
  `/stream`) may still be attached.
  - `stateless_stream_run` steals both `body_iterator` and `client_close_handler_callable` from the inner response
  and rewraps them in an outer `EventSourceResponse`, so ping and disconnect run against the cleaned-up iterator
  while disconnect-cancel still reaches the inner broker.
  - Added `sse-starlette>=3.3.4,<4.0.0` dependency.
  - Updated `docs/guides/streaming.mdx` with the new keepalive/disconnect behavior.

  ## Testing

  - [x] Unit tests added/updated
  - [x] Integration tests added/updated
  - [ ] E2E tests added/updated
  - [x] Manual testing performed

  New tests:

  - `tests/integration/test_sse_keepalive.py` (3 tests):
    - `test_keepalive_pings_during_silent_broker` — counts `: heartbeat` on the wire during a silent broker.
    - `test_client_disconnect_triggers_close_handler` — drives ASGI directly (httpx.ASGITransport does not
  synthesize `http.disconnect`) and asserts the handler fires exactly once.
    - `test_cancelled_error_no_longer_requests_cancel` — regression for the original bug; monkeypatches
  `request_cancel` and asserts it is never called on `CancelledError`.
  - `tests/unit/test_api/test_runs_streaming.py` (+2 parametrized) — disconnect-handler wiring across
  `on_disconnect` values and broker-error swallowing.
  - `tests/unit/test_api/test_stateless_runs.py` — mocks updated to `EventSourceResponse` + bytes iterators.
  - `tests/unit/test_settings.py::TestSsePingIntervalSecs` — default, truncation, sub-second clamping.

  Full suite: **1174 passed**, lint + type-check clean.

  Manual verification against `docker compose up -d`:

  | Endpoint | `: heartbeat` hits | legacy `: ping` hits |
  |---|---|---|
  | `POST /threads/{id}/runs/stream` | ≥1 | 0 |
  | `GET /threads/{id}/runs/{rid}/stream` | ≥2 | 0 |
  | `POST /runs/stream` (stateless) | ≥1 | 0 |

  Raw wire frame observed: `: heartbeat\r\n\r\n` (15 bytes) — matches `langgraph-api==0.8.0` byte-for-byte.

  ## Checklist

  - [x] Code follows project style (Ruff formatting)
  - [x] All linting checks pass (`make lint`)
  - [x] Type checking passes (`make type-check`)
  - [x] All tests pass (`make test`)
  - [x] Documentation updated (if needed)
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] PR title follows Conventional Commits format

  ## Screenshots (if applicable)

  N/A — server-side SSE wire change.

  ## Additional Notes

  **Client compatibility (important for upstream adopters).** W3C EventSource spec §9.2.6 requires clients to ignore
   lines starting with `:`. Verified in the relevant SSE parsers used against Aegra:

  - `langgraph_sdk/sse.py` — filters `:` lines
  - `httpx_sse/_decoders.py` — filters `:` lines
  - Browser `EventSource` — spec-compliant in all major engines

  Only self-written parsers without a `:` filter would need updating — one such parser exists in
  `tests/e2e/test_streaming/test_streaming_error_e2e.py` but currently silently skips heartbeats by accident (safe).

  **Not migrated.** `/runs/{id}/join` and `/runs/wait` (both threaded and stateless) still use `StreamingResponse`
  with a `\n`-byte heartbeat in `run_waiters.py` — that's correct for their `application/json` contract.

  **DEBUG logs from `sse_starlette.sse._ping` are deliberately left in** — useful in debug mode, and not overridable
   without forking `_ping`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSE endpoints now emit periodic keepalive heartbeats to reduce idle-proxy disconnects.
  * Keepalive interval exposed as an integer ping setting (truncated/clamped to >=1s).

* **Behavior**
  * Client disconnects cancel runs only for endpoints configured to do so; reconnect-style streams won’t cancel shared runs on single-client disconnects.
  * Errors in streams are emitted as structured SSE error events; heartbeat lines are SSE comments and ignored by standard clients.

* **Documentation**
  * Guide updated with keepalive and cancellation interoperability details.

* **Tests**
  * New integration, unit and e2e tests validating keepalives, disconnect handling, and cancellation semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Migrates three SSE endpoints from `StreamingResponse` to `sse_starlette.EventSourceResponse` with `: heartbeat` keepalive pings (default 5 s, configurable via `KEEPALIVE_INTERVAL_SECS`), fixing silent-agent interruption caused by idle-proxy timeouts firing a spurious `CancelledError` that was being misread as a real client disconnect.
- Moves `cancel_on_disconnect` logic from the streaming generator to `client_close_handler_callable` on the transport layer, so only a genuine ASGI `http.disconnect` event cancels the run; proxy drops no longer trigger `broker_manager.request_cancel`. The reconnect endpoint (`GET .../stream`) deliberately omits the close handler.
- Fixes a latent `UnboundLocalError` in `stateless_wait_for_run`'s `_wrapped_iterator` (missing `completed = False` initializer) and narrows broad `except Exception` cleanup catches to a typed `_CLEANUP_ERRORS` tuple so programmer errors surface instead of being silently swallowed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core transport-layer disconnect fix is architecturally sound, well-tested, and the latent UnboundLocalError in the wait endpoint is also resolved.

No P0 or P1 findings. The design cleanly separates SSE keepalive from run cancellation, all three path variants (cancel/continue/reconnect) are covered by unit and integration tests, and the previous review thread findings have been addressed in this revision. 1174 tests pass.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/sse.py | New heartbeat_factory, sse_to_bytes, and make_sse_response helpers that centralize SSE defaults; sse_to_bytes wraps the inner generator with aclosing for deterministic cleanup |
| libs/aegra-api/src/aegra_api/api/runs.py | Migrated create_and_stream_run and stream_run from StreamingResponse to EventSourceResponse; disconnect-cancel moved to _cancel_on_client_close closure wired via client_close_handler_callable; reconnect endpoint correctly omits the close handler |
| libs/aegra-api/src/aegra_api/api/stateless_runs.py | Narrow _CLEANUP_ERRORS tuple replaces bare except Exception; new _wrapped_iterator correctly handles completed/slow-client-abort/early-disconnect paths; Content-Location header is correctly extracted for run_id lookup |
| libs/aegra-api/src/aegra_api/services/streaming_service.py | Removed cancel_on_disconnect parameter; CancelledError handler is now side-effect-free; error event now emits structured {error: TypeName, message: execution failed} to avoid leaking internal details |
| libs/aegra-api/src/aegra_api/settings.py | Added sse_ping_interval_secs computed field that clamps the float KEEPALIVE_INTERVAL_SECS to an int >= 1, matching sse-starlette's requirement |
| libs/aegra-api/tests/integration/test_sse_keepalive.py | Three focused integration tests: heartbeat counting during silent broker, ASGI-driven http.disconnect firing close handler, and regression for CancelledError no longer calling request_cancel |
| libs/aegra-api/tests/unit/test_api/test_runs_streaming.py | New parametrized tests cover disconnect-handler wiring for all on_disconnect values and broker-error swallowing; stream_run confirmed to never wire a close handler |
| libs/aegra-api/tests/unit/test_api/test_stateless_runs.py | Updated mocks to EventSourceResponse + bytes iterators; new tests for early disconnect, slow-client abort (finished/active run), missing header, and programmer-error propagation |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant ASGI as ASGI / sse-starlette
    participant Handler as Endpoint Handler
    participant SSE as sse_to_bytes + stream_run_execution
    participant Broker as RunBroker

    Client->>ASGI: POST /threads/{id}/runs/stream
    ASGI->>Handler: create_and_stream_run()
    Handler->>Handler: build _cancel_on_client_close (if cancel_on_disconnect)
    Handler->>ASGI: EventSourceResponse(body=sse_to_bytes(...), ping=5s, close_handler=...)
    ASGI-->>Client: HTTP 200 text/event-stream

    loop Every 5 s (idle)
        ASGI-->>Client: : heartbeat CRLF CRLF
    end

    Broker-->>SSE: put(event_data)
    SSE-->>ASGI: bytes (pre-formatted SSE)
    ASGI-->>Client: event chunk

    alt Real http.disconnect (client closes)
        Client->>ASGI: http.disconnect
        ASGI->>Handler: client_close_handler_callable(msg)
        Handler->>Broker: broker_manager.request_cancel(run_id)
    else Proxy idle-drop (no real disconnect)
        Note over ASGI,Handler: CancelledError in generator -> re-raise only, no request_cancel
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix(api): address SSE keepalive follow-u..."](https://github.com/aegra/aegra/commit/207359ec7c452f95e063e0dd80ad7cb4c65b081b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30818441)</sub>

<!-- /greptile_comment -->