### PR TITLE
chore: bump version to 0.9.5

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.4"
+    "version": "0.9.5"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.4"
+version = "0.9.5"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.4"
+version = "0.9.5"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.4"
+version = "0.9.5"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -96,7 +96,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.4"
+version = "0.9.5"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
Patch bump for fixes and small features merged since 0.9.4 (multi-host DATABASE_URL HA, observability fixes, --no-reload + debug-port CLI fixes, langfuse session_id fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.9.5 across API and CLI packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->