### PR TITLE
[db] Add POSTGRES_SCHEMA support for schema-isolated deployments

### DIFF
--- a/libs/aegra-api/alembic/env.py
+++ b/libs/aegra-api/alembic/env.py
@@ -4,7 +4,7 @@ import asyncio
 import threading
 from logging.config import fileConfig
 
-from sqlalchemy import pool
+from sqlalchemy import pool, text
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
@@ -56,15 +56,26 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        version_table_schema=settings.db.POSTGRES_SCHEMA,
     )
 
     with context.begin_transaction():
+        if settings.db.POSTGRES_SCHEMA:
+            context.execute(f'CREATE SCHEMA IF NOT EXISTS "{settings.db.POSTGRES_SCHEMA}"')
+            context.execute(f'SET search_path TO "{settings.db.POSTGRES_SCHEMA}", public')
         context.run_migrations()
 
 
 def do_run_migrations(connection: Connection) -> None:
     """Run migrations with the given connection."""
-    context.configure(connection=connection, target_metadata=target_metadata)
+    if settings.db.POSTGRES_SCHEMA:
+        connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{settings.db.POSTGRES_SCHEMA}"'))
+        connection.execute(text(f'SET search_path TO "{settings.db.POSTGRES_SCHEMA}", public'))
+        connection.commit()
+
+    context.configure(
+        connection=connection, target_metadata=target_metadata, version_table_schema=settings.db.POSTGRES_SCHEMA
+    )
 
     with context.begin_transaction():
         context.run_migrations()

--- a/libs/aegra-api/alembic/versions/20250817172544_initial_schema.py
+++ b/libs/aegra-api/alembic/versions/20250817172544_initial_schema.py
@@ -28,7 +28,7 @@ def upgrade() -> None:
     """Create initial database schema for Aegra Agent Protocol server."""
 
     # Create PostgreSQL extensions
-    op.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
+    op.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp" SCHEMA public;')
 
     # Create assistant table
     op.create_table(

--- a/libs/aegra-api/src/aegra_api/core/database.py
+++ b/libs/aegra-api/src/aegra_api/core/database.py
@@ -3,6 +3,7 @@
 import structlog
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langgraph.store.postgres.aio import AsyncPostgresStore
+from psycopg import sql as psycopg_sql
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
@@ -34,13 +35,17 @@ class DatabaseManager:
         # 1. SQLAlchemy Engine (app metadata, uses asyncpg)
         # We strictly limit this pool because the main load
         # is handled by LangGraph components.
+        connect_args: dict = {"prepared_statement_cache_size": 0}  # PgBouncer compatibility
+        if settings.db.POSTGRES_SCHEMA:
+            connect_args["server_settings"] = {"search_path": f"{settings.db.POSTGRES_SCHEMA}, public"}
+
         self.engine = create_async_engine(
             self._database_url,
             pool_size=settings.pool.SQLALCHEMY_POOL_SIZE,
             max_overflow=settings.pool.SQLALCHEMY_MAX_OVERFLOW,
             pool_pre_ping=True,
             echo=settings.db.DB_ECHO_LOG,
-            connect_args={"prepared_statement_cache_size": 0},  # PgBouncer compatibility
+            connect_args=connect_args,
         )
 
         lg_max = settings.pool.LANGGRAPH_MAX_POOL_SIZE
@@ -49,6 +54,16 @@ class DatabaseManager:
             "prepare_threshold": None,  # Disable prepared statements for PgBouncer compatibility
             "row_factory": dict_row,  # LangGraph requires dictionary rows, not tuples
         }
+
+        # Build per-connection configure callback when schema isolation is active.
+        pool_configure = None
+        if settings.db.POSTGRES_SCHEMA:
+            set_sp = psycopg_sql.SQL("SET search_path TO {}, public").format(
+                psycopg_sql.Identifier(settings.db.POSTGRES_SCHEMA)
+            )
+
+            async def pool_configure(conn):  # noqa: E303
+                await conn.execute(set_sp)
 
         # Create a single shared pool.
         # 'open=False' is important to avoid RuntimeWarning; we open it explicitly below.
@@ -59,10 +74,20 @@ class DatabaseManager:
             open=False,
             kwargs=lg_kwargs,
             check=AsyncConnectionPool.check_connection,
+            configure=pool_configure,
         )
 
         # Explicitly open the pool
         await self.lg_pool.open()
+
+        # Create the target schema if it doesn't exist yet.
+        if settings.db.POSTGRES_SCHEMA:
+            async with self.lg_pool.connection() as conn:
+                await conn.execute(
+                    psycopg_sql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(
+                        psycopg_sql.Identifier(settings.db.POSTGRES_SCHEMA)
+                    )
+                )
 
         # 2. Initialize LangGraph components using the shared pool
         # Passing 'conn=self.lg_pool' prevents components from creating their own pools.

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -90,6 +90,7 @@ class DatabaseSettings(EnvBase):
     POSTGRES_HOST: str = "localhost"
     POSTGRES_PORT: str = "5432"
     POSTGRES_DB: str = "aegra"
+    POSTGRES_SCHEMA: str | None = None
     DB_ECHO_LOG: bool = False
 
     @staticmethod

--- a/libs/aegra-api/tests/unit/test_core/test_database_manager.py
+++ b/libs/aegra-api/tests/unit/test_core/test_database_manager.py
@@ -1,9 +1,9 @@
 import os
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# Adjust the import path to match your project structure
 from aegra_api.core.database import DatabaseManager
 from aegra_api.settings import settings
 
@@ -51,6 +51,14 @@ class TestDatabaseManager:
             mock_pool_cls.return_value = mock_pool_instance
             # Mock the static/class method check_connection
             mock_pool_cls.check_connection = MagicMock()
+
+            mock_conn = AsyncMock()
+
+            @asynccontextmanager
+            async def _fake_connection():
+                yield mock_conn
+
+            mock_pool_instance.connection = _fake_connection
 
             # 3. Setup Saver and Store Mocks
             mock_saver_instance = AsyncMock()
@@ -226,3 +234,262 @@ class TestDatabaseManager:
         # Store should be initialized with index=None
         mock_db_deps["store_cls"].assert_called_with(conn=mock_db_deps["pool_instance"], index=None)
         mock_db_deps["store_instance"].setup.assert_awaited_once()
+
+
+class TestDatabaseManagerSchemaIsolation:
+    """Tests for POSTGRES_SCHEMA-based schema isolation in DatabaseManager."""
+
+    @pytest.fixture
+    def db_manager(self) -> DatabaseManager:
+        """Creates a fresh DatabaseManager instance for each test."""
+        return DatabaseManager()
+
+    @pytest.fixture
+    def mock_env_with_schema(self):
+        """Sets environment with POSTGRES_SCHEMA configured."""
+        env_vars = {
+            "DATABASE_URL": settings.db.database_url,
+            "SQLALCHEMY_POOL_SIZE": str(settings.pool.SQLALCHEMY_POOL_SIZE),
+            "LANGGRAPH_MAX_POOL_SIZE": str(settings.pool.LANGGRAPH_MAX_POOL_SIZE),
+            "LANGGRAPH_MIN_POOL_SIZE": str(settings.pool.LANGGRAPH_MIN_POOL_SIZE),
+            "POSTGRES_SCHEMA": "tenant_x",
+        }
+        with patch.dict(os.environ, env_vars), patch.object(settings.db, "POSTGRES_SCHEMA", "tenant_x"):
+            yield
+
+    @pytest.fixture
+    def mock_db_deps_with_schema(self, mock_env_with_schema):
+        """Mocks all external database dependencies with schema isolation active."""
+        with (
+            patch("aegra_api.core.database.create_async_engine") as mock_create_engine,
+            patch("aegra_api.core.database.AsyncConnectionPool") as mock_pool_cls,
+            patch("aegra_api.core.database.AsyncPostgresSaver") as mock_saver_cls,
+            patch("aegra_api.core.database.AsyncPostgresStore") as mock_store_cls,
+            patch("aegra_api.core.database.load_store_config") as mock_load_store_config,
+        ):
+            mock_engine = AsyncMock()
+            mock_create_engine.return_value = mock_engine
+
+            mock_pool_instance = AsyncMock()
+            mock_pool_cls.return_value = mock_pool_instance
+            mock_pool_cls.check_connection = MagicMock()
+
+            mock_conn = AsyncMock()
+
+            @asynccontextmanager
+            async def _fake_connection():
+                yield mock_conn
+
+            mock_pool_instance.connection = _fake_connection
+
+            mock_saver_instance = AsyncMock()
+            mock_saver_cls.return_value = mock_saver_instance
+
+            mock_store_instance = AsyncMock()
+            mock_store_cls.return_value = mock_store_instance
+
+            mock_load_store_config.return_value = None
+
+            yield {
+                "create_engine": mock_create_engine,
+                "engine_instance": mock_engine,
+                "pool_cls": mock_pool_cls,
+                "pool_instance": mock_pool_instance,
+                "pool_conn": mock_conn,
+                "saver_cls": mock_saver_cls,
+                "saver_instance": mock_saver_instance,
+                "store_cls": mock_store_cls,
+                "store_instance": mock_store_instance,
+                "load_store_config": mock_load_store_config,
+            }
+
+    @pytest.mark.asyncio
+    async def test_sqlalchemy_connect_args_include_search_path(
+        self, db_manager: DatabaseManager, mock_db_deps_with_schema: dict
+    ) -> None:
+        """When POSTGRES_SCHEMA is set, SQLAlchemy connect_args must include server_settings with search_path."""
+        await db_manager.initialize()
+
+        _, kwargs = mock_db_deps_with_schema["create_engine"].call_args
+        connect_args = kwargs["connect_args"]
+        assert "server_settings" in connect_args
+        assert connect_args["server_settings"]["search_path"] == "tenant_x, public"
+
+    @pytest.mark.asyncio
+    async def test_sqlalchemy_connect_args_no_search_path_without_schema(self, db_manager: DatabaseManager) -> None:
+        """When POSTGRES_SCHEMA is None, connect_args should NOT include server_settings."""
+        env_vars = {
+            "DATABASE_URL": settings.db.database_url,
+            "SQLALCHEMY_POOL_SIZE": str(settings.pool.SQLALCHEMY_POOL_SIZE),
+            "LANGGRAPH_MAX_POOL_SIZE": str(settings.pool.LANGGRAPH_MAX_POOL_SIZE),
+            "LANGGRAPH_MIN_POOL_SIZE": str(settings.pool.LANGGRAPH_MIN_POOL_SIZE),
+        }
+        with (
+            patch.dict(os.environ, env_vars),
+            patch.object(settings.db, "POSTGRES_SCHEMA", None),
+            patch("aegra_api.core.database.create_async_engine") as mock_create_engine,
+            patch("aegra_api.core.database.AsyncConnectionPool") as mock_pool_cls,
+            patch("aegra_api.core.database.AsyncPostgresSaver") as mock_saver_cls,
+            patch("aegra_api.core.database.AsyncPostgresStore") as mock_store_cls,
+            patch("aegra_api.core.database.load_store_config") as mock_load_store_config,
+        ):
+            mock_create_engine.return_value = AsyncMock()
+            mock_pool_instance = AsyncMock()
+            mock_pool_cls.return_value = mock_pool_instance
+            mock_pool_cls.check_connection = MagicMock()
+
+            mock_conn = AsyncMock()
+
+            @asynccontextmanager
+            async def _fake_connection():
+                yield mock_conn
+
+            mock_pool_instance.connection = _fake_connection
+
+            mock_saver_cls.return_value = AsyncMock()
+            mock_store_cls.return_value = AsyncMock()
+            mock_load_store_config.return_value = None
+
+            await db_manager.initialize()
+
+            _, kwargs = mock_create_engine.call_args
+            connect_args = kwargs["connect_args"]
+            assert "server_settings" not in connect_args
+
+    @pytest.mark.asyncio
+    async def test_langgraph_pool_receives_configure_callback(
+        self, db_manager: DatabaseManager, mock_db_deps_with_schema: dict
+    ) -> None:
+        """When POSTGRES_SCHEMA is set, the LangGraph pool must receive a configure callback."""
+        await db_manager.initialize()
+
+        _, kwargs = mock_db_deps_with_schema["pool_cls"].call_args
+        assert kwargs["configure"] is not None
+        assert callable(kwargs["configure"])
+
+    @pytest.mark.asyncio
+    async def test_langgraph_pool_configure_is_none_without_schema(self, db_manager: DatabaseManager) -> None:
+        """When POSTGRES_SCHEMA is None, the pool configure callback must be None."""
+        env_vars = {
+            "DATABASE_URL": settings.db.database_url,
+            "SQLALCHEMY_POOL_SIZE": str(settings.pool.SQLALCHEMY_POOL_SIZE),
+            "LANGGRAPH_MAX_POOL_SIZE": str(settings.pool.LANGGRAPH_MAX_POOL_SIZE),
+            "LANGGRAPH_MIN_POOL_SIZE": str(settings.pool.LANGGRAPH_MIN_POOL_SIZE),
+        }
+        with (
+            patch.dict(os.environ, env_vars),
+            patch.object(settings.db, "POSTGRES_SCHEMA", None),
+            patch("aegra_api.core.database.create_async_engine") as mock_create_engine,
+            patch("aegra_api.core.database.AsyncConnectionPool") as mock_pool_cls,
+            patch("aegra_api.core.database.AsyncPostgresSaver") as mock_saver_cls,
+            patch("aegra_api.core.database.AsyncPostgresStore") as mock_store_cls,
+            patch("aegra_api.core.database.load_store_config") as mock_load_store_config,
+        ):
+            mock_create_engine.return_value = AsyncMock()
+            mock_pool_instance = AsyncMock()
+            mock_pool_cls.return_value = mock_pool_instance
+            mock_pool_cls.check_connection = MagicMock()
+
+            mock_conn = AsyncMock()
+
+            @asynccontextmanager
+            async def _fake_connection():
+                yield mock_conn
+
+            mock_pool_instance.connection = _fake_connection
+
+            mock_saver_cls.return_value = AsyncMock()
+            mock_store_cls.return_value = AsyncMock()
+            mock_load_store_config.return_value = None
+
+            await db_manager.initialize()
+
+            _, kwargs = mock_pool_cls.call_args
+            assert kwargs["configure"] is None
+
+    @pytest.mark.asyncio
+    async def test_schema_created_on_initialize(
+        self, db_manager: DatabaseManager, mock_db_deps_with_schema: dict
+    ) -> None:
+        """When POSTGRES_SCHEMA is set, CREATE SCHEMA IF NOT EXISTS is executed via the pool."""
+        await db_manager.initialize()
+
+        mock_conn = mock_db_deps_with_schema["pool_conn"]
+        mock_conn.execute.assert_awaited()
+
+        sql_obj = mock_conn.execute.call_args_list[0][0][0]
+        executed_sql = sql_obj.as_string(None)
+        assert "CREATE SCHEMA IF NOT EXISTS" in executed_sql
+        assert '"tenant_x"' in executed_sql
+
+    @pytest.mark.asyncio
+    async def test_no_schema_created_without_postgres_schema(self, db_manager: DatabaseManager) -> None:
+        """When POSTGRES_SCHEMA is None, no CREATE SCHEMA is executed."""
+        env_vars = {
+            "DATABASE_URL": settings.db.database_url,
+            "SQLALCHEMY_POOL_SIZE": str(settings.pool.SQLALCHEMY_POOL_SIZE),
+            "LANGGRAPH_MAX_POOL_SIZE": str(settings.pool.LANGGRAPH_MAX_POOL_SIZE),
+            "LANGGRAPH_MIN_POOL_SIZE": str(settings.pool.LANGGRAPH_MIN_POOL_SIZE),
+        }
+        with (
+            patch.dict(os.environ, env_vars),
+            patch.object(settings.db, "POSTGRES_SCHEMA", None),
+            patch("aegra_api.core.database.create_async_engine") as mock_create_engine,
+            patch("aegra_api.core.database.AsyncConnectionPool") as mock_pool_cls,
+            patch("aegra_api.core.database.AsyncPostgresSaver") as mock_saver_cls,
+            patch("aegra_api.core.database.AsyncPostgresStore") as mock_store_cls,
+            patch("aegra_api.core.database.load_store_config") as mock_load_store_config,
+        ):
+            mock_create_engine.return_value = AsyncMock()
+            mock_pool_instance = AsyncMock()
+            mock_pool_cls.return_value = mock_pool_instance
+            mock_pool_cls.check_connection = MagicMock()
+
+            mock_conn = AsyncMock()
+
+            @asynccontextmanager
+            async def _fake_connection():
+                yield mock_conn
+
+            mock_pool_instance.connection = _fake_connection
+
+            mock_saver_cls.return_value = AsyncMock()
+            mock_store_cls.return_value = AsyncMock()
+            mock_load_store_config.return_value = None
+
+            await db_manager.initialize()
+
+            # The pool's connection context manager should never be called
+            # since POSTGRES_SCHEMA is None — the _fake_connection should not
+            # have been entered, meaning mock_conn.execute was not called.
+            mock_conn.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_configure_callback_sets_search_path(
+        self, db_manager: DatabaseManager, mock_db_deps_with_schema: dict
+    ) -> None:
+        """The pool configure callback should execute SET search_path when called."""
+        await db_manager.initialize()
+
+        _, kwargs = mock_db_deps_with_schema["pool_cls"].call_args
+        configure_fn = kwargs["configure"]
+
+        fake_conn = AsyncMock()
+        await configure_fn(fake_conn)
+
+        fake_conn.execute.assert_awaited_once()
+        sql_obj = fake_conn.execute.call_args[0][0]
+        executed_sql = sql_obj.as_string(None)
+        assert "SET search_path TO" in executed_sql
+        assert '"tenant_x"' in executed_sql
+
+    @pytest.mark.asyncio
+    async def test_pgbouncer_cache_size_preserved_with_schema(
+        self, db_manager: DatabaseManager, mock_db_deps_with_schema: dict
+    ) -> None:
+        """PgBouncer compatibility setting must be preserved when schema is set."""
+        await db_manager.initialize()
+
+        _, kwargs = mock_db_deps_with_schema["create_engine"].call_args
+        connect_args = kwargs["connect_args"]
+        assert connect_args["prepared_statement_cache_size"] == 0

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -287,6 +287,48 @@ class TestMultiHostDatabaseURL:
         assert db.database_url == "postgresql+asyncpg:///db?host=h1,h2&port=5432,5432"
 
 
+class TestPostgresSchema:
+    """Test POSTGRES_SCHEMA setting for schema isolation."""
+
+    def _clear_db_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Remove env vars that affect DatabaseSettings."""
+        for var in (
+            "DATABASE_URL",
+            "POSTGRES_USER",
+            "POSTGRES_PASSWORD",
+            "POSTGRES_HOST",
+            "POSTGRES_PORT",
+            "POSTGRES_DB",
+            "POSTGRES_SCHEMA",
+            "DB_ECHO_LOG",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_defaults_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSTGRES_SCHEMA defaults to None when not set."""
+        self._clear_db_env(monkeypatch)
+        db = DatabaseSettings(_env_file=None)
+
+        assert db.POSTGRES_SCHEMA is None
+
+    def test_set_via_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """POSTGRES_SCHEMA can be configured via environment variable."""
+        self._clear_db_env(monkeypatch)
+        monkeypatch.setenv("POSTGRES_SCHEMA", "tenant_a")
+        db = DatabaseSettings(_env_file=None)
+
+        assert db.POSTGRES_SCHEMA == "tenant_a"
+
+    def test_empty_string_is_treated_as_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty POSTGRES_SCHEMA env var is kept as empty string (falsy)."""
+        self._clear_db_env(monkeypatch)
+        monkeypatch.setenv("POSTGRES_SCHEMA", "")
+        db = DatabaseSettings(_env_file=None)
+
+        assert db.POSTGRES_SCHEMA == ""
+        assert not db.POSTGRES_SCHEMA
+
+
 class TestWorkerSettingsLeaseValidation:
     """Test that lease timing invariants are enforced at startup."""
 


### PR DESCRIPTION
## Summary

Adds a new `POSTGRES_SCHEMA` env var that lets you run all Aegra tables inside a dedicated PostgreSQL schema instead of `public`. This is useful when you're sharing a database across multiple services or tenants and dont want everything lumped into the same schema.

When `POSTGRES_SCHEMA` is set:
- SQLAlchemy connections get `search_path` set via `server_settings`
- LangGraph pool connections get `search_path` via a per-connection `configure` callback
- The schema is auto-created (`CREATE SCHEMA IF NOT EXISTS`) on startup
- Alembic migrations create the schema and set `search_path` before running, and the version table is placed in the target schema
- The `uuid-ossp` extension is explicitly created in the `public` schema (extensions are cluster-wide, avoids issues when running in a non-public schema)

When not set (default), behavior is completely unchanged.

## Changes
- `settings.py` — new `POSTGRES_SCHEMA: str | None = None` field
- `database.py` — schema creation + search_path for both SQLAlchemy and LangGraph pools
- `alembic/env.py` — schema-aware offline and online migrations with `version_table_schema`
- `alembic/versions/initial_schema.py` — `uuid-ossp` extension pinned to public schema
- Tests — added 11 new unit tests covering settings defaults and all schema isolation paths in DatabaseManager

## Test plan
- [x] `POSTGRES_SCHEMA` defaults to `None`
- [x] `POSTGRES_SCHEMA` can be set via env var
- [x] SQLAlchemy `connect_args` includes `search_path` when schema is set
- [x] SQLAlchemy `connect_args` has no `server_settings` when schema is `None`
- [x] LangGraph pool gets `configure` callback when schema is set
- [x] LangGraph pool `configure` is `None` when schema is not set
- [x] `CREATE SCHEMA IF NOT EXISTS` runs on init
- [x] No schema creation when `POSTGRES_SCHEMA` is unset
- [x] Configure callback executes correct `SET search_path`
- [x] PgBouncer compatibility preserved alongside schema settings
- [x] All 912 unit tests pass, lint + format clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL schema isolation support enabling multi-tenant database separation.
  * Database initialization now automatically manages schema creation and search path configuration.

* **Tests**
  * Added comprehensive test coverage for schema isolation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->