### PR TITLE
chore: bump version to 0.9.6

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.5"
+    "version": "0.9.6"
   },
   "paths": {
     "/info": {
@@ -4365,8 +4365,43 @@
               }
             ],
             "title": "Order By",
-            "description": "Sort order",
-            "default": "created_at DESC"
+            "description": "DEPRECATED: use sort_by + sort_order. Legacy single-field form, e.g. 'updated_at ASC'.",
+            "default": "created_at DESC",
+            "deprecated": true
+          },
+          "sort_by": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "thread_id",
+                  "status",
+                  "created_at",
+                  "updated_at"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort By",
+            "description": "Field to sort by (SDK-compatible). Takes precedence over order_by."
+          },
+          "sort_order": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "asc",
+                  "desc"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort Order",
+            "description": "Sort direction (SDK-compatible). Defaults to 'desc' when sort_by is set."
           }
         },
         "type": "object",

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.5"
+version = "0.9.6"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.5"
+version = "0.9.6"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.5"
+version = "0.9.6"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -96,7 +96,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.5"
+version = "0.9.6"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary

- bump aegra-api + aegra-cli from 0.9.5 to 0.9.6 (patch)
- regenerate docs/openapi.json so SDK consumers see the new threads search fields

## Changes since 0.9.5

- fix(api): /threads/search honors sort_by/sort_order, fixes metadata type coercion via JSONB containment, adds GIN jsonb_path_ops index migration, stable pagination tie-break on thread_id (#322, fixes #302)
- fix(settings): URL-encode database credentials with special characters (#328)
- feat(cli): add --no-reload flag to aegra dev (#319)
- fix(cli): debug-port passed as string to debugpy (#318)
- fix(observability): emit langfuse_session_id from get_metadata (#313)

All non-breaking, patch bump per CLAUDE.md versioning rules. aegra-cli's aegra-api~=0.9.0 constraint already covers 0.9.6, no constraint change needed.

## OpenAPI spec changes

ThreadSearchRequest now exposes:
- sort_by (Literal: thread_id | status | created_at | updated_at)
- sort_order (Literal: asc | desc)
- order_by marked deprecated=True

The auto-spec workflow can't open PRs on this org (Actions are not permitted to create or approve PRs), so I'm rolling the spec regen into this version-bump PR instead.

## Test plan

- [ ] CI green
- [ ] uv sync resolves cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `sort_by` parameter for thread search with support for sorting by thread ID, status, creation date, or update date.
  * Added `sort_order` parameter to control ascending or descending sort direction.

* **Deprecations**
  * The `order_by` parameter for thread search is now deprecated; use `sort_by` and `sort_order` instead.

* **Chores**
  * Version bumped to 0.9.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->