### PR TITLE
fix(auth): Add LRU cache to get_auth_backend function

### DIFF
--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -275,7 +275,7 @@ class LangGraphAuthBackend(AuthenticationBackend):
             logger.error(f"Unexpected error during authentication: {e}", exc_info=True)
             raise AuthenticationError("Authentication system error") from e
 
-
+@functools.lru_cache(maxsize=1)
 def get_auth_backend() -> AuthenticationBackend:
     """
     Get authentication backend based on AUTH_TYPE environment variable.

--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -275,6 +275,7 @@ class LangGraphAuthBackend(AuthenticationBackend):
             logger.error(f"Unexpected error during authentication: {e}", exc_info=True)
             raise AuthenticationError("Authentication system error") from e
 
+
 @functools.lru_cache(maxsize=1)
 def get_auth_backend() -> AuthenticationBackend:
     """


### PR DESCRIPTION
Previously, `get_auth_backend()` in `auth_middleware.py` returned a new  instance of `LangGraphAuthBackend` on every API request. This triggered  `_load_auth_instance()` repeatedly, causing unnecessary file I/O, degraded  performance, and significant log spam.

This commit introduces a caching mechanism (Singleton pattern) to ensure  the authentication backend is instantiated and loaded only once. Subsequent  requests will reuse the cached instance.

Close: #339

## Description
<!-- Provide a clear description of your changes -->

## Type of Change
<!-- Check the relevant option -->
- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->

## Changes Made
<!-- List the main changes -->
Previously, `get_auth_backend()` in `auth_middleware.py` returned a new 
instance of `LangGraphAuthBackend` on every API request. This triggered 
`_load_auth_instance()` repeatedly, causing unnecessary file I/O, degraded 
performance, and significant log spam.

This commit introduces a caching mechanism (Singleton pattern) to ensure 
the authentication backend is instantiated and loaded only once. Subsequent 
requests will reuse the cached instance.

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

## Checklist
<!-- Ensure all items are checked before requesting review -->
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [ ] Documentation updated (if needed)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] PR title follows Conventional Commits format

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Notes
<!-- Any additional information for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved authentication backend initialization performance — repeated initialization in the same process is now avoided, reducing overhead and improving responsiveness for authenticated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR caches the result of `get_auth_backend()` with `@functools.lru_cache(maxsize=1)` to prevent `LangGraphAuthBackend` from being re-instantiated (and `_load_auth_instance()` from re-running) on every request.

- The fix is incomplete: `get_auth_instance()` (lines 320–332) still constructs its own `LangGraphAuthBackend()` independently rather than delegating to `get_auth_backend()`, so two separate backend instances are created and `_load_auth_instance()` is still called twice per process lifetime. The `@lru_cache` on `get_auth_instance()` should be removed and the function should delegate to `get_auth_backend().auth_instance`.

<h3>Confidence Score: 4/5</h3>

Safe to merge but the original problem persists partially — _load_auth_instance() is still called twice per process due to get_auth_instance() creating its own separate backend.

One P1 finding: get_auth_instance() bypasses the new cache by constructing LangGraphAuthBackend directly, meaning file I/O and log spam from _load_auth_instance() is still triggered twice per process. The fix addresses only half of the issue. No security or data-integrity concerns.

libs/aegra-api/src/aegra_api/core/auth_middleware.py — specifically the get_auth_instance() function at line 320.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/auth_middleware.py | Adds @functools.lru_cache(maxsize=1) to get_auth_backend(), but get_auth_instance() still creates a separate LangGraphAuthBackend independently, so _load_auth_instance() is still invoked twice per process lifetime. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Request
    participant M as AuthMiddleware
    participant GAB as get_auth_backend() [lru_cache]
    participant GAI as get_auth_instance() [lru_cache]
    participant LB as LangGraphAuthBackend
    participant LI as _load_auth_instance()

    Note over GAB,GAI: Two separate cached paths — two LangGraphAuthBackend instances

    R->>M: HTTP Request
    M->>GAB: get_auth_backend()
    GAB->>LB: new LangGraphAuthBackend() (1st instance)
    LB->>LI: _load_auth_instance() call 1
    LI-->>LB: Auth or None
    LB-->>GAB: backend cached
    GAB-->>M: AuthenticationBackend

    Note over GAI: Called separately by other modules
    R->>GAI: get_auth_instance()
    GAI->>LB: new LangGraphAuthBackend() (2nd instance)
    LB->>LI: _load_auth_instance() call 2
    LI-->>LB: Auth or None
    LB-->>GAI: auth_instance cached

    Note over GAB,GAI: After fix: get_auth_instance() delegates to get_auth_backend() — single instance, single _load_auth_instance() call
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `libs/aegra-api/src/aegra_api/core/auth_middleware.py`, line 320-332 ([link](https://github.com/aegra/aegra/blob/3fd8d1772fa9e9ee532235b7da6700731b3d333f/libs/aegra-api/src/aegra_api/core/auth_middleware.py#L320-L332)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Redundant `LangGraphAuthBackend` instantiation**

   `get_auth_instance()` constructs its own `LangGraphAuthBackend()` directly instead of delegating to the newly-cached `get_auth_backend()`. Because both functions carry their own `@lru_cache`, two separate `LangGraphAuthBackend` instances are created per process, meaning `_load_auth_instance()` (with its file I/O and log output) is still invoked twice — once by each cached function on its first call. The fix should have `get_auth_instance()` call `get_auth_backend()` so that only one backend instance ever exists and `_load_auth_instance()` runs exactly once.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%0ALine%3A%20320-332%0A%0AComment%3A%0A**Redundant%20%60LangGraphAuthBackend%60%20instantiation**%0A%0A%60get_auth_instance%28%29%60%20constructs%20its%20own%20%60LangGraphAuthBackend%28%29%60%20directly%20instead%20of%20delegating%20to%20the%20newly-cached%20%60get_auth_backend%28%29%60.%20Because%20both%20functions%20carry%20their%20own%20%60%40lru_cache%60%2C%20two%20separate%20%60LangGraphAuthBackend%60%20instances%20are%20created%20per%20process%2C%20meaning%20%60_load_auth_instance%28%29%60%20%28with%20its%20file%20I%2FO%20and%20log%20output%29%20is%20still%20invoked%20twice%20%E2%80%94%20once%20by%20each%20cached%20function%20on%20its%20first%20call.%20The%20fix%20should%20have%20%60get_auth_instance%28%29%60%20call%20%60get_auth_backend%28%29%60%20so%20that%20only%20one%20backend%20instance%20ever%20exists%20and%20%60_load_auth_instance%28%29%60%20runs%20exactly%20once.%0A%0A%60%60%60suggestion%0Adef%20get_auth_instance%28%29%20-%3E%20Auth%20%7C%20None%3A%0A%20%20%20%20%22%22%22Get%20cached%20Auth%20instance%20for%20use%20by%20other%20modules.%0A%0A%20%20%20%20Delegates%20to%20get_auth_backend%28%29%20to%20reuse%20the%20single%20cached%0A%20%20%20%20LangGraphAuthBackend%2C%20ensuring%20_load_auth_instance%28%29%20runs%20exactly%20once.%0A%0A%20%20%20%20Returns%3A%0A%20%20%20%20%20%20%20%20Auth%20instance%20or%20None%20if%20not%20configured%2Ffound%0A%20%20%20%20%22%22%22%0A%20%20%20%20backend%20%3D%20get_auth_backend%28%29%0A%20%20%20%20return%20backend.auth_instance%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=340&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%0ALine%3A%20320-332%0A%0AComment%3A%0A**Redundant%20%60LangGraphAuthBackend%60%20instantiation**%0A%0A%60get_auth_instance%28%29%60%20constructs%20its%20own%20%60LangGraphAuthBackend%28%29%60%20directly%20instead%20of%20delegating%20to%20the%20newly-cached%20%60get_auth_backend%28%29%60.%20Because%20both%20functions%20carry%20their%20own%20%60%40lru_cache%60%2C%20two%20separate%20%60LangGraphAuthBackend%60%20instances%20are%20created%20per%20process%2C%20meaning%20%60_load_auth_instance%28%29%60%20%28with%20its%20file%20I%2FO%20and%20log%20output%29%20is%20still%20invoked%20twice%20%E2%80%94%20once%20by%20each%20cached%20function%20on%20its%20first%20call.%20The%20fix%20should%20have%20%60get_auth_instance%28%29%60%20call%20%60get_auth_backend%28%29%60%20so%20that%20only%20one%20backend%20instance%20ever%20exists%20and%20%60_load_auth_instance%28%29%60%20runs%20exactly%20once.%0A%0A%60%60%60suggestion%0Adef%20get_auth_instance%28%29%20-%3E%20Auth%20%7C%20None%3A%0A%20%20%20%20%22%22%22Get%20cached%20Auth%20instance%20for%20use%20by%20other%20modules.%0A%0A%20%20%20%20Delegates%20to%20get_auth_backend%28%29%20to%20reuse%20the%20single%20cached%0A%20%20%20%20LangGraphAuthBackend%2C%20ensuring%20_load_auth_instance%28%29%20runs%20exactly%20once.%0A%0A%20%20%20%20Returns%3A%0A%20%20%20%20%20%20%20%20Auth%20instance%20or%20None%20if%20not%20configured%2Ffound%0A%20%20%20%20%22%22%22%0A%20%20%20%20backend%20%3D%20get_auth_backend%28%29%0A%20%20%20%20return%20backend.auth_instance%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=340&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22main%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22main%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%0ALine%3A%20320-332%0A%0AComment%3A%0A**Redundant%20%60LangGraphAuthBackend%60%20instantiation**%0A%0A%60get_auth_instance%28%29%60%20constructs%20its%20own%20%60LangGraphAuthBackend%28%29%60%20directly%20instead%20of%20delegating%20to%20the%20newly-cached%20%60get_auth_backend%28%29%60.%20Because%20both%20functions%20carry%20their%20own%20%60%40lru_cache%60%2C%20two%20separate%20%60LangGraphAuthBackend%60%20instances%20are%20created%20per%20process%2C%20meaning%20%60_load_auth_instance%28%29%60%20%28with%20its%20file%20I%2FO%20and%20log%20output%29%20is%20still%20invoked%20twice%20%E2%80%94%20once%20by%20each%20cached%20function%20on%20its%20first%20call.%20The%20fix%20should%20have%20%60get_auth_instance%28%29%60%20call%20%60get_auth_backend%28%29%60%20so%20that%20only%20one%20backend%20instance%20ever%20exists%20and%20%60_load_auth_instance%28%29%60%20runs%20exactly%20once.%0A%0A%60%60%60suggestion%0Adef%20get_auth_instance%28%29%20-%3E%20Auth%20%7C%20None%3A%0A%20%20%20%20%22%22%22Get%20cached%20Auth%20instance%20for%20use%20by%20other%20modules.%0A%0A%20%20%20%20Delegates%20to%20get_auth_backend%28%29%20to%20reuse%20the%20single%20cached%0A%20%20%20%20LangGraphAuthBackend%2C%20ensuring%20_load_auth_instance%28%29%20runs%20exactly%20once.%0A%0A%20%20%20%20Returns%3A%0A%20%20%20%20%20%20%20%20Auth%20instance%20or%20None%20if%20not%20configured%2Ffound%0A%20%20%20%20%22%22%22%0A%20%20%20%20backend%20%3D%20get_auth_backend%28%29%0A%20%20%20%20return%20backend.auth_instance%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%3A320-332%0A**Redundant%20%60LangGraphAuthBackend%60%20instantiation**%0A%0A%60get_auth_instance%28%29%60%20constructs%20its%20own%20%60LangGraphAuthBackend%28%29%60%20directly%20instead%20of%20delegating%20to%20the%20newly-cached%20%60get_auth_backend%28%29%60.%20Because%20both%20functions%20carry%20their%20own%20%60%40lru_cache%60%2C%20two%20separate%20%60LangGraphAuthBackend%60%20instances%20are%20created%20per%20process%2C%20meaning%20%60_load_auth_instance%28%29%60%20%28with%20its%20file%20I%2FO%20and%20log%20output%29%20is%20still%20invoked%20twice%20%E2%80%94%20once%20by%20each%20cached%20function%20on%20its%20first%20call.%20The%20fix%20should%20have%20%60get_auth_instance%28%29%60%20call%20%60get_auth_backend%28%29%60%20so%20that%20only%20one%20backend%20instance%20ever%20exists%20and%20%60_load_auth_instance%28%29%60%20runs%20exactly%20once.%0A%0A%60%60%60suggestion%0Adef%20get_auth_instance%28%29%20-%3E%20Auth%20%7C%20None%3A%0A%20%20%20%20%22%22%22Get%20cached%20Auth%20instance%20for%20use%20by%20other%20modules.%0A%0A%20%20%20%20Delegates%20to%20get_auth_backend%28%29%20to%20reuse%20the%20single%20cached%0A%20%20%20%20LangGraphAuthBackend%2C%20ensuring%20_load_auth_instance%28%29%20runs%20exactly%20once.%0A%0A%20%20%20%20Returns%3A%0A%20%20%20%20%20%20%20%20Auth%20instance%20or%20None%20if%20not%20configured%2Ffound%0A%20%20%20%20%22%22%22%0A%20%20%20%20backend%20%3D%20get_auth_backend%28%29%0A%20%20%20%20return%20backend.auth_instance%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=340&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%3A320-332%0A**Redundant%20%60LangGraphAuthBackend%60%20instantiation**%0A%0A%60get_auth_instance%28%29%60%20constructs%20its%20own%20%60LangGraphAuthBackend%28%29%60%20directly%20instead%20of%20delegating%20to%20the%20newly-cached%20%60get_auth_backend%28%29%60.%20Because%20both%20functions%20carry%20their%20own%20%60%40lru_cache%60%2C%20two%20separate%20%60LangGraphAuthBackend%60%20instances%20are%20created%20per%20process%2C%20meaning%20%60_load_auth_instance%28%29%60%20%28with%20its%20file%20I%2FO%20and%20log%20output%29%20is%20still%20invoked%20twice%20%E2%80%94%20once%20by%20each%20cached%20function%20on%20its%20first%20call.%20The%20fix%20should%20have%20%60get_auth_instance%28%29%60%20call%20%60get_auth_backend%28%29%60%20so%20that%20only%20one%20backend%20instance%20ever%20exists%20and%20%60_load_auth_instance%28%29%60%20runs%20exactly%20once.%0A%0A%60%60%60suggestion%0Adef%20get_auth_instance%28%29%20-%3E%20Auth%20%7C%20None%3A%0A%20%20%20%20%22%22%22Get%20cached%20Auth%20instance%20for%20use%20by%20other%20modules.%0A%0A%20%20%20%20Delegates%20to%20get_auth_backend%28%29%20to%20reuse%20the%20single%20cached%0A%20%20%20%20LangGraphAuthBackend%2C%20ensuring%20_load_auth_instance%28%29%20runs%20exactly%20once.%0A%0A%20%20%20%20Returns%3A%0A%20%20%20%20%20%20%20%20Auth%20instance%20or%20None%20if%20not%20configured%2Ffound%0A%20%20%20%20%22%22%22%0A%20%20%20%20backend%20%3D%20get_auth_backend%28%29%0A%20%20%20%20return%20backend.auth_instance%0A%60%60%60%0A%0A&pr=340&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22main%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22main%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%3A320-332%0A**Redundant%20%60LangGraphAuthBackend%60%20instantiation**%0A%0A%60get_auth_instance%28%29%60%20constructs%20its%20own%20%60LangGraphAuthBackend%28%29%60%20directly%20instead%20of%20delegating%20to%20the%20newly-cached%20%60get_auth_backend%28%29%60.%20Because%20both%20functions%20carry%20their%20own%20%60%40lru_cache%60%2C%20two%20separate%20%60LangGraphAuthBackend%60%20instances%20are%20created%20per%20process%2C%20meaning%20%60_load_auth_instance%28%29%60%20%28with%20its%20file%20I%2FO%20and%20log%20output%29%20is%20still%20invoked%20twice%20%E2%80%94%20once%20by%20each%20cached%20function%20on%20its%20first%20call.%20The%20fix%20should%20have%20%60get_auth_instance%28%29%60%20call%20%60get_auth_backend%28%29%60%20so%20that%20only%20one%20backend%20instance%20ever%20exists%20and%20%60_load_auth_instance%28%29%60%20runs%20exactly%20once.%0A%0A%60%60%60suggestion%0Adef%20get_auth_instance%28%29%20-%3E%20Auth%20%7C%20None%3A%0A%20%20%20%20%22%22%22Get%20cached%20Auth%20instance%20for%20use%20by%20other%20modules.%0A%0A%20%20%20%20Delegates%20to%20get_auth_backend%28%29%20to%20reuse%20the%20single%20cached%0A%20%20%20%20LangGraphAuthBackend%2C%20ensuring%20_load_auth_instance%28%29%20runs%20exactly%20once.%0A%0A%20%20%20%20Returns%3A%0A%20%20%20%20%20%20%20%20Auth%20instance%20or%20None%20if%20not%20configured%2Ffound%0A%20%20%20%20%22%22%22%0A%20%20%20%20backend%20%3D%20get_auth_backend%28%29%0A%20%20%20%20return%20backend.auth_instance%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Fix error handling in authentication mid..."](https://github.com/aegra/aegra/commit/3fd8d1772fa9e9ee532235b7da6700731b3d333f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30664431)</sub>

<!-- /greptile_comment -->