### PR TITLE
chore: bump version to 0.9.7 (security patch)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.6"
+    "version": "0.9.7"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.6"
+version = "0.9.7"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -51,9 +51,7 @@ async def create_run(
     endpoint to follow progress. Provide either `input` or `command` (for
     human-in-the-loop resumption) but not both.
     """
-    existing_thread = await session.scalar(
-        select(ThreadORM).where(ThreadORM.thread_id == thread_id)
-    )
+    existing_thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == thread_id))
     if existing_thread and existing_thread.user_id != user.identity:
         raise HTTPException(404, f"Thread '{thread_id}' not found")
 
@@ -99,9 +97,7 @@ async def create_and_stream_run(
     after the client disconnects (default is `"cancel"`). Use `stream_mode`
     to control which event types are emitted.
     """
-    existing_thread = await session.scalar(
-        select(ThreadORM).where(ThreadORM.thread_id == thread_id)
-    )
+    existing_thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == thread_id))
     if existing_thread and existing_thread.user_id != user.identity:
         raise HTTPException(404, f"Thread '{thread_id}' not found")
 
@@ -324,9 +320,7 @@ async def wait_for_run(
 
     # Session block: all pre-execution DB work (validate, create run, submit)
     async with maker() as session:
-        existing_thread = await session.scalar(
-            select(ThreadORM).where(ThreadORM.thread_id == thread_id)
-        )
+        existing_thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == thread_id))
         if existing_thread and existing_thread.user_id != user.identity:
             raise HTTPException(404, f"Thread '{thread_id}' not found")
 

--- a/libs/aegra-api/tests/e2e/manual_auth_tests/test_thread_user_isolation_e2e.py
+++ b/libs/aegra-api/tests/e2e/manual_auth_tests/test_thread_user_isolation_e2e.py
@@ -62,9 +62,7 @@ class TestThreadOwnership:
         elog("Alice created thread", {"thread_id": thread_id})
 
         bob_headers = get_auth_headers("bob")
-        async with httpx.AsyncClient(
-            base_url=get_server_url(), headers=bob_headers, timeout=30.0
-        ) as http:
+        async with httpx.AsyncClient(base_url=get_server_url(), headers=bob_headers, timeout=30.0) as http:
             resp = await http.get(f"/threads/{thread_id}")
 
         elog("Bob GET Alice's thread", {"status": resp.status_code})
@@ -91,9 +89,7 @@ class TestThreadSearch:
         elog("Seeded threads", {"alice": alice_thread["thread_id"], "bob": bob_thread["thread_id"]})
 
         alice_headers = get_auth_headers("alice")
-        async with httpx.AsyncClient(
-            base_url=get_server_url(), headers=alice_headers, timeout=30.0
-        ) as http:
+        async with httpx.AsyncClient(base_url=get_server_url(), headers=alice_headers, timeout=30.0) as http:
             resp = await http.post(
                 "/threads/search",
                 json={"metadata": {"isolation_tag": tag}, "limit": 100},
@@ -117,9 +113,7 @@ class TestThreadSearch:
         bob_thread = await bob_client.threads.create(metadata={"isolation_tag": tag})
 
         alice_headers = get_auth_headers("alice")
-        async with httpx.AsyncClient(
-            base_url=get_server_url(), headers=alice_headers, timeout=30.0
-        ) as http:
+        async with httpx.AsyncClient(base_url=get_server_url(), headers=alice_headers, timeout=30.0) as http:
             resp = await http.get("/threads", params={"limit": 1000})
         assert resp.status_code == 200, resp.text
 
@@ -144,9 +138,7 @@ class TestThreadMutationIsolation:
         thread_id = thread["thread_id"]
 
         bob_headers = get_auth_headers("bob")
-        async with httpx.AsyncClient(
-            base_url=get_server_url(), headers=bob_headers, timeout=30.0
-        ) as http:
+        async with httpx.AsyncClient(base_url=get_server_url(), headers=bob_headers, timeout=30.0) as http:
             resp = await http.patch(
                 f"/threads/{thread_id}",
                 json={"metadata": {"hijacked": True}},
@@ -164,9 +156,7 @@ class TestThreadMutationIsolation:
         thread_id = thread["thread_id"]
 
         bob_headers = get_auth_headers("bob")
-        async with httpx.AsyncClient(
-            base_url=get_server_url(), headers=bob_headers, timeout=30.0
-        ) as http:
+        async with httpx.AsyncClient(base_url=get_server_url(), headers=bob_headers, timeout=30.0) as http:
             resp = await http.delete(f"/threads/{thread_id}")
         elog("Bob DELETE Alice's thread", {"status": resp.status_code})
         assert resp.status_code == 404, (
@@ -185,9 +175,7 @@ class TestThreadMutationIsolation:
         thread_id = thread["thread_id"]
 
         bob_headers = get_auth_headers("bob")
-        async with httpx.AsyncClient(
-            base_url=get_server_url(), headers=bob_headers, timeout=30.0
-        ) as http:
+        async with httpx.AsyncClient(base_url=get_server_url(), headers=bob_headers, timeout=30.0) as http:
             resp = await http.post(
                 f"/threads/{thread_id}/runs",
                 json={"assistant_id": "agent", "input": {"messages": [{"role": "human", "content": "hi"}]}},
@@ -205,9 +193,7 @@ class TestThreadMutationIsolation:
         thread_id = thread["thread_id"]
 
         bob_headers = get_auth_headers("bob")
-        async with httpx.AsyncClient(
-            base_url=get_server_url(), headers=bob_headers, timeout=30.0
-        ) as http:
+        async with httpx.AsyncClient(base_url=get_server_url(), headers=bob_headers, timeout=30.0) as http:
             resp = await http.post(
                 f"/threads/{thread_id}/runs/stream",
                 json={"assistant_id": "agent", "input": {"messages": [{"role": "human", "content": "hi"}]}},
@@ -225,9 +211,7 @@ class TestThreadMutationIsolation:
         thread_id = thread["thread_id"]
 
         bob_headers = get_auth_headers("bob")
-        async with httpx.AsyncClient(
-            base_url=get_server_url(), headers=bob_headers, timeout=30.0
-        ) as http:
+        async with httpx.AsyncClient(base_url=get_server_url(), headers=bob_headers, timeout=30.0) as http:
             resp = await http.post(
                 f"/threads/{thread_id}/runs/wait",
                 json={"assistant_id": "agent", "input": {"messages": [{"role": "human", "content": "hi"}]}},

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.6"
+version = "0.9.7"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.6"
+version = "0.9.7"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -96,7 +96,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.6"
+version = "0.9.7"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary

- security patch release
- bump aegra-api + aegra-cli from 0.9.6 to 0.9.7
- ruff format the two files PR #337 left unformatted (so lint CI goes green)
- regenerate docs/openapi.json

## Changes since 0.9.6

- **fix(runs): enforce thread ownership before creating runs** (#337, fixes #336) — critical IDOR. Authenticated users could submit runs against another user's threads via `POST /threads/{thread_id}/runs`, `/runs/stream`, and `/runs/wait`, reading the victim's checkpoint state and injecting messages. Now blocked at SQL level with 404. Credit: @JoJoTheBizarre (report), @victorjmarin + @jawhardjebbi (fix).

## Action required for deployers

All deployments running 0.9.0 through 0.9.6 should upgrade. Affects any setup with multiple authenticated tenants on a shared aegra instance.

Will publish a GitHub Security Advisory after this lands so it appears on the repo's security tab and pushes a notification to anyone consuming aegra via Dependabot.

## Test plan

- [x] CI green (lint, test-api, test-cli)
- [x] Local: 1199 unit+integration tests pass on this branch
- [ ] Smoke test against running server post-merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.9.7 for aegra-api and aegra-cli packages with corresponding OpenAPI specification updates

* **Refactor**
  * Consolidated multi-line database query expressions into streamlined single-line equivalents for improved code readability without altering functionality

* **Tests**
  * Refactored HTTP client initialization in end-to-end authentication test suites to use simplified single-line patterns for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->