### PR TITLE
chore(security): add SECURITY.md and CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly run catches drift even when no PRs land
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Aegra, please report it privately via
+[GitHub Security Advisories](https://github.com/aegra/aegra/security/advisories/new).
+
+Do **not** open a public issue for security bugs. Public issues let attackers
+weaponize a bug before a fix is available.
+
+We will:
+
+- Acknowledge receipt within 48 hours
+- Confirm or dispute the vulnerability within 7 days
+- Ship a patch release for confirmed high-severity bugs as soon as the fix is reviewed
+- Credit you in the published advisory unless you prefer anonymity
+
+## Supported Versions
+
+We patch security bugs in the latest minor release. Older minors do not receive
+security backports, upgrade to the latest patch on each minor.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.9.x   | Yes       |
+| < 0.9   | No        |
+
+## Scope
+
+**In scope:**
+
+- `aegra-api` (core server)
+- `aegra-cli`
+- Official Docker images published from this repo
+- Official examples in `examples/`
+
+**Out of scope:**
+
+- Third-party graphs and user-written `@auth.on` handlers
+- Deployment infrastructure you operate (Postgres, Redis, K8s configs, reverse proxies)
+- Vulnerabilities in upstream dependencies (report those to the upstream project)
+
+## Past advisories
+
+Published advisories are listed at:
+https://github.com/aegra/aegra/security/advisories


### PR DESCRIPTION
## Summary

Adds two security baselines:

1. **SECURITY.md** in the repo root. Documents the private vulnerability reporting flow (via GitHub Security Advisories), supported version policy, and scope. Currently reporters open public issues for security bugs (e.g. #336) — this gives them a clear private channel.

2. **CodeQL workflow** at .github/workflows/codeql.yml. Static analysis on push, PR, and a weekly schedule. Uses the `security-extended` + `security-and-quality` query packs, which include taint analysis on user input → SQL paths. Free for public repos, runs on GitHub-hosted runners.

Already enabled separately via API (no file diff needed):

- Secret scanning: catches accidentally committed API keys / tokens
- Push protection: blocks pushes containing detected secrets before they land
- Dependabot security updates: was already on

## Why now

Just shipped 0.9.7 fixing a critical IDOR (#336 / #337). CodeQL's taint-tracking queries cover the exact class of bug (user-controlled URL parameter flowing into SQL without ownership filter). Want this baseline before the next bug, not after.

## Test plan

- [ ] CodeQL workflow runs on this PR — verify it passes (or fails with real findings)
- [x] SECURITY.md renders correctly on the repo "Security" tab
- [x] Secret scanning + push protection visible as enabled in repo settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security policy with vulnerability reporting procedures, supported versions, and project scope coverage.

* **Chores**
  * Enabled automated security analysis workflow for continuous code quality monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->