### PR TITLE
feat(observability): propagate user-supplied run metadata to OTEL trace context

### DIFF
--- a/docs/guides/observability.mdx
+++ b/docs/guides/observability.mdx
@@ -96,6 +96,49 @@ Aegra uses a pure OpenTelemetry approach:
 
 This keeps overhead low and maintains compatibility with the entire OpenTelemetry ecosystem.
 
+## Run metadata
+
+Each `POST /threads/{thread_id}/runs` (and `/runs/stream`, `/runs/wait`) request accepts an optional top-level `metadata` field whose key/value pairs are propagated onto the run's root OTEL span. This is the recommended channel for filterable trace attributes that aren't part of the LangGraph payload — tenant id, feature flag, environment tag, sub-agent type, and similar.
+
+```json
+{
+  "assistant_id": "agent",
+  "input": {"question": "..."},
+  "metadata": {
+    "tenant": "acme",
+    "feature_flag": true,
+    "subagent": "matter_legal"
+  }
+}
+```
+
+Each entry reaches the root span as `langfuse.trace.metadata.<key>`, which Langfuse exposes as a queryable trace property (rather than burying it under per-observation metadata). On Phoenix and other OTLP targets the same attribute is set verbatim; native first-class metadata aliasing is a planned follow-up.
+
+The value is also persisted to the runs table (`execution_params.run_metadata` JSONB column) so it survives worker restart and is available for post-hoc analysis.
+
+### Constraints
+
+The request validator rejects payloads that would either be silently dropped downstream or balloon span size past collector limits. A violating payload returns `422` with a single message identifying the offending key:
+
+| Constraint | Limit |
+|------------|-------|
+| Maximum number of keys | 32 |
+| Key character set | `[A-Za-z0-9_-]` (no dots, no whitespace, no non-ASCII) |
+| Key length | 1–64 characters |
+| Value type | `str`, `int`, `float`, or `bool` (no nested dicts, lists, or `null`) |
+| String value length | ≤ 512 characters |
+
+The dot exclusion is deliberate: keys are stored under the `langfuse.trace.metadata.` prefix, and allowing dots would let a caller land bare attributes (e.g. `langfuse.user.id`) next to the system ones.
+
+### System-key collisions
+
+Aegra injects a small number of runtime keys into the same metadata stream so they're filterable alongside user-supplied attributes:
+
+- `run_id`, `thread_id`, `graph_id` — always present
+- `original_request_id` — present on the worker path when an HTTP correlation-id was supplied
+
+If the request `metadata` contains a key already populated by the runtime, the system value wins, the user value is dropped, and a warning is logged from `aegra_api.observability.span_enrichment`. This makes the OTEL view a reliable join key with logs and the runs table; user audit fidelity is preserved by keeping the original payload in `execution_params.run_metadata`.
+
 ## Key environment variables
 
 The main variables you'll need:

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -67,6 +67,17 @@ class RunJob(BaseModel):
     user: User
     execution: RunExecution = RunExecution()
     behavior: RunBehavior = RunBehavior()
+    # User-supplied request metadata, persisted to ``execution_params``
+    # JSONB.  Validation is deliberately asymmetric: ``RunCreate.metadata``
+    # is strict at ingress (primitive-only union, key regex, length caps),
+    # while this field is permissive ``dict[str, Any]`` so legacy rows and
+    # any future schema drift remain readable on ``from_run_orm``.  Values
+    # may collide with reserved system keys (e.g. ``run_id``) — the row
+    # stores user input verbatim for audit fidelity, and the OTEL boundary
+    # in ``observability.span_enrichment.merge_run_metadata`` filters and
+    # warns at emit time.  Consume only via ``merge_run_metadata``; do not
+    # tighten this annotation without restoring an equivalent filter on
+    # read in ``from_run_orm``.
     run_metadata: dict[str, Any] = Field(default_factory=dict)
 
     def to_execution_params(self) -> dict[str, Any]:

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -67,6 +67,7 @@ class RunJob(BaseModel):
     user: User
     execution: RunExecution = RunExecution()
     behavior: RunBehavior = RunBehavior()
+    run_metadata: dict[str, Any] = Field(default_factory=dict)
 
     def to_execution_params(self) -> dict[str, Any]:
         """Serialize for the ``execution_params`` JSONB column.
@@ -80,6 +81,7 @@ class RunJob(BaseModel):
             "user": self.user.model_dump(),
             "execution": self.execution.model_dump(),
             "behavior": self.behavior.model_dump(),
+            "run_metadata": self.run_metadata,
         }
 
     @classmethod
@@ -97,4 +99,5 @@ class RunJob(BaseModel):
             user=User.model_validate(params["user"]),
             execution=RunExecution.model_validate(params["execution"]),
             behavior=RunBehavior.model_validate(params["behavior"]),
+            run_metadata=params.get("run_metadata") or {},
         )

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -67,17 +67,8 @@ class RunJob(BaseModel):
     user: User
     execution: RunExecution = RunExecution()
     behavior: RunBehavior = RunBehavior()
-    # User-supplied request metadata, persisted to ``execution_params``
-    # JSONB.  Validation is deliberately asymmetric: ``RunCreate.metadata``
-    # is strict at ingress (primitive-only union, key regex, length caps),
-    # while this field is permissive ``dict[str, Any]`` so legacy rows and
-    # any future schema drift remain readable on ``from_run_orm``.  Values
-    # may collide with reserved system keys (e.g. ``run_id``) — the row
-    # stores user input verbatim for audit fidelity, and the OTEL boundary
-    # in ``observability.span_enrichment.merge_run_metadata`` filters and
-    # warns at emit time.  Consume only via ``merge_run_metadata``; do not
-    # tighten this annotation without restoring an equivalent filter on
-    # read in ``from_run_orm``.
+    # JSONB-persisted; deliberately ``dict[str, Any]`` so legacy/drifted rows stay readable via
+    # ``from_run_orm``. OTEL boundary in ``merge_run_metadata`` filters at emit. Do not narrow.
     run_metadata: dict[str, Any] = Field(default_factory=dict)
 
     def to_execution_params(self) -> dict[str, Any]:

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -79,11 +79,12 @@ class RunCreate(BaseModel):
 
     # Request metadata (top-level in payload).  Reaches OTEL trace
     # attributes as ``langfuse.trace.metadata.<key>`` (and the
-    # OpenInference ``metadata.<key>`` alias on Phoenix targets).  Values
-    # are restricted to OTEL-attribute primitives because the SDK silently
-    # drops nested values; surfacing the rejection as a 422 makes the
-    # contract honest in the OpenAPI schema.
-    metadata: dict[str, str | int | float | bool] | None = Field(
+    # OpenInference ``metadata.<key>`` alias on Phoenix targets).  The
+    # field is annotated ``dict[str, Any]`` rather than a primitive
+    # union so a malformed payload produces one actionable 422 message
+    # from ``validate_metadata_shape`` instead of N parallel union-arm
+    # errors (one per primitive type Pydantic tries) per offending key.
+    metadata: dict[str, Any] | None = Field(
         None,
         description=(
             "Request metadata propagated to OTEL trace attributes "
@@ -100,23 +101,29 @@ class RunCreate(BaseModel):
     @classmethod
     def validate_metadata_shape(
         cls,
-        v: dict[str, str | int | float | bool] | None,
-    ) -> dict[str, str | int | float | bool] | None:
-        """Enforce key shape, key count, and string-value length.
+        metadata: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """Enforce key shape, key count, value type, and string-value length.
 
-        Pydantic's type annotation already rejects non-primitive values;
-        this validator covers the bounds the type system can't express.
+        Validation runs entirely here (rather than relying on a primitive
+        union on the field type) so each violation produces one clear
+        error message instead of N parallel union-arm errors per offending
+        key — easier for clients to surface to humans.
         """
-        if v is None:
+        if metadata is None:
             return None
-        if len(v) > _METADATA_MAX_KEYS:
-            raise ValueError(f"metadata exceeds {_METADATA_MAX_KEYS} keys (got {len(v)})")
-        for key, value in v.items():
+        if len(metadata) > _METADATA_MAX_KEYS:
+            raise ValueError(f"metadata exceeds {_METADATA_MAX_KEYS} keys (got {len(metadata)})")
+        for key, value in metadata.items():
             if not _METADATA_KEY_RE.match(key):
                 raise ValueError(f"metadata key {key!r} must match {_METADATA_KEY_RE.pattern}")
+            if not isinstance(value, (str, int, float, bool)):
+                raise ValueError(
+                    f"metadata value for key {key!r} must be str/int/float/bool, got {type(value).__name__}"
+                )
             if isinstance(value, str) and len(value) > _METADATA_MAX_VALUE_LEN:
                 raise ValueError(f"metadata value for key {key!r} exceeds {_METADATA_MAX_VALUE_LEN} characters")
-        return v
+        return metadata
 
     @model_validator(mode="after")
     def validate_input_command_exclusivity(self) -> Self:

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -1,5 +1,6 @@
 """Run-related Pydantic models for Agent Protocol"""
 
+import re
 from datetime import datetime
 from typing import Any, Literal, Self
 
@@ -12,6 +13,18 @@ from pydantic import (
 )
 
 from aegra_api.utils.status_compat import validate_run_status
+
+# Constraints for ``RunCreate.metadata`` keys/values, enforced at request
+# time so the OpenAPI schema is honest about what reaches OTEL.  Without
+# these limits a tenant could submit thousands of keys, megabyte-scale
+# values, or nested structures — all of which would either be silently
+# dropped by ``merge_run_metadata`` or balloon span size past the OTEL
+# collector limits.  Bounds chosen to be generous for legitimate use
+# (tenant id, feature flag, environment, sub-agent type, ...) while
+# closing the DoS surface.
+_METADATA_KEY_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_METADATA_MAX_KEYS = 32
+_METADATA_MAX_VALUE_LEN = 512
 
 
 class RunCreate(BaseModel):
@@ -64,11 +77,46 @@ class RunCreate(BaseModel):
         description="Whether to include subgraph events in streaming. When True, includes events from all subgraphs. When False (default when None), excludes subgraph events. Defaults to False for backwards compatibility.",
     )
 
-    # Request metadata (top-level in payload)
-    metadata: dict[str, Any] | None = Field(
+    # Request metadata (top-level in payload).  Reaches OTEL trace
+    # attributes as ``langfuse.trace.metadata.<key>`` (and the
+    # OpenInference ``metadata.<key>`` alias on Phoenix targets).  Values
+    # are restricted to OTEL-attribute primitives because the SDK silently
+    # drops nested values; surfacing the rejection as a 422 makes the
+    # contract honest in the OpenAPI schema.
+    metadata: dict[str, str | int | float | bool] | None = Field(
         None,
-        description="Request metadata (e.g., from_studio flag)",
+        description=(
+            "Request metadata propagated to OTEL trace attributes "
+            "(``langfuse.trace.metadata.<key>``).  Keys must match "
+            "``[A-Za-z0-9_-]{1,64}``.  Values must be primitive "
+            "(``str``, ``int``, ``float``, ``bool``); string values are "
+            "capped at 512 characters.  Maximum 32 keys.  Use this for "
+            "filterable attributes (tenant, feature flag, environment, "
+            "sub-agent type) rather than payload data."
+        ),
     )
+
+    @field_validator("metadata", mode="after")
+    @classmethod
+    def validate_metadata_shape(
+        cls,
+        v: dict[str, str | int | float | bool] | None,
+    ) -> dict[str, str | int | float | bool] | None:
+        """Enforce key shape, key count, and string-value length.
+
+        Pydantic's type annotation already rejects non-primitive values;
+        this validator covers the bounds the type system can't express.
+        """
+        if v is None:
+            return None
+        if len(v) > _METADATA_MAX_KEYS:
+            raise ValueError(f"metadata exceeds {_METADATA_MAX_KEYS} keys (got {len(v)})")
+        for key, value in v.items():
+            if not _METADATA_KEY_RE.match(key):
+                raise ValueError(f"metadata key {key!r} must match {_METADATA_KEY_RE.pattern}")
+            if isinstance(value, str) and len(value) > _METADATA_MAX_VALUE_LEN:
+                raise ValueError(f"metadata value for key {key!r} exceeds {_METADATA_MAX_VALUE_LEN} characters")
+        return v
 
     @model_validator(mode="after")
     def validate_input_command_exclusivity(self) -> Self:

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -22,6 +22,7 @@ Usage::
 
 import contextvars
 import logging
+from typing import Any
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
@@ -31,7 +32,20 @@ logger = logging.getLogger(__name__)
 # Metadata keys reserved for runtime state; user-supplied values for
 # these keys are dropped (system value wins) so they remain reliable
 # join keys between logs, spans, and the runs table.
-_RESERVED_METADATA_KEYS = frozenset({"run_id", "thread_id", "graph_id", "original_request_id"})
+#
+# ``original_request_id`` is intentionally not reserved: only the worker
+# path injects it (when an HTTP correlation-id is present), and it is
+# absent on the local-executor path. Reserving it would make
+# ``merge_run_metadata`` drop a user-supplied value with a misleading
+# "overridden by system value" warning whenever the system value is
+# missing — a silent data loss with no guarantee benefit.
+_RESERVED_METADATA_KEYS = frozenset({"run_id", "thread_id", "graph_id"})
+
+# OTEL span attributes only accept primitive scalar types. The
+# observability SDK silently drops any other value at attribute-set
+# time, so we filter at this layer and emit an aegra-level warning
+# instead of letting drops happen invisibly inside the SDK.
+_PRIMITIVE_ATTR_TYPES: tuple[type, ...] = (str, int, float, bool)
 
 # Per-request context variable holding span attributes to inject.
 # None means no trace context is set; on_start() is a no-op in that case.
@@ -127,16 +141,22 @@ def set_trace_context(
 
 
 def merge_run_metadata(
-    extra_metadata: dict[str, str | int | float | bool] | None,
+    extra_metadata: dict[str, Any] | None,
     system_metadata: dict[str, str | int | float | bool],
 ) -> dict[str, str | int | float | bool]:
     """Merge user-supplied metadata with system-injected runtime keys.
 
-    The reserved keys (``run_id``, ``thread_id``, ``graph_id``,
-    ``original_request_id``) are runtime invariants and join keys between
-    logs, spans, and the runs table.  When a user-supplied key collides
-    with a reserved key, the system value wins and a warning is logged so
-    the override is visible during debugging without breaking the request.
+    The reserved keys (``run_id``, ``thread_id``, ``graph_id``) are
+    runtime invariants and join keys between logs, spans, and the runs
+    table. When a user-supplied key collides with a reserved key, the
+    system value wins and a warning is logged so the override is visible
+    during debugging without breaking the request.
+
+    Non-primitive values (anything other than ``str``, ``int``, ``float``,
+    ``bool``) are dropped with a warning. OTEL span attributes accept
+    only primitives; passing a nested dict or list to ``span.set_attribute``
+    is a silent no-op at the SDK level. Filtering here surfaces the drop
+    with the offending key so callers can fix the payload upstream.
     """
     if not extra_metadata:
         return dict(system_metadata)
@@ -147,6 +167,14 @@ def merge_run_metadata(
                 "User metadata key '%s' overridden by system value; reserved keys: %s",
                 key,
                 sorted(_RESERVED_METADATA_KEYS),
+            )
+            continue
+        if not isinstance(value, _PRIMITIVE_ATTR_TYPES):
+            logger.warning(
+                "User metadata key '%s' has non-primitive type %s; dropping "
+                "(OTEL attributes accept str/int/float/bool only)",
+                key,
+                type(value).__name__,
             )
             continue
         merged[key] = value
@@ -160,7 +188,7 @@ def make_run_trace_context(
     graph_id: str,
     user_identity: str | None,
     *,
-    extra_metadata: dict[str, str | int | float | bool] | None = None,
+    extra_metadata: dict[str, Any] | None = None,
 ) -> contextvars.Context:
     """Return an isolated context copy with OTEL trace attributes pre-set for a run.
 

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -21,9 +21,17 @@ Usage::
 """
 
 import contextvars
+import logging
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+
+logger = logging.getLogger(__name__)
+
+# Metadata keys reserved for runtime state; user-supplied values for
+# these keys are dropped (system value wins) so they remain reliable
+# join keys between logs, spans, and the runs table.
+_RESERVED_METADATA_KEYS = frozenset({"run_id", "thread_id", "graph_id", "original_request_id"})
 
 # Per-request context variable holding span attributes to inject.
 # None means no trace context is set; on_start() is a no-op in that case.
@@ -118,24 +126,64 @@ def set_trace_context(
     _trace_attrs.set(attrs or None)
 
 
+def merge_run_metadata(
+    extra_metadata: dict[str, str | int | float | bool] | None,
+    system_metadata: dict[str, str | int | float | bool],
+) -> dict[str, str | int | float | bool]:
+    """Merge user-supplied metadata with system-injected runtime keys.
+
+    The reserved keys (``run_id``, ``thread_id``, ``graph_id``,
+    ``original_request_id``) are runtime invariants and join keys between
+    logs, spans, and the runs table.  When a user-supplied key collides
+    with a reserved key, the system value wins and a warning is logged so
+    the override is visible during debugging without breaking the request.
+    """
+    if not extra_metadata:
+        return dict(system_metadata)
+    merged: dict[str, str | int | float | bool] = {}
+    for key, value in extra_metadata.items():
+        if key in _RESERVED_METADATA_KEYS:
+            logger.warning(
+                "User metadata key '%s' overridden by system value; reserved keys: %s",
+                key,
+                sorted(_RESERVED_METADATA_KEYS),
+            )
+            continue
+        merged[key] = value
+    merged.update(system_metadata)
+    return merged
+
+
 def make_run_trace_context(
     run_id: str,
     thread_id: str,
     graph_id: str,
     user_identity: str | None,
+    *,
+    extra_metadata: dict[str, str | int | float | bool] | None = None,
 ) -> contextvars.Context:
     """Return an isolated context copy with OTEL trace attributes pre-set for a run.
 
     Creates a copy of the current context and populates it with per-request
     span attributes.  Pass the returned context to ``asyncio.create_task(...,
     context=ctx)`` so the background task starts with the correct trace data.
+
+    User-supplied ``extra_metadata`` is merged with the system runtime keys
+    (``run_id``, ``thread_id``, ``graph_id``).  System keys win on collision —
+    see :func:`merge_run_metadata`.
     """
+    system_metadata: dict[str, str | int | float | bool] = {
+        "run_id": run_id,
+        "thread_id": thread_id,
+        "graph_id": graph_id,
+    }
+    metadata = merge_run_metadata(extra_metadata, system_metadata)
     ctx = contextvars.copy_context()
     ctx.run(
         set_trace_context,
         user_id=user_identity,
         session_id=thread_id,
         trace_name=graph_id,
-        metadata={"run_id": run_id, "thread_id": thread_id, "graph_id": graph_id},
+        metadata=metadata,
     )
     return ctx

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -29,18 +29,6 @@ from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 
 logger = logging.getLogger(__name__)
 
-# Metadata keys reserved for runtime state; user-supplied values for
-# these keys are dropped (system value wins) so they remain reliable
-# join keys between logs, spans, and the runs table.
-#
-# ``original_request_id`` is intentionally not reserved: only the worker
-# path injects it (when an HTTP correlation-id is present), and it is
-# absent on the local-executor path. Reserving it would make
-# ``merge_run_metadata`` drop a user-supplied value with a misleading
-# "overridden by system value" warning whenever the system value is
-# missing — a silent data loss with no guarantee benefit.
-_RESERVED_METADATA_KEYS = frozenset({"run_id", "thread_id", "graph_id"})
-
 # OTEL span attributes only accept primitive scalar types. The
 # observability SDK silently drops any other value at attribute-set
 # time, so we filter at this layer and emit an aegra-level warning
@@ -146,18 +134,13 @@ def merge_run_metadata(
 ) -> dict[str, str | int | float | bool]:
     """Merge user-supplied metadata with system-injected runtime keys.
 
-    The reserved keys (``run_id``, ``thread_id``, ``graph_id``) are
-    runtime invariants and join keys between logs, spans, and the runs
-    table. When a user-supplied key collides with a reserved key, the
-    system value wins and a warning is logged so the override is visible
-    during debugging without breaking the request.
-
-    Non-reserved system keys (e.g., ``original_request_id`` injected by
-    the worker path when an HTTP correlation-id is present) also win on
-    collision; a warning is emitted there too so user-metadata loss is
-    never silent. The contract is uniform: any key already in
-    ``system_metadata`` is overridden, regardless of whether it is
-    reserved or only conditionally injected.
+    Any key already present in ``system_metadata`` (currently
+    ``run_id``, ``thread_id``, ``graph_id``, and ``original_request_id``
+    on the worker path) wins on collision: the system value is kept and
+    a warning is logged so the override is visible during debugging
+    without breaking the request. ``system_metadata`` is the single
+    source of truth for "what the runtime owns" — there is no separate
+    reserved-key registry to drift out of sync with caller behavior.
 
     Non-primitive values (anything other than ``str``, ``int``, ``float``,
     ``bool``) are dropped with a warning. OTEL span attributes accept
@@ -169,13 +152,6 @@ def merge_run_metadata(
         return dict(system_metadata)
     merged: dict[str, str | int | float | bool] = {}
     for key, value in extra_metadata.items():
-        if key in _RESERVED_METADATA_KEYS:
-            logger.warning(
-                "User metadata key '%s' overridden by system value; reserved keys: %s",
-                key,
-                sorted(_RESERVED_METADATA_KEYS),
-            )
-            continue
         if key in system_metadata:
             logger.warning(
                 "User metadata key '%s' overridden by system value",

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -152,6 +152,13 @@ def merge_run_metadata(
     system value wins and a warning is logged so the override is visible
     during debugging without breaking the request.
 
+    Non-reserved system keys (e.g., ``original_request_id`` injected by
+    the worker path when an HTTP correlation-id is present) also win on
+    collision; a warning is emitted there too so user-metadata loss is
+    never silent. The contract is uniform: any key already in
+    ``system_metadata`` is overridden, regardless of whether it is
+    reserved or only conditionally injected.
+
     Non-primitive values (anything other than ``str``, ``int``, ``float``,
     ``bool``) are dropped with a warning. OTEL span attributes accept
     only primitives; passing a nested dict or list to ``span.set_attribute``
@@ -167,6 +174,12 @@ def merge_run_metadata(
                 "User metadata key '%s' overridden by system value; reserved keys: %s",
                 key,
                 sorted(_RESERVED_METADATA_KEYS),
+            )
+            continue
+        if key in system_metadata:
+            logger.warning(
+                "User metadata key '%s' overridden by system value",
+                key,
             )
             continue
         if not isinstance(value, _PRIMITIVE_ATTR_TYPES):

--- a/libs/aegra-api/src/aegra_api/services/local_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/local_executor.py
@@ -30,6 +30,7 @@ class LocalExecutor(BaseExecutor):
             job.identity.thread_id,
             job.identity.graph_id,
             job.user.identity,
+            extra_metadata=job.run_metadata,
         )
         task = asyncio.create_task(execute_run(job), context=trace_ctx)
         active_runs[job.identity.run_id] = task

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -237,6 +237,7 @@ async def _prepare_run(
             multitask_strategy=request.multitask_strategy,
             subgraphs=request.stream_subgraphs or False,
         ),
+        run_metadata=request.metadata or {},
     )
 
     # Persist run record with trace metadata for worker observability.

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -26,7 +26,7 @@ from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import _get_session_maker
 from aegra_api.core.redis_manager import redis_manager
 from aegra_api.models.run_job import RunJob
-from aegra_api.observability.span_enrichment import set_trace_context
+from aegra_api.observability.span_enrichment import merge_run_metadata, set_trace_context
 from aegra_api.services.base_executor import BaseExecutor
 from aegra_api.services.run_executor import _lease_loss_cancellations, execute_run
 from aegra_api.services.run_status import finalize_run, update_run_status
@@ -466,7 +466,9 @@ def _restore_trace_context(run_id: str, job: RunJob, trace: dict[str, str]) -> N
     """Restore OTEL and structlog trace context for a worker-executed run.
 
     Clears previous context first to prevent bleed between concurrent
-    jobs processed by the same worker.
+    jobs processed by the same worker.  User-supplied ``run_metadata`` is
+    merged with the system runtime keys; system keys win on collision —
+    see :func:`merge_run_metadata`.
     """
     structlog.contextvars.clear_contextvars()
 
@@ -474,16 +476,17 @@ def _restore_trace_context(run_id: str, job: RunJob, trace: dict[str, str]) -> N
     if original_request_id:
         correlation_id.set(original_request_id)
 
+    system_metadata: dict[str, str | int | float | bool] = {
+        "run_id": run_id,
+        "thread_id": job.identity.thread_id,
+        "graph_id": job.identity.graph_id,
+        "original_request_id": original_request_id,
+    }
     set_trace_context(
         user_id=job.user.identity,
         session_id=job.identity.thread_id,
         trace_name=job.identity.graph_id,
-        metadata={
-            "run_id": run_id,
-            "thread_id": job.identity.thread_id,
-            "graph_id": job.identity.graph_id,
-            "original_request_id": original_request_id,
-        },
+        metadata=merge_run_metadata(job.run_metadata, system_metadata),
     )
 
     structlog.contextvars.bind_contextvars(

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -480,8 +480,13 @@ def _restore_trace_context(run_id: str, job: RunJob, trace: dict[str, str]) -> N
         "run_id": run_id,
         "thread_id": job.identity.thread_id,
         "graph_id": job.identity.graph_id,
-        "original_request_id": original_request_id,
     }
+    # Gate on non-empty: requests without an upstream correlation-id header
+    # leave ``original_request_id`` as ``""`` — including the empty string
+    # would emit a noisy ``langfuse.trace.metadata.original_request_id=""``
+    # attribute on every such trace.
+    if original_request_id:
+        system_metadata["original_request_id"] = original_request_id
     set_trace_context(
         user_id=job.user.identity,
         session_id=job.identity.thread_id,

--- a/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
@@ -53,6 +53,7 @@ def _make_request() -> MagicMock:
     request.interrupt_after = None
     request.multitask_strategy = None
     request.stream_subgraphs = False
+    request.metadata = None
     return request
 
 

--- a/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
@@ -1,6 +1,7 @@
 """Tests for RunCreate model validation."""
 
 import pytest
+from pydantic import ValidationError
 
 from aegra_api.models.runs import RunCreate
 
@@ -29,3 +30,84 @@ class TestRunCreateValidation:
         """Ensure payloads with no input, command, or checkpoint are rejected."""
         with pytest.raises(ValueError, match="Must specify at least one of 'input', 'command', or 'checkpoint'"):
             RunCreate(assistant_id="agent")
+
+
+class TestRunCreateMetadataValidation:
+    """Tests for ``RunCreate.metadata`` shape enforcement.
+
+    The schema constrains user-supplied metadata to OTEL-attribute
+    primitives at request time so the contract is honest in the OpenAPI
+    schema.  Previously ``dict[str, Any]`` accepted nested values that
+    were silently dropped downstream by ``merge_run_metadata``; surfacing
+    the rejection as a 422 means clients can fix the payload upstream
+    rather than wonder why their metadata never reaches Langfuse.
+    """
+
+    def _payload(self, **overrides):
+        base = {"assistant_id": "agent", "input": {"x": 1}}
+        base.update(overrides)
+        return base
+
+    def test_none_metadata_accepted(self):
+        run_create = RunCreate(**self._payload(metadata=None))
+        assert run_create.metadata is None
+
+    def test_empty_dict_metadata_accepted(self):
+        run_create = RunCreate(**self._payload(metadata={}))
+        assert run_create.metadata == {}
+
+    def test_all_primitive_types_accepted(self):
+        run_create = RunCreate(**self._payload(metadata={"tenant": "acme", "retries": 3, "ratio": 0.5, "flag": True}))
+        assert run_create.metadata == {
+            "tenant": "acme",
+            "retries": 3,
+            "ratio": 0.5,
+            "flag": True,
+        }
+
+    def test_nested_dict_value_rejected(self):
+        with pytest.raises(ValidationError):
+            RunCreate(**self._payload(metadata={"k": {"nested": 1}}))
+
+    def test_list_value_rejected(self):
+        with pytest.raises(ValidationError):
+            RunCreate(**self._payload(metadata={"k": [1, 2, 3]}))
+
+    def test_too_many_keys_rejected(self):
+        with pytest.raises(ValidationError, match="exceeds 32 keys"):
+            RunCreate(**self._payload(metadata={f"k{i}": i for i in range(33)}))
+
+    def test_dotted_key_rejected(self):
+        """Reject keys containing ``.`` so users cannot land bare attributes
+        like ``langfuse.user.id`` next to the system ones via the
+        ``langfuse.trace.metadata.<key>`` channel."""
+        with pytest.raises(ValidationError, match="must match"):
+            RunCreate(**self._payload(metadata={"langfuse.user.id": "spoof"}))
+
+    def test_empty_key_rejected(self):
+        with pytest.raises(ValidationError, match="must match"):
+            RunCreate(**self._payload(metadata={"": "v"}))
+
+    def test_too_long_key_rejected(self):
+        with pytest.raises(ValidationError, match="must match"):
+            RunCreate(**self._payload(metadata={"k" * 65: "v"}))
+
+    def test_non_ascii_key_rejected(self):
+        """Reject non-ASCII keys to prevent visual-spoof of join keys
+        (e.g. ``run_id`` vs ``run_id​`` zero-width-space variant)."""
+        with pytest.raises(ValidationError, match="must match"):
+            RunCreate(**self._payload(metadata={"run_id​": "v"}))
+
+    def test_too_long_string_value_rejected(self):
+        with pytest.raises(ValidationError, match="exceeds 512 characters"):
+            RunCreate(**self._payload(metadata={"k": "v" * 513}))
+
+    def test_max_keys_exactly_32_accepted(self):
+        """Boundary: exactly 32 keys is allowed."""
+        run_create = RunCreate(**self._payload(metadata={f"k{i}": i for i in range(32)}))
+        assert len(run_create.metadata) == 32
+
+    def test_max_value_length_exactly_512_accepted(self):
+        """Boundary: exactly 512 chars is allowed."""
+        run_create = RunCreate(**self._payload(metadata={"k": "v" * 512}))
+        assert len(run_create.metadata["k"]) == 512

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -1,6 +1,7 @@
 """Unit tests for SpanEnrichmentProcessor and set_trace_context."""
 
 import asyncio
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -289,17 +290,16 @@ class TestMergeRunMetadata:
 
     def test_collision_emits_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         """A user-supplied reserved key triggers a warning log."""
-        import logging
-
         with caplog.at_level(logging.WARNING, logger="aegra_api.observability.span_enrichment"):
             merge_run_metadata({"thread_id": "spoofed"}, {"thread_id": "actual"})
 
         assert any("thread_id" in record.message for record in caplog.records)
 
     def test_no_warning_when_keys_do_not_collide(self, caplog: pytest.LogCaptureFixture) -> None:
-        import logging
-
+        """No warning of any kind is emitted when user keys do not hit reserved names."""
         with caplog.at_level(logging.WARNING, logger="aegra_api.observability.span_enrichment"):
             merge_run_metadata({"tenant": "acme"}, {"run_id": "r1"})
 
-        assert not any("overridden" in record.message for record in caplog.records)
+        # Stricter than a substring check: assert no WARNING-level record was
+        # emitted from the merge_run_metadata logger at all.
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -5,6 +5,11 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 
 from aegra_api.observability.span_enrichment import (
     SpanEnrichmentProcessor,
@@ -359,3 +364,143 @@ class TestMergeRunMetadata:
         assert result["i"] == 42
         assert result["f"] == 3.14
         assert result["b"] is True
+
+
+class TestSpanEnrichmentEndToEnd:
+    """End-to-end verification with the real OpenTelemetry SDK.
+
+    The other tests in this file mock the SDK to isolate behavior.  This
+    class wires up an actual ``TracerProvider`` with an
+    ``InMemorySpanExporter`` so the full chain
+    ``make_run_trace_context`` → context var →
+    ``SpanEnrichmentProcessor.on_start`` → root-span attributes is
+    exercised without mocks.
+
+    Without this coverage, a refactor that quietly broke any link in the
+    chain (e.g. a dropped ``extra_metadata`` kwarg, a wrongly-passed
+    ``contextvars.Context`` to ``asyncio.create_task``, an
+    ``on_start``-vs-``on_end`` ordering regression) would still pass
+    every other test in the file.
+    """
+
+    def setup_method(self) -> None:
+        _trace_attrs.set(None)
+        self.exporter = InMemorySpanExporter()
+        self.provider = TracerProvider()
+        # Order matters: enrichment must run BEFORE export so the
+        # exporter sees attributes set by ``on_start``.
+        self.provider.add_span_processor(SpanEnrichmentProcessor())
+        self.provider.add_span_processor(SimpleSpanProcessor(self.exporter))
+        self.tracer = self.provider.get_tracer(__name__)
+
+    def teardown_method(self) -> None:
+        self.provider.shutdown()
+        _trace_attrs.set(None)
+
+    def _emit_root_span(self, ctx) -> None:
+        """Open and close a root span inside the supplied context."""
+
+        def _create() -> None:
+            with self.tracer.start_as_current_span("test_root_span"):
+                pass
+
+        ctx.run(_create)
+
+    def test_user_metadata_reaches_root_span_attributes(self) -> None:
+        """Happy path: every layer of the propagation pipeline cooperates."""
+        ctx = make_run_trace_context(
+            run_id="run-1",
+            thread_id="thread-1",
+            graph_id="my_graph",
+            user_identity="user-1",
+            extra_metadata={"tenant": "acme", "retries": 3, "ratio": 0.5, "flag": True},
+        )
+
+        self._emit_root_span(ctx)
+
+        spans = self.exporter.get_finished_spans()
+        assert len(spans) == 1
+        attrs = dict(spans[0].attributes or {})
+
+        # Langfuse-native + Phoenix/OpenInference aliases for first-class fields.
+        assert attrs["langfuse.user.id"] == "user-1"
+        assert attrs["user.id"] == "user-1"
+        assert attrs["langfuse.session.id"] == "thread-1"
+        assert attrs["session.id"] == "thread-1"
+        assert attrs["langfuse.trace.name"] == "my_graph"
+
+        # System metadata is always present.
+        assert attrs["langfuse.trace.metadata.run_id"] == "run-1"
+        assert attrs["langfuse.trace.metadata.thread_id"] == "thread-1"
+        assert attrs["langfuse.trace.metadata.graph_id"] == "my_graph"
+
+        # User-supplied metadata flows through with primitive types preserved.
+        assert attrs["langfuse.trace.metadata.tenant"] == "acme"
+        assert attrs["langfuse.trace.metadata.retries"] == 3
+        assert attrs["langfuse.trace.metadata.ratio"] == 0.5
+        assert attrs["langfuse.trace.metadata.flag"] is True
+
+    def test_reserved_collision_system_value_wins_on_root_span(self) -> None:
+        """User attempt to overwrite a reserved key is dropped; non-collision
+        keys still flow through.  This is the contract surfaced via the
+        warning in ``merge_run_metadata`` — verified end-to-end here."""
+        ctx = make_run_trace_context(
+            run_id="actual-run",
+            thread_id="thread-1",
+            graph_id="my_graph",
+            user_identity="user-1",
+            extra_metadata={"run_id": "spoofed", "tenant": "acme"},
+        )
+
+        self._emit_root_span(ctx)
+
+        attrs = dict(self.exporter.get_finished_spans()[0].attributes or {})
+        assert attrs["langfuse.trace.metadata.run_id"] == "actual-run"
+        assert attrs["langfuse.trace.metadata.tenant"] == "acme"
+
+    def test_anonymous_user_with_no_extra_metadata(self) -> None:
+        """``user_identity=None`` + ``extra_metadata=None`` produces a span
+        with system metadata only and no user.id keys at all."""
+        ctx = make_run_trace_context(
+            run_id="r1",
+            thread_id="t1",
+            graph_id="g1",
+            user_identity=None,
+            extra_metadata=None,
+        )
+
+        self._emit_root_span(ctx)
+
+        attrs = dict(self.exporter.get_finished_spans()[0].attributes or {})
+        assert "langfuse.user.id" not in attrs
+        assert "user.id" not in attrs
+        assert attrs["langfuse.session.id"] == "t1"
+        assert attrs["langfuse.trace.name"] == "g1"
+        assert attrs["langfuse.trace.metadata.run_id"] == "r1"
+        # No leftover metadata keys from a previous run/test.
+        user_metadata_keys = [
+            k
+            for k in attrs
+            if k.startswith("langfuse.trace.metadata.") and k.split(".")[-1] not in {"run_id", "thread_id", "graph_id"}
+        ]
+        assert user_metadata_keys == []
+
+    def test_non_primitive_user_metadata_is_dropped_before_span(self) -> None:
+        """A nested value submitted in ``extra_metadata`` is filtered by
+        ``merge_run_metadata`` and never reaches the OTEL SDK — so the
+        span carries the surviving primitive keys but not the nested
+        value (which would otherwise be silently no-op'd inside
+        ``span.set_attribute``)."""
+        ctx = make_run_trace_context(
+            run_id="r1",
+            thread_id="t1",
+            graph_id="g1",
+            user_identity="u1",
+            extra_metadata={"tenant": "acme", "nested": {"x": 1}},
+        )
+
+        self._emit_root_span(ctx)
+
+        attrs = dict(self.exporter.get_finished_spans()[0].attributes or {})
+        assert attrs["langfuse.trace.metadata.tenant"] == "acme"
+        assert "langfuse.trace.metadata.nested" not in attrs

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -9,6 +9,7 @@ from aegra_api.observability.span_enrichment import (
     SpanEnrichmentProcessor,
     _trace_attrs,
     make_run_trace_context,
+    merge_run_metadata,
     set_trace_context,
 )
 
@@ -230,3 +231,75 @@ class TestMakeRunTraceContext:
         assert "langfuse.user.id" not in attrs
         assert "user.id" not in attrs
         assert attrs["langfuse.trace.name"] == "my_graph"
+
+    def test_extra_metadata_merged_into_trace_context(self) -> None:
+        """User-supplied extra_metadata appears alongside system runtime keys."""
+        ctx = make_run_trace_context(
+            "run-1",
+            "thread-1",
+            "my_graph",
+            "user-1",
+            extra_metadata={"tenant": "acme", "feature_flag": True},
+        )
+
+        attrs = ctx.run(_trace_attrs.get)
+        assert attrs["langfuse.trace.metadata.tenant"] == "acme"
+        assert attrs["langfuse.trace.metadata.feature_flag"] is True
+        # System keys preserved
+        assert attrs["langfuse.trace.metadata.run_id"] == "run-1"
+        assert attrs["langfuse.trace.metadata.thread_id"] == "thread-1"
+        assert attrs["langfuse.trace.metadata.graph_id"] == "my_graph"
+
+    def test_extra_metadata_cannot_override_system_keys(self) -> None:
+        """Reserved system keys win on collision; user value is dropped."""
+        ctx = make_run_trace_context(
+            "run-actual",
+            "thread-1",
+            "my_graph",
+            "user-1",
+            extra_metadata={"run_id": "run-spoofed", "tenant": "acme"},
+        )
+
+        attrs = ctx.run(_trace_attrs.get)
+        assert attrs["langfuse.trace.metadata.run_id"] == "run-actual"
+        assert attrs["langfuse.trace.metadata.tenant"] == "acme"
+
+
+class TestMergeRunMetadata:
+    """Tests for merge_run_metadata()."""
+
+    def test_returns_system_only_when_extra_is_none(self) -> None:
+        system = {"run_id": "r1", "thread_id": "t1"}
+        assert merge_run_metadata(None, system) == system
+
+    def test_returns_system_only_when_extra_is_empty(self) -> None:
+        system = {"run_id": "r1", "thread_id": "t1"}
+        assert merge_run_metadata({}, system) == system
+
+    def test_user_keys_added_when_no_collision(self) -> None:
+        system = {"run_id": "r1", "thread_id": "t1"}
+        result = merge_run_metadata({"tenant": "acme", "retries": 3}, system)
+        assert result == {"run_id": "r1", "thread_id": "t1", "tenant": "acme", "retries": 3}
+
+    def test_system_wins_on_collision(self) -> None:
+        system = {"run_id": "actual", "thread_id": "t1"}
+        result = merge_run_metadata({"run_id": "spoofed", "tenant": "acme"}, system)
+        assert result["run_id"] == "actual"
+        assert result["tenant"] == "acme"
+
+    def test_collision_emits_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A user-supplied reserved key triggers a warning log."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="aegra_api.observability.span_enrichment"):
+            merge_run_metadata({"thread_id": "spoofed"}, {"thread_id": "actual"})
+
+        assert any("thread_id" in record.message for record in caplog.records)
+
+    def test_no_warning_when_keys_do_not_collide(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="aegra_api.observability.span_enrichment"):
+            merge_run_metadata({"tenant": "acme"}, {"run_id": "r1"})
+
+        assert not any("overridden" in record.message for record in caplog.records)

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -303,3 +303,41 @@ class TestMergeRunMetadata:
         # Stricter than a substring check: assert no WARNING-level record was
         # emitted from the merge_run_metadata logger at all.
         assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_original_request_id_is_not_reserved(self) -> None:
+        """``original_request_id`` is set only on the worker path; the local-executor
+        path omits it. Reserving it would silently drop user values when the
+        system value is missing — confirm it flows through as a regular key."""
+        system = {"run_id": "r1", "thread_id": "t1", "graph_id": "g1"}
+        result = merge_run_metadata({"original_request_id": "user-corr-id"}, system)
+        assert result["original_request_id"] == "user-corr-id"
+
+    def test_non_primitive_value_is_dropped_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """OTEL span attributes accept only primitives; nested values are
+        dropped at this layer with an aegra-level warning so the loss is
+        visible (rather than swallowed inside the OTEL SDK)."""
+        system = {"run_id": "r1"}
+        with caplog.at_level(logging.WARNING, logger="aegra_api.observability.span_enrichment"):
+            result = merge_run_metadata(
+                {"tenant": "acme", "nested": {"x": 1}, "items": [1, 2, 3]},
+                system,
+            )
+
+        assert result["tenant"] == "acme"
+        assert "nested" not in result
+        assert "items" not in result
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("nested" in w.message for w in warnings)
+        assert any("items" in w.message for w in warnings)
+
+    def test_primitive_types_pass_through(self) -> None:
+        """str, int, float, bool all flow through unchanged."""
+        system: dict[str, str | int | float | bool] = {"run_id": "r1"}
+        result = merge_run_metadata(
+            {"s": "v", "i": 42, "f": 3.14, "b": True},
+            system,
+        )
+        assert result["s"] == "v"
+        assert result["i"] == 42
+        assert result["f"] == 3.14
+        assert result["b"] is True

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -304,13 +304,31 @@ class TestMergeRunMetadata:
         # emitted from the merge_run_metadata logger at all.
         assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
-    def test_original_request_id_is_not_reserved(self) -> None:
+    def test_original_request_id_passes_through_when_system_lacks_it(self) -> None:
         """``original_request_id`` is set only on the worker path; the local-executor
         path omits it. Reserving it would silently drop user values when the
         system value is missing — confirm it flows through as a regular key."""
         system = {"run_id": "r1", "thread_id": "t1", "graph_id": "g1"}
         result = merge_run_metadata({"original_request_id": "user-corr-id"}, system)
         assert result["original_request_id"] == "user-corr-id"
+
+    def test_non_reserved_system_collision_drops_user_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A user value that collides with a non-reserved system key is dropped
+        with a warning. Without this, the worker path silently overwrote
+        user-supplied ``original_request_id`` (and any other future system
+        injection) via ``merged.update(system_metadata)``."""
+        system = {
+            "run_id": "r1",
+            "thread_id": "t1",
+            "graph_id": "g1",
+            "original_request_id": "system-corr-id",
+        }
+        with caplog.at_level(logging.WARNING, logger="aegra_api.observability.span_enrichment"):
+            result = merge_run_metadata({"original_request_id": "user-corr-id"}, system)
+
+        assert result["original_request_id"] == "system-corr-id"
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("original_request_id" in w.message for w in warnings)
 
     def test_non_primitive_value_is_dropped_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         """OTEL span attributes accept only primitives; nested values are

--- a/libs/aegra-api/tests/unit/test_services/test_run_job.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_job.py
@@ -123,3 +123,51 @@ class TestRunJob:
         )
         assert job.execution.input_data is None
         assert job.behavior.subgraphs is False
+        assert job.run_metadata == {}
+
+    def test_run_metadata_roundtrip(self) -> None:
+        """run_metadata round-trips through to_execution_params / from_run_orm."""
+        job = RunJob(
+            identity=RunIdentity(run_id="r1", thread_id="t1", graph_id="g1"),
+            user=User(identity="u1"),
+            run_metadata={"tenant": "acme", "feature_flag": True, "retry_count": 2},
+        )
+        params = job.to_execution_params()
+        assert params["run_metadata"] == {"tenant": "acme", "feature_flag": True, "retry_count": 2}
+
+        class FakeORM:
+            run_id = "r1"
+            thread_id = "t1"
+            execution_params = params
+
+        restored = RunJob.from_run_orm(FakeORM())
+        assert restored.run_metadata == job.run_metadata
+
+    def test_from_run_orm_legacy_row_without_run_metadata(self) -> None:
+        """Rows persisted before run_metadata existed deserialize with an empty dict."""
+
+        class LegacyORM:
+            run_id = "r1"
+            thread_id = "t1"
+            execution_params = {
+                "graph_id": "g1",
+                "user": {"identity": "u1", "is_authenticated": True, "permissions": []},
+                "execution": {
+                    "input_data": {},
+                    "config": {},
+                    "context": {},
+                    "stream_mode": None,
+                    "checkpoint": None,
+                    "command": None,
+                },
+                "behavior": {
+                    "interrupt_before": None,
+                    "interrupt_after": None,
+                    "multitask_strategy": None,
+                    "subgraphs": False,
+                },
+                # No "run_metadata" key — pre-PR row.
+            }
+
+        restored = RunJob.from_run_orm(LegacyORM())
+        assert restored.run_metadata == {}

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -415,8 +415,9 @@ class TestRestoreTraceContext:
         assert metadata["run_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         assert metadata["tenant"] == "acme"
 
-    def test_empty_run_metadata_keeps_system_keys_only(self) -> None:
-        """A job without run_metadata produces the four system keys unchanged."""
+    def test_empty_run_metadata_with_correlation_id_keeps_four_system_keys(self) -> None:
+        """When a correlation-id is present, ``original_request_id`` is
+        included in the metadata alongside the three runtime keys."""
         job = _make_run_job()  # run_metadata defaults to {}
         trace = {"correlation_id": "req-abc"}
 
@@ -425,6 +426,19 @@ class TestRestoreTraceContext:
 
         metadata = mock_set_trace.call_args.kwargs["metadata"]
         assert set(metadata.keys()) == {"run_id", "thread_id", "graph_id", "original_request_id"}
+
+    def test_missing_correlation_id_omits_original_request_id(self) -> None:
+        """Requests without an upstream correlation-id header should not produce
+        a ``langfuse.trace.metadata.original_request_id=""`` empty attribute."""
+        job = _make_run_job()
+        trace: dict[str, str] = {}  # no correlation_id
+
+        with patch(f"{MODULE}.set_trace_context") as mock_set_trace:
+            _restore_trace_context("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", job, trace)
+
+        metadata = mock_set_trace.call_args.kwargs["metadata"]
+        assert "original_request_id" not in metadata
+        assert set(metadata.keys()) == {"run_id", "thread_id", "graph_id"}
 
 
 # ------------------------------------------------------------------

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -370,6 +370,62 @@ class TestRestoreTraceContext:
 
         assert call_order == ["clear", "set_trace", "bind"]
 
+    def test_user_metadata_merged_with_system_keys(self) -> None:
+        """job.run_metadata is merged into the trace context metadata."""
+        job = RunJob(
+            identity=RunIdentity(
+                run_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                thread_id="11111111-2222-3333-4444-555555555555",
+                graph_id="test-graph",
+            ),
+            user=User(identity="test-user"),
+            run_metadata={"tenant": "acme", "feature_flag": True},
+        )
+        trace = {"correlation_id": "req-abc"}
+
+        with patch(f"{MODULE}.set_trace_context") as mock_set_trace:
+            _restore_trace_context("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", job, trace)
+
+        metadata = mock_set_trace.call_args.kwargs["metadata"]
+        assert metadata["tenant"] == "acme"
+        assert metadata["feature_flag"] is True
+        # System keys still present
+        assert metadata["run_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert metadata["thread_id"] == "11111111-2222-3333-4444-555555555555"
+        assert metadata["graph_id"] == "test-graph"
+        assert metadata["original_request_id"] == "req-abc"
+
+    def test_user_metadata_cannot_override_system_keys(self) -> None:
+        """Reserved system keys win on collision; user spoof is dropped."""
+        job = RunJob(
+            identity=RunIdentity(
+                run_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                thread_id="11111111-2222-3333-4444-555555555555",
+                graph_id="test-graph",
+            ),
+            user=User(identity="test-user"),
+            run_metadata={"run_id": "spoofed", "tenant": "acme"},
+        )
+        trace = {"correlation_id": "req-abc"}
+
+        with patch(f"{MODULE}.set_trace_context") as mock_set_trace:
+            _restore_trace_context("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", job, trace)
+
+        metadata = mock_set_trace.call_args.kwargs["metadata"]
+        assert metadata["run_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        assert metadata["tenant"] == "acme"
+
+    def test_empty_run_metadata_keeps_system_keys_only(self) -> None:
+        """A job without run_metadata produces the four system keys unchanged."""
+        job = _make_run_job()  # run_metadata defaults to {}
+        trace = {"correlation_id": "req-abc"}
+
+        with patch(f"{MODULE}.set_trace_context") as mock_set_trace:
+            _restore_trace_context("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", job, trace)
+
+        metadata = mock_set_trace.call_args.kwargs["metadata"]
+        assert set(metadata.keys()) == {"run_id", "thread_id", "graph_id", "original_request_id"}
+
 
 # ------------------------------------------------------------------
 # WorkerExecutor.submit


### PR DESCRIPTION
We're running aegra as the runtime for an enterprise agent platform we're building, and we hit this while wiring up Langfuse for our staging traces. Aegra accepts `metadata` on `POST /threads/{id}/runs` — it's part of `RunCreate` and the LangGraph SDK ships it as a first-class parameter — but the value is silently dropped before any span is emitted. The OTEL trace context that ends up in Langfuse/Phoenix/Generic exporters carries only the four runtime keys aegra injects internally (`run_id`, `thread_id`, `graph_id`, `original_request_id`) and nothing the caller asked to attach. From the observability side this makes filtering and correlation impossible without rewriting metadata server-side, which defeats the point of the field.

The data is lost in five places along the way. `RunCreate.metadata` reaches the API, but `_prepare_run` in `services/run_preparation.py` never reads it, so it doesn't make it into the `RunJob`. `RunJob` itself has no field for it, so even if `_prepare_run` did read the value there'd be nowhere to put it. The serialized `execution_params` JSONB column doesn't store it. The worker's `_restore_trace_context` builds a hardcoded four-key dict for `set_trace_context`. The local executor's `make_run_trace_context` does the same. Each step is small on its own; together they make the field non-functional.

This PR threads user metadata through the whole pipeline. We add a `run_metadata: dict[str, Any]` field on `RunJob` with a default of `{}` (backward compatible — old serialized rows missing the key deserialize fine). `_prepare_run` now reads `request.metadata or {}` and passes it to `RunJob`. `to_execution_params` and `from_run_orm` round-trip the field through JSONB. `make_run_trace_context` accepts an optional `extra_metadata` argument and merges it into the trace metadata dict. `_restore_trace_context` does the equivalent merge on the worker path.

When a user-supplied key collides with one of the four reserved system keys, we let the system value win and log a warning. The reasoning is that `run_id` and friends are runtime invariants — they are the join keys between logs, spans, and the `runs` table, and a caller spoofing them would silently break correlation across the platform. The warning gives the user a clear debug signal without breaking the request. We considered three alternatives (user wins, namespace separation under `aegra.*`, hard reject with 422); system-wins is the smallest viable change and the most reversible if community feedback prefers something else.

We kept the implementation vendor-neutral. `set_trace_context` already emits `langfuse.trace.metadata.<key>` for each metadata entry, and we preserved that pattern untouched, so Langfuse traces continue to expose metadata as queryable trace-level fields. Phoenix and Generic OTLP exporters surface the same attributes through standard span attribute mechanics. No Langfuse-specific imports leak into core code.

One note on values: `RunCreate.metadata` is typed `dict[str, Any]` (matching the LangGraph SDK), but OTEL span attributes only accept primitives (`str`, `int`, `float`, `bool`) and sequences of primitives. Non-primitive values (nested dicts, custom objects) reach `span.set_attribute` and are dropped with an OTEL warning rather than serialized. We considered validating at the `RunCreate` boundary but kept the SDK-aligned permissive type to avoid divergence; users pre-flatten or stringify complex values if they want them in trace metadata.

Tags are out of scope for this PR. The LangGraph SDK doesn't ship a `tags` parameter on `runs.create`, so adding one here would diverge from upstream contract. Users who need tag-like filtering can put a list under `metadata={"tags": [...]}` and Langfuse will surface it as `langfuse.trace.metadata.tags`. We can follow up with first-class tags if there's demand.

### Type of change

- [x] `feat`: new feature
- [ ] `fix`: bug fix (could also be argued — the field is documented but non-functional)

### Related issues

None open at the time of writing.

### Changes made

- `models/run_job.py`: added `run_metadata: dict[str, Any] = Field(default_factory=dict)` to `RunJob`. Updated `to_execution_params()` and `from_run_orm()` to round-trip the field with safe defaults
- `services/run_preparation.py`: `_prepare_run` now reads `request.metadata or {}` and passes it to `RunJob`
- `services/worker_executor.py`: `_restore_trace_context` merges `job.run_metadata` with the four system keys; system keys take precedence, collisions emit a `WARN` log
- `services/local_executor.py`: `submit` passes `job.run_metadata` to `make_run_trace_context`
- `observability/span_enrichment.py`: `make_run_trace_context` gains an optional `extra_metadata` parameter; system metadata still overrides on collision

### Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed — TBD before submission

Unit coverage:

- `tests/unit/test_models/test_run_job.py`: round-trip `run_metadata` through `to_execution_params` / `from_run_orm`, plus default-empty behavior for legacy rows
- `tests/unit/test_services/test_worker_executor.py`: `_restore_trace_context` merges user metadata, system keys override on collision, warning is logged
- `tests/unit/test_observability/test_span_enrichment.py`: `make_run_trace_context` includes `extra_metadata` and respects collision precedence
- `tests/unit/test_services/test_run_preparation.py` (extending existing if present, otherwise new): `RunCreate.metadata` flows into `RunJob.run_metadata`

### Validation in our staging environment

We're already running this fork against our staging Cloud Run deployment of aegra `0.9.6` (built from the wheel of this branch) and the change works end-to-end. We validated two paths.

**Happy path — propagation of legitimate user keys.** A real user query that dispatches a sub-agent emits two Langfuse traces, one for the main run and one for the worker run. The worker trace's `metadata` now contains the user-supplied keys we send from our orchestrator (`turn_id`, `subagent_type`, `workspace_id`, `job_id`, `parent_thread_id`) alongside the four reserved system keys (`run_id`, `thread_id`, `graph_id`, `original_request_id`). Phoenix aliases (`session.id` alongside `langfuse.session.id`) are emitted as expected, so the change is consumed correctly by both Langfuse and Phoenix-shaped exporters in our setup. In practice this lets us filter Langfuse traces by `metadata.turn_id` and reconstruct the full chain of a multi-agent turn (one main run + N worker dispatches) without joining against an external database — before this PR we maintained a SQL bridge for that.

**Anti-spoofing path — collision policy under attack.** Since our regular traffic doesn't reuse reserved key names, we ran a dedicated probe to exercise the merge policy directly. We POSTed a run with `metadata` containing the four reserved keys all set to obvious sentinel values (`SPOOFED-RUN-ID-AAAA`, `SPOOFED-THREAD-ID-BBBB`, `SPOOFED-GRAPH-CCCC`, `SPOOFED-CORR-DDDD`) plus two legitimate keys (`tenant`, `test_id`). On the resulting Langfuse trace, all four reserved fields hold the actual aegra runtime values (worker run UUID, real thread UUID, real graph name, real correlation_id) — none of the spoofed sentinels surface. The two legitimate keys pass through to `metadata.tenant` and `metadata.test_id` as expected. The worker logs emit the four corresponding `User metadata key 'X' overridden by system value` warnings from `merge_run_metadata`, one per reserved-key collision, confirming the policy fires audibly without breaking the request.

### Backward compatibility

The new `run_metadata` field defaults to `{}`. Rows persisted before this PR don't have the key in `execution_params`; `from_run_orm` falls back to `{}` so they deserialize without error. No migration is required because `execution_params` is JSONB.

### Vendor neutrality

We emit user metadata as `langfuse.trace.metadata.<key>` (existing convention). Phoenix and Generic OTLP exporters surface the same span attributes through standard OTEL mechanics — no exporter-specific code paths added.

### Additional notes

The four reserved keys (`run_id`, `thread_id`, `graph_id`, `original_request_id`) are runtime invariants and the join keys between logs, spans, and the `runs` table. Letting a caller override them would silently break correlation in any nontrivial setup, which is why the merge gives system precedence. The warning log makes the override visible to anyone debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runs accept optional custom run metadata preserved through serialization and reconstruction.
  * Run metadata is merged into trace contexts so user metadata appears alongside system runtime identifiers.
  * System-reserved keys win on collisions (user entries dropped with a warning); non-primitive user values are dropped with a warning.
  * original_request_id is included in metadata only when a correlation id is present.

* **Tests**
  * Added unit tests for metadata defaults, serialization, merging, collision handling, non-primitive dropping, and trace propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads user-supplied `RunCreate.metadata` through the full execution pipeline so it appears in OTEL trace spans alongside the four runtime system keys. The change touches five layers: API-boundary validation, `RunJob` serialization, JSONB persistence, and both the local-executor and worker-executor trace-context restore paths.

- **`RunCreate` validator** (`runs.py`): a new `validate_metadata_shape` field validator enforces key regex, a 32-key cap, primitive-only values, and 512-char string cap — returning a clean 422 for violating payloads rather than silently dropping values downstream.
- **`merge_run_metadata`** (`span_enrichment.py`): a new helper merges user metadata with `system_metadata`; system keys always win and emit a warning on collision. By using the live `system_metadata` dict as the collision authority rather than a separate reserved-key constant, the implementation avoids the drift issue noted in prior review threads — including the `original_request_id` local-executor behaviour, which is now correctly gated on whether the runtime actually supplies that key.
- **`RunJob`** (`run_job.py`) + **JSONB round-trip**: `run_metadata` defaults to `{}` so pre-PR rows deserialize without a migration.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all three concerns from previous review rounds are addressed and the implementation is internally consistent across both executor paths.

The propagation chain is complete and correctly wired end-to-end. The dynamic `system_metadata` approach eliminates the reserved-key drift concern from earlier threads. Validation at the `RunCreate` boundary ensures non-primitives and over-large payloads are rejected before they reach the OTEL layer. The only gap is a missing direct unit test for the `_prepare_run` → `RunJob.run_metadata` assignment, which the PR description committed to but omitted.

libs/aegra-api/src/aegra_api/services/run_preparation.py — the one-liner that starts the propagation chain has no dedicated test.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/models/runs.py | Adds `validate_metadata_shape` field_validator to `RunCreate.metadata`, enforcing key regex, key count limit, primitive value types, and string length — all consistently matching the documented constraints in observability.mdx. |
| libs/aegra-api/src/aegra_api/observability/span_enrichment.py | Introduces `merge_run_metadata` helper and updates `make_run_trace_context` to accept `extra_metadata`; uses a dynamic `system_metadata` dict as the collision authority, resolving the previous `_RESERVED_METADATA_KEYS` drift concern. `original_request_id` is correctly absent from the local-executor `system_metadata`. |
| libs/aegra-api/src/aegra_api/models/run_job.py | Adds `run_metadata: dict[str, Any] = Field(default_factory=dict)` with round-trip support in `to_execution_params` and `from_run_orm`; the `or {}` fallback in `from_run_orm` correctly handles both missing keys (legacy rows) and JSONB null values. |
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Conditionally gates `original_request_id` in `system_metadata` on the worker path, so collision detection and warning fire correctly when a user supplies that key with a real correlation ID present. |
| libs/aegra-api/src/aegra_api/services/run_preparation.py | One-line change passes `request.metadata or {}` to `RunJob.run_metadata`; straightforward and correct, though no dedicated `test_run_preparation.py` test was added (mentioned in the PR description but absent from the changeset). |
| libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py | Adds unit tests for `merge_run_metadata` and two new `make_run_trace_context` tests; also includes a real-SDK end-to-end class (`TestSpanEnrichmentEndToEnd`) wiring up `TracerProvider`+`InMemorySpanExporter` to verify the full propagation chain without mocks. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as POST /threads/{id}/runs
    participant RC as RunCreate (Pydantic)
    participant PR as _prepare_run
    participant RJ as RunJob
    participant JSONB as execution_params (JSONB)
    participant LE as LocalExecutor.submit
    participant WE as _restore_trace_context
    participant MRM as merge_run_metadata
    participant SC as set_trace_context

    Client->>API: metadata: {tenant, flag, ...}
    API->>RC: validate_metadata_shape()
    Note over RC: key regex, count ≤32, primitives only, str ≤512
    RC-->>API: 422 if invalid
    API->>PR: RunCreate (validated)
    PR->>RJ: run_metadata = request.metadata or {}
    RJ->>JSONB: to_execution_params() stores run_metadata

    alt Local executor path
        RJ->>LE: job.run_metadata
        LE->>MRM: extra_metadata=job.run_metadata, system={run_id,thread_id,graph_id}
        MRM-->>LE: merged (system wins on collision)
        LE->>SC: metadata=merged → contextvars.Context
    else Worker executor path
        JSONB->>RJ: from_run_orm() → run_metadata
        RJ->>WE: job.run_metadata
        WE->>MRM: extra_metadata=job.run_metadata, system={run_id,thread_id,graph_id[,original_request_id]}
        MRM-->>WE: merged (system wins on collision)
        WE->>SC: metadata=merged
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Frun_preparation.py%3A240-241%0A**Missing%20test%20for%20%60_prepare_run%60%20metadata%20propagation**%0A%0AThe%20PR%20description%20explicitly%20lists%20%60tests%2Funit%2Ftest_services%2Ftest_run_preparation.py%60%20as%20a%20testing%20target%20%E2%80%94%20%22extending%20existing%20if%20present%2C%20otherwise%20new%22%20%E2%80%94%20to%20verify%20%60RunCreate.metadata%60%20flows%20into%20%60RunJob.run_metadata%60.%20That%20file%20is%20absent%20from%20the%20changeset.%20The%20%60test_runs_wait.py%60%20update%20only%20adds%20%60request.metadata%20%3D%20None%60%20to%20fix%20the%20existing%20mock%3B%20it%20doesn't%20assert%20that%20a%20non-%60None%60%20metadata%20dict%20reaches%20the%20%60RunJob%60.%20Because%20this%20one-liner%20sits%20at%20the%20head%20of%20the%20propagation%20chain%2C%20a%20future%20accidental%20regression%20here%20%28e.g.%20forgetting%20%60or%20%7B%7D%60%2C%20renaming%20the%20field%29%20would%20produce%20no%20span%20attributes%20in%20Langfuse%2FPhoenix%20with%20no%20failing%20tests.%0A%0A&repo=aegra%2Faegra&pr=335&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Frun_preparation.py%3A240-241%0A**Missing%20test%20for%20%60_prepare_run%60%20metadata%20propagation**%0A%0AThe%20PR%20description%20explicitly%20lists%20%60tests%2Funit%2Ftest_services%2Ftest_run_preparation.py%60%20as%20a%20testing%20target%20%E2%80%94%20%22extending%20existing%20if%20present%2C%20otherwise%20new%22%20%E2%80%94%20to%20verify%20%60RunCreate.metadata%60%20flows%20into%20%60RunJob.run_metadata%60.%20That%20file%20is%20absent%20from%20the%20changeset.%20The%20%60test_runs_wait.py%60%20update%20only%20adds%20%60request.metadata%20%3D%20None%60%20to%20fix%20the%20existing%20mock%3B%20it%20doesn't%20assert%20that%20a%20non-%60None%60%20metadata%20dict%20reaches%20the%20%60RunJob%60.%20Because%20this%20one-liner%20sits%20at%20the%20head%20of%20the%20propagation%20chain%2C%20a%20future%20accidental%20regression%20here%20%28e.g.%20forgetting%20%60or%20%7B%7D%60%2C%20renaming%20the%20field%29%20would%20produce%20no%20span%20attributes%20in%20Langfuse%2FPhoenix%20with%20no%20failing%20tests.%0A%0A&pr=335&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Frun-metadata-propagation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Frun-metadata-propagation%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Frun_preparation.py%3A240-241%0A**Missing%20test%20for%20%60_prepare_run%60%20metadata%20propagation**%0A%0AThe%20PR%20description%20explicitly%20lists%20%60tests%2Funit%2Ftest_services%2Ftest_run_preparation.py%60%20as%20a%20testing%20target%20%E2%80%94%20%22extending%20existing%20if%20present%2C%20otherwise%20new%22%20%E2%80%94%20to%20verify%20%60RunCreate.metadata%60%20flows%20into%20%60RunJob.run_metadata%60.%20That%20file%20is%20absent%20from%20the%20changeset.%20The%20%60test_runs_wait.py%60%20update%20only%20adds%20%60request.metadata%20%3D%20None%60%20to%20fix%20the%20existing%20mock%3B%20it%20doesn't%20assert%20that%20a%20non-%60None%60%20metadata%20dict%20reaches%20the%20%60RunJob%60.%20Because%20this%20one-liner%20sits%20at%20the%20head%20of%20the%20propagation%20chain%2C%20a%20future%20accidental%20regression%20here%20%28e.g.%20forgetting%20%60or%20%7B%7D%60%2C%20renaming%20the%20field%29%20would%20produce%20no%20span%20attributes%20in%20Langfuse%2FPhoenix%20with%20no%20failing%20tests.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (6): Last reviewed commit: ["fix(models): shorten run\_metadata commen..."](https://github.com/aegra/aegra/commit/9cac3b6c04be46e231e49b1c07075835f9124935) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30811794)</sub>

<!-- /greptile_comment -->