### PR TITLE
fix(store): ignore empty namespace query values

### DIFF
--- a/libs/aegra-api/src/aegra_api/api/store.py
+++ b/libs/aegra-api/src/aegra_api/api/store.py
@@ -82,7 +82,7 @@ async def get_store_item(
     if isinstance(namespace, str):
         ns_list = [part for part in namespace.split(".") if part]
     elif isinstance(namespace, list):
-        ns_list = namespace
+        ns_list = [part for part in namespace if part]
     else:
         ns_list = []
 

--- a/libs/aegra-api/src/aegra_api/api/store.py
+++ b/libs/aegra-api/src/aegra_api/api/store.py
@@ -77,17 +77,8 @@ async def get_store_item(
         if "key" in filters:
             key = filters["key"]
 
-    # Accept SDK-style dotted namespaces or list
-    ns_list: list[str]
-    if isinstance(namespace, str):
-        ns_list = [part for part in namespace.split(".") if part]
-    elif isinstance(namespace, list):
-        ns_list = [part for part in namespace if part]
-    else:
-        ns_list = []
-
     # Apply user namespace scoping
-    scoped_namespace = apply_user_namespace_scoping(user.identity, ns_list)
+    scoped_namespace = apply_user_namespace_scoping(user.identity, _normalize_namespace(namespace))
 
     store = db_manager.get_store()
 
@@ -120,7 +111,7 @@ async def delete_store_item(
     else:
         if key is None:
             raise HTTPException(422, "Missing 'key' parameter")
-        ns = namespace or []
+        ns = _normalize_namespace(namespace)
         k = key
 
     # Authorization check
@@ -231,6 +222,15 @@ async def list_namespaces(
     )
 
     return StoreListNamespacesResponse(namespaces=[list(ns) for ns in result])
+
+
+def _normalize_namespace(value: str | list[str] | None) -> list[str]:
+    """Normalize namespace input to a clean list, filtering out empty parts."""
+    if isinstance(value, str):
+        return [part for part in value.split(".") if part]
+    if isinstance(value, list):
+        return [part for part in value if part]
+    return []
 
 
 def apply_user_namespace_scoping(user_id: str, namespace: list[str]) -> list[str]:

--- a/libs/aegra-api/src/aegra_api/api/store.py
+++ b/libs/aegra-api/src/aegra_api/api/store.py
@@ -106,7 +106,7 @@ async def delete_store_item(
     ns = None
     k = None
     if body is not None:
-        ns = body.namespace
+        ns = _normalize_namespace(body.namespace)
         k = body.key
     else:
         if key is None:

--- a/libs/aegra-api/tests/integration/test_api/test_store_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_store_crud.py
@@ -211,6 +211,22 @@ class TestGetStoreItem:
         data = resp.json()
         assert data["key"] == "test-key"
 
+    def test_get_item_with_empty_namespace_query_param(self, client, mock_store):
+        """Test empty namespace query param is treated as no namespace"""
+        mock_item = DummyStoreItem(
+            key="test-key",
+            value={"data": "test"},
+            namespace=("users", "test-user"),
+        )
+        mock_store.aget.return_value = mock_item
+
+        resp = client.get("/store/items?namespace=&key=test-key")
+
+        assert resp.status_code == 200
+        call_args = mock_store.aget.call_args
+        namespace = call_args[0][0]
+        assert namespace == ("users", "test-user")
+
 
 class TestDeleteStoreItem:
     """Test DELETE /store/items"""

--- a/libs/aegra-api/tests/integration/test_api/test_store_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_store_crud.py
@@ -213,7 +213,7 @@ class TestGetStoreItem:
 
     def test_get_item_with_empty_namespace_query_param(self, client, mock_store):
         """Test empty namespace query param is treated as no namespace"""
-        from unittest.mock import patch, wraps
+        from unittest.mock import patch
 
         from aegra_api.api.store import apply_user_namespace_scoping
 
@@ -268,7 +268,7 @@ class TestDeleteStoreItem:
 
     def test_delete_item_with_empty_namespace_query_param(self, client, mock_store):
         """Test empty namespace query param is treated as no namespace"""
-        from unittest.mock import patch, wraps
+        from unittest.mock import patch
 
         from aegra_api.api.store import apply_user_namespace_scoping
 

--- a/libs/aegra-api/tests/integration/test_api/test_store_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_store_crud.py
@@ -213,6 +213,10 @@ class TestGetStoreItem:
 
     def test_get_item_with_empty_namespace_query_param(self, client, mock_store):
         """Test empty namespace query param is treated as no namespace"""
+        from unittest.mock import patch, wraps
+
+        from aegra_api.api.store import apply_user_namespace_scoping
+
         mock_item = DummyStoreItem(
             key="test-key",
             value={"data": "test"},
@@ -220,12 +224,16 @@ class TestGetStoreItem:
         )
         mock_store.aget.return_value = mock_item
 
-        resp = client.get("/store/items?namespace=&key=test-key")
+        with patch(
+            "aegra_api.api.store.apply_user_namespace_scoping",
+            wraps=apply_user_namespace_scoping,
+        ) as spy:
+            resp = client.get("/store/items?namespace=&key=test-key")
 
         assert resp.status_code == 200
+        spy.assert_called_once_with("test-user", [])
         call_args = mock_store.aget.call_args
-        namespace = call_args[0][0]
-        assert namespace == ("users", "test-user")
+        assert call_args[0][0] == ("users", "test-user")
 
 
 class TestDeleteStoreItem:
@@ -257,6 +265,23 @@ class TestDeleteStoreItem:
 
         assert resp.status_code == 422
         assert "key" in resp.json()["detail"].lower()
+
+    def test_delete_item_with_empty_namespace_query_param(self, client, mock_store):
+        """Test empty namespace query param is treated as no namespace"""
+        from unittest.mock import patch, wraps
+
+        from aegra_api.api.store import apply_user_namespace_scoping
+
+        with patch(
+            "aegra_api.api.store.apply_user_namespace_scoping",
+            wraps=apply_user_namespace_scoping,
+        ) as spy:
+            resp = client.delete("/store/items?key=test-key&namespace=")
+
+        assert resp.status_code == 204
+        spy.assert_called_once_with("test-user", [])
+        call_args = mock_store.adelete.call_args
+        assert call_args[0][0] == ("users", "test-user")
 
     def test_delete_item_with_namespace(self, client, mock_store):
         """Test deleting item with specific namespace"""


### PR DESCRIPTION
## Summary
- Ignore empty `namespace` query values in `GET /store/items` so `namespace=` is treated as no namespace.
- Add an integration regression test for `GET /store/items?namespace=&key=...`.

## Test plan
- [x] `uv run --package aegra-api pytest libs/aegra-api/tests/integration/test_api/test_store_crud.py`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with empty or list-style namespace parameters now behave like requests without a namespace, ensuring consistent scoping.

* **Tests**
  * Added integration tests verifying empty namespace parameters trigger the expected scoping and store operations.

* **Refactor**
  * Consolidated namespace normalization to ensure consistent behavior across store operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/325)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where an empty namespace query parameter was not treated as "no namespace," causing incorrect store scoping. It extracts a shared `_normalize_namespace` helper and applies it consistently across the GET and DELETE endpoints, with regression tests for both.

- **`store.py`**: New `_normalize_namespace(value)` handles `str | list[str] | None` → `list[str]`, filtering empty parts; applied to `get_store_item` and both code paths of `delete_store_item`.
- **`test_store_crud.py`**: Two new integration tests assert that an empty namespace query param results in `apply_user_namespace_scoping` receiving `[]`, and the store backend is called with the correct user-scoped namespace tuple.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted normalization fix with no behavioral regressions on existing paths.

The refactoring is minimal and well-scoped: a single helper function replaces inline logic that was already correct for the non-empty case, and the new tests directly cover the previously broken empty-string path. All three affected call sites (GET query param, DELETE query param, DELETE body) now go through the same normalization, and `put_store_item` is intentionally unchanged since it operates on an already-validated JSON body.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/store.py | Extracts `_normalize_namespace` helper and applies it to `get_store_item` (query param) and `delete_store_item` (both query param and body paths), fixing the empty-string namespace bug. |
| libs/aegra-api/tests/integration/test_api/test_store_crud.py | Adds two integration regression tests confirming that `?namespace=` is treated as no namespace for GET and DELETE, using `patch(..., wraps=...)` spies to assert the scoping function receives an empty list. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{Has body?}
    B -- Yes --> C[body.namespace]
    B -- No --> D[namespace query param]
    C --> E[_normalize_namespace]
    D --> E
    E --> F{Type?}
    F -- str --> G["split('.'), filter empty"]
    F -- list --> H["filter empty strings"]
    F -- None --> I["return []"]
    G --> J[list of str]
    H --> J
    I --> J
    J --> K[apply_user_namespace_scoping]
    K --> L["['users', user_id, ...namespace]"]
    L --> M[Store Operation]
```

<sub>Reviews (2): Last reviewed commit: ["fix(store): normalize namespace in delet..."](https://github.com/aegra/aegra/commit/057d760ffc4cc27e3adda3f5fc41a3e63a7220c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30666164)</sub>

<!-- /greptile_comment -->