### PR TITLE
fix: pass user object directly to langgraph_auth_user for Runtime injection

### DIFF
--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -680,14 +680,10 @@ def inject_user_context(user: Any | None, base_config: dict[str, Any] | None = N
         config["configurable"].setdefault("user_id", user.identity)
         config["configurable"].setdefault("user_display_name", getattr(user, "display_name", None) or user.identity)
 
-        # Full auth payload for graph nodes - includes ALL fields from auth handler
+        # Pass user object directly so langgraph's _build_server_info() can
+        # detect it via hasattr(obj, "identity") and populate Runtime.server_info.
         if "langgraph_auth_user" not in config["configurable"]:
-            try:
-                # user.to_dict() returns all fields including extras from auth handlers
-                config["configurable"]["langgraph_auth_user"] = user.to_dict()
-            except Exception:
-                # Fallback: minimal dict if to_dict unavailable or fails
-                config["configurable"]["langgraph_auth_user"] = {"identity": user.identity}
+            config["configurable"]["langgraph_auth_user"] = user
 
     return config
 

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -680,10 +680,7 @@ def inject_user_context(user: Any | None, base_config: dict[str, Any] | None = N
         config["configurable"].setdefault("user_id", user.identity)
         config["configurable"].setdefault("user_display_name", getattr(user, "display_name", None) or user.identity)
 
-        # Pass user object directly so langgraph's _build_server_info() can
-        # detect it via hasattr(obj, "identity") and populate Runtime.server_info.
-        if "langgraph_auth_user" not in config["configurable"]:
-            config["configurable"]["langgraph_auth_user"] = user
+        config["configurable"]["langgraph_auth_user"] = user
 
     return config
 

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -536,7 +536,6 @@ class TestLangGraphServiceContext:
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.return_value = {"identity": "user-123", "name": "Test User"}
 
         base_config = {"existing": "value"}
 
@@ -562,7 +561,6 @@ class TestLangGraphServiceContext:
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.return_value = {"identity": "user-123"}
 
         result = inject_user_context(mock_user, None)
 
@@ -586,7 +584,6 @@ class TestLangGraphServiceContext:
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.return_value = {"identity": "user-123"}
 
         base_config = {"configurable": {"existing_key": "existing_value"}}
 
@@ -604,7 +601,6 @@ class TestLangGraphServiceConfigs:
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.return_value = {"identity": "user-123"}
 
         thread_id = "thread-456"
         additional_config = {"custom": "value"}
@@ -620,7 +616,6 @@ class TestLangGraphServiceConfigs:
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.return_value = {"identity": "user-123"}
 
         thread_id = "thread-456"
 
@@ -634,7 +629,6 @@ class TestLangGraphServiceConfigs:
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.return_value = {"identity": "user-123"}
 
         run_id = "run-789"
         thread_id = "thread-456"
@@ -656,7 +650,6 @@ class TestLangGraphServiceConfigs:
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.return_value = {"identity": "user-123"}
 
         run_id = "run-789"
         thread_id = "thread-456"
@@ -675,7 +668,6 @@ class TestLangGraphServiceConfigs:
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.return_value = {"identity": "user-123"}
 
         run_id = "run-789"
         thread_id = "thread-456"
@@ -716,7 +708,6 @@ class TestLangGraphServiceConfigs:
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.return_value = {"identity": "user-123"}
 
         run_id = "run-789"
         thread_id = "thread-456"
@@ -742,7 +733,6 @@ class TestLangGraphServiceConfigs:
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.return_value = {"identity": "user-123"}
 
         run_id = "run-789"
         thread_id = "thread-456"
@@ -781,7 +771,6 @@ class TestLangGraphServiceConfigs:
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.return_value = {"identity": "user-123"}
 
         run_id = "run-abc-123"
         thread_id = "thread-456"

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -545,10 +545,7 @@ class TestLangGraphServiceContext:
         assert result["existing"] == "value"
         assert result["configurable"]["user_id"] == "user-123"
         assert result["configurable"]["user_display_name"] == "Test User"
-        assert result["configurable"]["langgraph_auth_user"] == {
-            "identity": "user-123",
-            "name": "Test User",
-        }
+        assert result["configurable"]["langgraph_auth_user"] is mock_user
 
     def test_inject_user_context_without_user(self):
         """Test injecting context without user object"""
@@ -572,18 +569,17 @@ class TestLangGraphServiceContext:
         assert result["configurable"]["user_id"] == "user-123"
         assert result["configurable"]["user_display_name"] == "Test User"
 
-    def test_inject_user_context_user_to_dict_failure(self):
-        """Test fallback when user.to_dict() fails"""
+    def test_inject_user_context_user_object_passed_directly(self):
+        """Test that the user object is passed directly (not serialized)."""
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.side_effect = Exception("to_dict failed")
 
         result = inject_user_context(mock_user, {})
 
         assert result["configurable"]["user_id"] == "user-123"
         assert result["configurable"]["user_display_name"] == "Test User"
-        assert result["configurable"]["langgraph_auth_user"] == {"identity": "user-123"}
+        assert result["configurable"]["langgraph_auth_user"] is mock_user
 
     def test_inject_user_context_existing_configurable(self):
         """Test preserving existing configurable values"""


### PR DESCRIPTION
## Summary

- Pass the user object directly to `langgraph_auth_user` instead of serializing it via `to_dict()`, so LangGraph's `_build_server_info()` can detect it via `hasattr(obj, "identity")` and correctly populate `Runtime.server_info` in graph nodes.

## Problem

When `langgraph_auth_user` was set to a serialized dict, LangGraph could not recognize it as an auth user object, leaving `Runtime.server_info` unpopulated.

## Test plan

- Updated unit tests to verify the user object is passed by reference
- Removed obsolete `to_dict()` fallback test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of authentication context so the original user object is passed through unchanged to downstream services.
* **Tests**
  * Updated unit tests to reflect the new authentication-context behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->