### PR TITLE
feat(migrations): make startup migrations skippable and lock-free

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,15 @@ DEBUG=true
 # [MANDATORY] Path to the main agent configuration file
 AEGRA_CONFIG=aegra.json
 
+# Migrations
+# Run `alembic upgrade head` automatically on FastAPI startup. The fast
+# path is lock-free when the database is already at head, so this is safe
+# and cheap for dev / single-pod / docker-compose deployments. Set to
+# `false` for multi-pod (Kubernetes) deployments and run migrations
+# out-of-band via `aegra db upgrade` (init container, Helm pre-upgrade
+# Job, etc.). See docs/guides/deployment.mdx.
+# RUN_MIGRATIONS_ON_STARTUP=true
+
 # --- Database ---
 # Option 1: Single connection string (standard for containers/cloud)
 # If your password contains special characters (@, /, #, %, +, etc.),

--- a/.env.example
+++ b/.env.example
@@ -6,13 +6,8 @@ DEBUG=true
 # [MANDATORY] Path to the main agent configuration file
 AEGRA_CONFIG=aegra.json
 
-# Migrations
-# Run `alembic upgrade head` automatically on FastAPI startup. The fast
-# path is lock-free when the database is already at head, so this is safe
-# and cheap for dev / single-pod / docker-compose deployments. Set to
-# `false` for multi-pod (Kubernetes) deployments and run migrations
-# out-of-band via `aegra db upgrade` (init container, Helm pre-upgrade
-# Job, etc.). See docs/guides/deployment.mdx.
+# Auto-run migrations on startup. Set false for multi-pod K8s; run
+# `aegra db upgrade` out-of-band instead. See docs/guides/deployment.mdx.
 # RUN_MIGRATIONS_ON_STARTUP=true
 
 # --- Database ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,44 +217,26 @@ These rules exist because AI agents repeatedly make these mistakes. Follow them 
 - **NEVER commit commented-out code.** Delete it or keep it — no middle ground.
 
 ### Database & Migrations (STRICT)
-Aegra runs against arbitrary user Postgres setups, including HA / multi-host. Database-related code has hidden invariants that bite in production. Before writing or reviewing any DB code, walk this checklist:
+Aegra runs against user-managed Postgres including multi-host HA (PR #299). DB code has invariants that break silently in prod. Before touching DB code, walk this checklist:
 
-- **Two URLs, two drivers, do not mix.**
-  - `settings.db.database_url` → async, asyncpg driver, used by SQLAlchemy. Multi-host is rewritten into asyncpg query-param form by `_to_sqlalchemy_multihost`.
-  - `settings.db.database_url_sync` → raw libpq form, used by psycopg v3 directly (LangGraph checkpointer, store, anything driven by psycopg.connect / psycopg_pool). Comma-separated hosts are preserved verbatim.
-  - **Never feed `database_url_sync` into SQLAlchemy** (`create_engine`, `async_engine_from_config`, etc.) — SQLAlchemy's URL parser does not understand libpq multi-host syntax and will silently break HA deployments. If you need a sync DBAPI conn, call `psycopg.connect(database_url_sync)` directly.
-  - **Never feed `database_url` into raw psycopg** — the asyncpg query-param form is not what libpq expects.
+- **Two URLs, do not cross drivers.**
+  - `settings.db.database_url` → asyncpg query-param form. SQLAlchemy only.
+  - `settings.db.database_url_sync` → raw libpq, comma-host preserved. psycopg only (LangGraph pool, migrations precheck).
+  - Feeding `database_url_sync` to SQLAlchemy (`create_engine`, `async_engine_from_config`) silently breaks HA — SQLAlchemy's URL parser doesn't grok libpq comma-hosts. For sync DBAPI, use `psycopg.connect(database_url_sync)` directly.
 
-- **Multi-host (PR #299) compatibility is mandatory.**
-  - `DATABASE_URL=postgresql://h1:5432,h2:5432/db?target_session_attrs=read-write` must keep working everywhere DB code executes.
-  - When you add code that opens a connection, prefer reusing `db_manager` pools or routing through the helpers above. If you must build your own connection, branch on which URL you need and document why in the call site.
-  - Add a regression test that asserts the URL handed to your driver is unchanged from `settings.db.*`, so future refactors do not silently re-introduce a SQLAlchemy URL parse on a libpq string.
-
-- **Pool ownership.**
-  - Long-lived pools live in `db_manager` (`core/database.py`). Application code should not open its own pool.
-  - Short-lived helpers (migrations precheck, one-shot scripts) are allowed to open a private connection but must close it deterministically (`with` block, or `try/finally` + `dispose`).
-  - Code that runs *before* `db_manager.initialize()` (anything in the FastAPI lifespan startup phase before that line) must not assume pools exist.
+- **Pool ownership.** Long-lived pools belong in `db_manager` only. Short-lived helpers must close deterministically (`with` or `try/finally`). Code running before `db_manager.initialize()` cannot assume pools exist.
 
 - **Migrations.**
-  - Schema changes go through Alembic — never `CREATE TABLE` / `ALTER TABLE` from app code.
-  - Generate migrations with `uv run --package aegra-api alembic revision --autogenerate -m "..."`, then review the generated file before committing. Autogenerate misses things (CHECK constraints, comment changes, certain index types).
-  - `down_revision` chain must be linear and complete. Every new migration's `down_revision` references the previous head.
-  - Migrations must be idempotent and resumable. Pods can crash mid-upgrade; the next run must pick up cleanly. Use `op.create_index(..., if_not_exists=True)` style guards where the dialect supports it.
-  - **Multi-pod startup race:** every replica boots and races for Alembic's advisory lock. The lifespan startup path uses `run_migrations_if_needed()` which short-circuits via a lock-free precheck when the DB is at head. Do not regress this. The unconditional `run_migrations()` is reserved for explicit, out-of-band invocation (`aegra db upgrade`, init container, Helm pre-upgrade Job).
-  - Set `RUN_MIGRATIONS_ON_STARTUP=false` is a documented multi-pod path; if you change startup behavior, update both `.env.example` files AND `docs/guides/deployment.mdx`.
+  - Schema changes go through alembic, never raw DDL from app code.
+  - Linear `down_revision` chain. Idempotent + resumable.
+  - Lifespan uses `run_migrations_if_needed()` (lock-free precheck). `run_migrations()` is for `aegra db upgrade` only. Don't regress the precheck.
+  - Multi-pod path: `RUN_MIGRATIONS_ON_STARTUP=false` + `aegra db upgrade` out-of-band. Changing startup behavior needs both `.env.example` files + `docs/guides/deployment.mdx` updated.
 
-- **Authorization at the SQL layer.**
-  - Every read or write of a tenant-scoped resource (threads, assistants, runs, store items, crons) MUST include a `user_id == user.identity` filter in the SQL `WHERE` clause, even when `@auth.on` policy hooks exist.
-  - Default-allow on missing `@auth.on` handlers means the SQL filter is the only safety net. See PR #337 / GHSA-m98r-6667-4wq7 for the cross-tenant IDOR class this prevents.
-  - When a route accepts a path resource id (`thread_id`, `assistant_id`, etc.) and writes anywhere, the very first thing the handler does after auth is verify ownership and 404 if it fails. Do not delegate this to deeper helpers — those can be called from other paths.
+- **SQL-layer authorization.** Every tenant-scoped read/write needs `user_id == user.identity` in the WHERE, even with `@auth.on` registered (default-allow when no handler — see GHSA-m98r-6667-4wq7). Routes taking `thread_id`/`assistant_id`/`cron_id` path params verify ownership + 404 at handler entry, not deeper.
 
-- **Connection footprint.**
-  - Every new persistent pool / engine increases per-pod connection count. Postgres `max_connections` is finite. Do not silently add a new pool — extend an existing one or document the cap impact.
-  - `pgbouncer` / RDS Proxy in transaction-pool mode breaks `LISTEN/NOTIFY` and prepared statements; aegra docs flag this. Don't add features that depend on those without flagging the same caveat.
+- **Connection footprint.** New pools increase per-pod conn count. Extend existing or document the cap impact. PgBouncer/RDS Proxy transaction-pool mode breaks LISTEN/NOTIFY + prepared statements; flag accordingly.
 
-- **Testing.**
-  - Unit tests for any DB helper must mock at the driver layer, not the SQLAlchemy layer, when the helper is supposed to bypass SQLAlchemy. Otherwise the test will pass while the real path silently regresses on multi-host URLs.
-  - Add a test that asserts the *exact URL* passed to the driver is the unmodified value from settings, so a future "small refactor" can't quietly inject SQLAlchemy URL parsing.
+- **Testing.** Mock at the driver layer, not SQLAlchemy, when bypassing SQLAlchemy. Assert the exact URL passed to the driver matches `settings.db.*` so refactors can't quietly reintroduce SQLAlchemy URL parsing on libpq strings.
 
 ### Security
 - NEVER store secrets, API keys, or passwords in code — only in `.env` files or environment variables.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,46 @@ These rules exist because AI agents repeatedly make these mistakes. Follow them 
 - **If you don't understand why code exists, ask or leave it alone** (Chesterton's Fence).
 - **NEVER commit commented-out code.** Delete it or keep it — no middle ground.
 
+### Database & Migrations (STRICT)
+Aegra runs against arbitrary user Postgres setups, including HA / multi-host. Database-related code has hidden invariants that bite in production. Before writing or reviewing any DB code, walk this checklist:
+
+- **Two URLs, two drivers, do not mix.**
+  - `settings.db.database_url` → async, asyncpg driver, used by SQLAlchemy. Multi-host is rewritten into asyncpg query-param form by `_to_sqlalchemy_multihost`.
+  - `settings.db.database_url_sync` → raw libpq form, used by psycopg v3 directly (LangGraph checkpointer, store, anything driven by psycopg.connect / psycopg_pool). Comma-separated hosts are preserved verbatim.
+  - **Never feed `database_url_sync` into SQLAlchemy** (`create_engine`, `async_engine_from_config`, etc.) — SQLAlchemy's URL parser does not understand libpq multi-host syntax and will silently break HA deployments. If you need a sync DBAPI conn, call `psycopg.connect(database_url_sync)` directly.
+  - **Never feed `database_url` into raw psycopg** — the asyncpg query-param form is not what libpq expects.
+
+- **Multi-host (PR #299) compatibility is mandatory.**
+  - `DATABASE_URL=postgresql://h1:5432,h2:5432/db?target_session_attrs=read-write` must keep working everywhere DB code executes.
+  - When you add code that opens a connection, prefer reusing `db_manager` pools or routing through the helpers above. If you must build your own connection, branch on which URL you need and document why in the call site.
+  - Add a regression test that asserts the URL handed to your driver is unchanged from `settings.db.*`, so future refactors do not silently re-introduce a SQLAlchemy URL parse on a libpq string.
+
+- **Pool ownership.**
+  - Long-lived pools live in `db_manager` (`core/database.py`). Application code should not open its own pool.
+  - Short-lived helpers (migrations precheck, one-shot scripts) are allowed to open a private connection but must close it deterministically (`with` block, or `try/finally` + `dispose`).
+  - Code that runs *before* `db_manager.initialize()` (anything in the FastAPI lifespan startup phase before that line) must not assume pools exist.
+
+- **Migrations.**
+  - Schema changes go through Alembic — never `CREATE TABLE` / `ALTER TABLE` from app code.
+  - Generate migrations with `uv run --package aegra-api alembic revision --autogenerate -m "..."`, then review the generated file before committing. Autogenerate misses things (CHECK constraints, comment changes, certain index types).
+  - `down_revision` chain must be linear and complete. Every new migration's `down_revision` references the previous head.
+  - Migrations must be idempotent and resumable. Pods can crash mid-upgrade; the next run must pick up cleanly. Use `op.create_index(..., if_not_exists=True)` style guards where the dialect supports it.
+  - **Multi-pod startup race:** every replica boots and races for Alembic's advisory lock. The lifespan startup path uses `run_migrations_if_needed()` which short-circuits via a lock-free precheck when the DB is at head. Do not regress this. The unconditional `run_migrations()` is reserved for explicit, out-of-band invocation (`aegra db upgrade`, init container, Helm pre-upgrade Job).
+  - Set `RUN_MIGRATIONS_ON_STARTUP=false` is a documented multi-pod path; if you change startup behavior, update both `.env.example` files AND `docs/guides/deployment.mdx`.
+
+- **Authorization at the SQL layer.**
+  - Every read or write of a tenant-scoped resource (threads, assistants, runs, store items, crons) MUST include a `user_id == user.identity` filter in the SQL `WHERE` clause, even when `@auth.on` policy hooks exist.
+  - Default-allow on missing `@auth.on` handlers means the SQL filter is the only safety net. See PR #337 / GHSA-m98r-6667-4wq7 for the cross-tenant IDOR class this prevents.
+  - When a route accepts a path resource id (`thread_id`, `assistant_id`, etc.) and writes anywhere, the very first thing the handler does after auth is verify ownership and 404 if it fails. Do not delegate this to deeper helpers — those can be called from other paths.
+
+- **Connection footprint.**
+  - Every new persistent pool / engine increases per-pod connection count. Postgres `max_connections` is finite. Do not silently add a new pool — extend an existing one or document the cap impact.
+  - `pgbouncer` / RDS Proxy in transaction-pool mode breaks `LISTEN/NOTIFY` and prepared statements; aegra docs flag this. Don't add features that depend on those without flagging the same caveat.
+
+- **Testing.**
+  - Unit tests for any DB helper must mock at the driver layer, not the SQLAlchemy layer, when the helper is supposed to bypass SQLAlchemy. Otherwise the test will pass while the real path silently regresses on multi-host URLs.
+  - Add a test that asserts the *exact URL* passed to the driver is the unmodified value from settings, so a future "small refactor" can't quietly inject SQLAlchemy URL parsing.
+
 ### Security
 - NEVER store secrets, API keys, or passwords in code — only in `.env` files or environment variables.
 - NEVER log sensitive information (passwords, tokens, PII).

--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -189,7 +189,33 @@ Two ways to configure the database connection:
 
 ## Migrations
 
-Migrations run automatically on startup for all deployment methods. You do not need to run them manually.
+By default, Aegra runs `alembic upgrade head` during FastAPI's lifespan startup. The fast path is lock-free: each pod first reads the current revision and skips the upgrade entirely if the database is already at head.
+
+For single-pod and dev setups (`aegra dev`, `aegra up`, single docker-compose service) this is what you want and you do not need to run migrations manually.
+
+### Multi-pod (Kubernetes, etc.)
+
+When several replicas boot at the same time and a real upgrade is pending, every pod queues on Alembic's advisory lock. Liveness or readiness probes can time out before pods finish startup, causing restart loops. To avoid this, run migrations out-of-band and disable the startup hook on app pods:
+
+```bash
+# .env (or pod env)
+RUN_MIGRATIONS_ON_STARTUP=false
+```
+
+Then run migrations once per release using one of:
+
+- **Helm pre-upgrade Job** that runs `aegra db upgrade` (recommended)
+- **Init container** on the deployment that runs `aegra db upgrade` before the API container starts
+- **Manual / CI step** that runs `aegra db upgrade` against the target database before the deployment rolls
+
+The same `aegra db` group also exposes `current`, `history`, and `downgrade` for inspection and rollback.
+
+```bash
+aegra db upgrade        # apply all pending migrations
+aegra db current        # show the current revision
+aegra db history -v     # show migration history
+aegra db downgrade -1   # roll back one revision
+```
 
 ## Health checks
 
@@ -218,5 +244,8 @@ The generated `docker-compose.yml` uses `/health` to monitor the API container. 
   </Accordion>
   <Accordion title="Migrations hang on startup">
     Check if another process holds a lock on the database, if the database is reachable but slow, or check server logs for specific migration errors.
+  </Accordion>
+  <Accordion title="Pods restart-loop on rolling deploy (Kubernetes)">
+    All replicas race for Alembic's advisory lock on boot. As fleet size grows, later pods queue past their probe deadline and the kubelet kills them. Set `RUN_MIGRATIONS_ON_STARTUP=false` and run `aegra db upgrade` once per release from a Helm pre-upgrade Job or init container.
   </Accordion>
 </AccordionGroup>

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.7"
+    "version": "0.9.8"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.7"
+version = "0.9.8"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/core/migrations.py
+++ b/libs/aegra-api/src/aegra_api/core/migrations.py
@@ -3,6 +3,18 @@
 Provides automatic Alembic migration support for both development (repo)
 and production (pip install) deployments. Resolves the alembic.ini and
 migration scripts from either CWD or the installed aegra-api package.
+
+Two entry points:
+
+- ``run_migrations()`` always upgrades to head, acquiring the alembic
+  advisory lock unconditionally. Suitable for explicit, out-of-band
+  invocation (init containers, Helm pre-upgrade Jobs, ``aegra migrate``).
+
+- ``run_migrations_if_needed()`` first does a cheap read-only check
+  comparing the database's current revision against the migration
+  script head. If they match, it returns without acquiring any lock.
+  This is what the FastAPI startup path uses to keep multi-pod boots
+  fast in the steady state, where the database is already migrated.
 """
 
 import asyncio
@@ -10,7 +22,11 @@ from pathlib import Path
 
 import structlog
 from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine
 
+from aegra_api.settings import settings
 from alembic import command
 
 logger = structlog.get_logger(__name__)
@@ -74,23 +90,81 @@ def get_alembic_config() -> Config:
     return cfg
 
 
-def run_migrations() -> None:
-    """Run all pending database migrations synchronously.
+def _is_database_up_to_date(cfg: Config) -> bool:
+    """Check whether the database is already at the migration head.
 
-    Uses Alembic's upgrade command to apply all pending migrations.
-    Safe to call repeatedly - Alembic is idempotent and uses database
-    locks to prevent concurrent migration conflicts.
+    Reads ``alembic_version`` via a short-lived sync engine and compares
+    against the script directory's head revision. No advisory lock is
+    acquired, so this is safe to call from many pods concurrently.
+
+    Returns:
+        True if the database revision matches head (no migration needed),
+        False otherwise (migration needed, or table not yet created).
+    """
+    script = ScriptDirectory.from_config(cfg)
+    head = script.get_current_head()
+
+    # Use the synchronous Postgres URL with the psycopg v3 driver.
+    # We deliberately do not reuse the app's async pool here because this
+    # runs before the app initializes its pools, and we want a short-lived
+    # connection that is closed before alembic opens its own.
+    sync_url = settings.db.database_url_sync.replace("postgresql://", "postgresql+psycopg://", 1)
+    engine = create_engine(sync_url, pool_pre_ping=True)
+    try:
+        with engine.connect() as conn:
+            ctx = MigrationContext.configure(conn)
+            current = ctx.get_current_revision()
+    finally:
+        engine.dispose()
+
+    return current is not None and current == head
+
+
+def run_migrations() -> None:
+    """Unconditionally run all pending database migrations.
+
+    Acquires Alembic's advisory lock and upgrades to head. Use this for
+    explicit invocations: init containers, Helm pre-upgrade Jobs, or the
+    ``aegra migrate`` CLI command.
     """
     cfg = get_alembic_config()
-    logger.info("Running database migrations...")
+    logger.info("running database migrations")
     command.upgrade(cfg, "head")
-    logger.info("Database migrations completed")
+    logger.info("database migrations completed")
+
+
+def run_migrations_if_needed() -> None:
+    """Run migrations only when the database is behind head.
+
+    Performs a lock-free read of the current revision first. If it
+    already matches head, returns immediately without entering the
+    alembic upgrade path. Otherwise falls through to ``run_migrations``.
+
+    This keeps app pod boots cheap in the steady state where the database
+    is already at head, avoiding the advisory-lock contention that
+    serializes ``alembic upgrade head`` calls across replicas.
+    """
+    cfg = get_alembic_config()
+    try:
+        if _is_database_up_to_date(cfg):
+            logger.debug("database already at migration head; skipping upgrade")
+            return
+    except Exception as exc:
+        # Fall through to full upgrade so first-time installs (where
+        # alembic_version doesn't exist yet) still work. The full path
+        # logs and raises on real failures.
+        logger.debug("revision precheck failed; falling back to full upgrade", error=str(exc))
+
+    logger.info("running database migrations")
+    command.upgrade(cfg, "head")
+    logger.info("database migrations completed")
 
 
 async def run_migrations_async() -> None:
-    """Run all pending database migrations (async-safe).
+    """Run pending migrations from an async context (lock-free fast path).
 
-    Wraps the synchronous migration in a thread executor because Alembic's
-    env.py uses asyncio.run() internally, which requires its own event loop.
+    Wraps :func:`run_migrations_if_needed` in a thread executor because
+    Alembic's env.py uses ``asyncio.run()`` internally, which requires
+    its own event loop.
     """
-    await asyncio.to_thread(run_migrations)
+    await asyncio.to_thread(run_migrations_if_needed)

--- a/libs/aegra-api/src/aegra_api/core/migrations.py
+++ b/libs/aegra-api/src/aegra_api/core/migrations.py
@@ -1,20 +1,10 @@
-"""Database migration utilities for Aegra.
+"""Alembic migration helpers.
 
-Provides automatic Alembic migration support for both development (repo)
-and production (pip install) deployments. Resolves the alembic.ini and
-migration scripts from either CWD or the installed aegra-api package.
-
-Two entry points:
-
-- ``run_migrations()`` always upgrades to head, acquiring the alembic
-  advisory lock unconditionally. Suitable for explicit, out-of-band
-  invocation (init containers, Helm pre-upgrade Jobs, ``aegra db upgrade``).
-
-- ``run_migrations_if_needed()`` first does a cheap read-only check
-  comparing the database's current revision against the migration
-  script head. If they match, it returns without acquiring any lock.
-  This is what the FastAPI startup path uses to keep multi-pod boots
-  fast in the steady state, where the database is already migrated.
+Resolves alembic.ini from CWD or the installed package. Two entry points:
+- ``run_migrations()``: unconditional upgrade, takes advisory lock. Use for
+  out-of-band runs (``aegra db upgrade``, init container, Helm Job).
+- ``run_migrations_if_needed()``: lock-free precheck, skips upgrade when
+  already at head. FastAPI startup uses this to avoid multi-pod lock contention.
 """
 
 import asyncio
@@ -91,31 +81,17 @@ def get_alembic_config() -> Config:
 
 
 def _is_database_up_to_date(cfg: Config) -> bool:
-    """Check whether the database is already at the migration head.
-
-    Reads ``alembic_version`` via a short-lived sync engine and compares
-    against the script directory's head revision. No advisory lock is
-    acquired, so this is safe to call from many pods concurrently.
-
-    Returns:
-        True if there is nothing to apply (the database revision matches
-        head, or the script directory has no revisions at all), False
-        otherwise (migration pending, or no current revision yet).
-    """
+    """Lock-free check: True iff DB revision matches script head."""
     script = ScriptDirectory.from_config(cfg)
     head = script.get_current_head()
 
-    # Empty script directory: nothing to apply, skip the upgrade entirely.
+    # Empty script directory: nothing to apply.
     if head is None:
         return True
 
-    # Open a short-lived psycopg connection directly using the libpq-style
-    # URL from settings. This deliberately bypasses SQLAlchemy's URL parser
-    # so multi-host DATABASE_URL values (``postgresql://h1,h2/db``, see
-    # ``DatabaseSettings._to_sqlalchemy_multihost``) work natively via libpq
-    # failover. We do not reuse the app's async pool because this runs
-    # before pools initialize, and we want the connection closed before
-    # alembic opens its own.
+    # Use psycopg.connect directly. SQLAlchemy's URL parser breaks on
+    # libpq comma-host syntax; psycopg parses it natively, preserving
+    # multi-host failover from PR #299.
     with psycopg.connect(settings.db.database_url_sync) as conn:
         ctx = MigrationContext.configure(conn)
         current = ctx.get_current_revision()
@@ -124,12 +100,7 @@ def _is_database_up_to_date(cfg: Config) -> bool:
 
 
 def run_migrations() -> None:
-    """Unconditionally run all pending database migrations.
-
-    Acquires Alembic's advisory lock and upgrades to head. Use this for
-    explicit invocations: init containers, Helm pre-upgrade Jobs, or the
-    ``aegra db upgrade`` CLI command.
-    """
+    """Unconditional upgrade to head. Takes advisory lock."""
     cfg = get_alembic_config()
     logger.info("running database migrations")
     command.upgrade(cfg, "head")
@@ -137,15 +108,10 @@ def run_migrations() -> None:
 
 
 def run_migrations_if_needed() -> None:
-    """Run migrations only when the database is behind head.
+    """Skip upgrade when already at head; otherwise fall through to upgrade.
 
-    Performs a lock-free read of the current revision first. If it
-    already matches head, returns immediately without entering the
-    alembic upgrade path. Otherwise falls through to ``run_migrations``.
-
-    This keeps app pod boots cheap in the steady state where the database
-    is already at head, avoiding the advisory-lock contention that
-    serializes ``alembic upgrade head`` calls across replicas.
+    Precheck failure (e.g. fresh install with no alembic_version yet) also
+    falls through so bootstrap works.
     """
     cfg = get_alembic_config()
     try:
@@ -153,9 +119,6 @@ def run_migrations_if_needed() -> None:
             logger.debug("database already at migration head; skipping upgrade")
             return
     except Exception as exc:
-        # Fall through to full upgrade so first-time installs (where
-        # alembic_version doesn't exist yet) still work. The full path
-        # logs and raises on real failures.
         logger.debug("revision precheck failed; falling back to full upgrade", error=str(exc))
 
     logger.info("running database migrations")
@@ -164,10 +127,6 @@ def run_migrations_if_needed() -> None:
 
 
 async def run_migrations_async() -> None:
-    """Run pending migrations from an async context (lock-free fast path).
-
-    Wraps :func:`run_migrations_if_needed` in a thread executor because
-    Alembic's env.py uses ``asyncio.run()`` internally, which requires
-    its own event loop.
-    """
+    """Async wrapper over the lock-free fast path. Alembic's env.py owns
+    its own event loop, so we hand off to a thread."""
     await asyncio.to_thread(run_migrations_if_needed)

--- a/libs/aegra-api/src/aegra_api/core/migrations.py
+++ b/libs/aegra-api/src/aegra_api/core/migrations.py
@@ -8,7 +8,7 @@ Two entry points:
 
 - ``run_migrations()`` always upgrades to head, acquiring the alembic
   advisory lock unconditionally. Suitable for explicit, out-of-band
-  invocation (init containers, Helm pre-upgrade Jobs, ``aegra migrate``).
+  invocation (init containers, Helm pre-upgrade Jobs, ``aegra db upgrade``).
 
 - ``run_migrations_if_needed()`` first does a cheap read-only check
   comparing the database's current revision against the migration
@@ -98,11 +98,16 @@ def _is_database_up_to_date(cfg: Config) -> bool:
     acquired, so this is safe to call from many pods concurrently.
 
     Returns:
-        True if the database revision matches head (no migration needed),
-        False otherwise (migration needed, or table not yet created).
+        True if there is nothing to apply (the database revision matches
+        head, or the script directory has no revisions at all), False
+        otherwise (migration pending, or no current revision yet).
     """
     script = ScriptDirectory.from_config(cfg)
     head = script.get_current_head()
+
+    # Empty script directory: nothing to apply, skip the upgrade entirely.
+    if head is None:
+        return True
 
     # Use the synchronous Postgres URL with the psycopg v3 driver.
     # We deliberately do not reuse the app's async pool here because this
@@ -117,7 +122,7 @@ def _is_database_up_to_date(cfg: Config) -> bool:
     finally:
         engine.dispose()
 
-    return current is not None and current == head
+    return current == head
 
 
 def run_migrations() -> None:
@@ -125,7 +130,7 @@ def run_migrations() -> None:
 
     Acquires Alembic's advisory lock and upgrades to head. Use this for
     explicit invocations: init containers, Helm pre-upgrade Jobs, or the
-    ``aegra migrate`` CLI command.
+    ``aegra db upgrade`` CLI command.
     """
     cfg = get_alembic_config()
     logger.info("running database migrations")

--- a/libs/aegra-api/src/aegra_api/core/migrations.py
+++ b/libs/aegra-api/src/aegra_api/core/migrations.py
@@ -20,11 +20,11 @@ Two entry points:
 import asyncio
 from pathlib import Path
 
+import psycopg
 import structlog
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
-from sqlalchemy import create_engine
 
 from aegra_api.settings import settings
 from alembic import command
@@ -109,18 +109,16 @@ def _is_database_up_to_date(cfg: Config) -> bool:
     if head is None:
         return True
 
-    # Use the synchronous Postgres URL with the psycopg v3 driver.
-    # We deliberately do not reuse the app's async pool here because this
-    # runs before the app initializes its pools, and we want a short-lived
-    # connection that is closed before alembic opens its own.
-    sync_url = settings.db.database_url_sync.replace("postgresql://", "postgresql+psycopg://", 1)
-    engine = create_engine(sync_url, pool_pre_ping=True)
-    try:
-        with engine.connect() as conn:
-            ctx = MigrationContext.configure(conn)
-            current = ctx.get_current_revision()
-    finally:
-        engine.dispose()
+    # Open a short-lived psycopg connection directly using the libpq-style
+    # URL from settings. This deliberately bypasses SQLAlchemy's URL parser
+    # so multi-host DATABASE_URL values (``postgresql://h1,h2/db``, see
+    # ``DatabaseSettings._to_sqlalchemy_multihost``) work natively via libpq
+    # failover. We do not reuse the app's async pool because this runs
+    # before pools initialize, and we want the connection closed before
+    # alembic opens its own.
+    with psycopg.connect(settings.db.database_url_sync) as conn:
+        ctx = MigrationContext.configure(conn)
+        current = ctx.get_current_revision()
 
     return current == head
 

--- a/libs/aegra-api/src/aegra_api/core/migrations.py
+++ b/libs/aegra-api/src/aegra_api/core/migrations.py
@@ -13,7 +13,6 @@ from pathlib import Path
 import psycopg
 import structlog
 from alembic.config import Config
-from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 
 from aegra_api.settings import settings
@@ -89,12 +88,18 @@ def _is_database_up_to_date(cfg: Config) -> bool:
     if head is None:
         return True
 
-    # Use psycopg.connect directly. SQLAlchemy's URL parser breaks on
-    # libpq comma-host syntax; psycopg parses it natively, preserving
-    # multi-host failover from PR #299.
-    with psycopg.connect(settings.db.database_url_sync) as conn:
-        ctx = MigrationContext.configure(conn)
-        current = ctx.get_current_revision()
+    # Read alembic_version directly via psycopg. MigrationContext.configure
+    # requires a SQLAlchemy Connection (accesses conn.dialect), and SQLAlchemy's
+    # URL parser breaks on libpq comma-host syntax — so we bypass both,
+    # preserving multi-host failover from PR #299.
+    with psycopg.connect(settings.db.database_url_sync) as conn, conn.cursor() as cur:
+        try:
+            cur.execute("SELECT version_num FROM alembic_version LIMIT 1")
+            row = cur.fetchone()
+            current = row[0] if row else None
+        except psycopg.errors.UndefinedTable:
+            conn.rollback()
+            current = None
 
     return current == head
 

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -77,7 +77,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # Auto-apply pending database migrations before anything else.
     # Disable in multi-pod deployments by setting RUN_MIGRATIONS_ON_STARTUP=false
     # and running migrations out-of-band (init container, Helm pre-upgrade Job,
-    # or `aegra migrate`). See docs/guides/production-deployment.mdx.
+    # or `aegra db upgrade`). See docs/guides/deployment.mdx.
     if settings.app.RUN_MIGRATIONS_ON_STARTUP:
         try:
             await run_migrations_async()

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -74,12 +74,18 @@ def _log_connection_help(error: Exception) -> None:
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """FastAPI lifespan context manager for startup/shutdown"""
-    # Auto-apply pending database migrations before anything else
-    try:
-        await run_migrations_async()
-    except (ConnectionRefusedError, OSError) as e:
-        _log_connection_help(e)
-        raise
+    # Auto-apply pending database migrations before anything else.
+    # Disable in multi-pod deployments by setting RUN_MIGRATIONS_ON_STARTUP=false
+    # and running migrations out-of-band (init container, Helm pre-upgrade Job,
+    # or `aegra migrate`). See docs/guides/production-deployment.mdx.
+    if settings.app.RUN_MIGRATIONS_ON_STARTUP:
+        try:
+            await run_migrations_async()
+        except (ConnectionRefusedError, OSError) as e:
+            _log_connection_help(e)
+            raise
+    else:
+        logger.info("skipping startup migrations (RUN_MIGRATIONS_ON_STARTUP=false)")
 
     # Startup: Initialize database and LangGraph components
     try:

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -74,10 +74,8 @@ def _log_connection_help(error: Exception) -> None:
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """FastAPI lifespan context manager for startup/shutdown"""
-    # Auto-apply pending database migrations before anything else.
-    # Disable in multi-pod deployments by setting RUN_MIGRATIONS_ON_STARTUP=false
-    # and running migrations out-of-band (init container, Helm pre-upgrade Job,
-    # or `aegra db upgrade`). See docs/guides/deployment.mdx.
+    # Multi-pod K8s: set RUN_MIGRATIONS_ON_STARTUP=false + run `aegra db upgrade`
+    # out-of-band. See docs/guides/deployment.mdx.
     if settings.app.RUN_MIGRATIONS_ON_STARTUP:
         try:
             await run_migrations_async()

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -62,6 +62,15 @@ class AppSettings(EnvBase):
     ENV_MODE: UpperStr = "LOCAL"
     DEBUG: bool = False
 
+    # Migrations
+    # When True (default), run `alembic upgrade head` on FastAPI startup.
+    # Convenient for dev / single-pod / docker-compose. In multi-pod
+    # deployments (e.g. Kubernetes), every replica boot races for the
+    # alembic advisory lock and probes can time out, so it's recommended
+    # to set this to False and run migrations out-of-band via an init
+    # container, Helm pre-upgrade Job, or `aegra migrate`.
+    RUN_MIGRATIONS_ON_STARTUP: bool = True
+
     # Logging
     LOG_LEVEL: UpperStr = "INFO"
     LOG_VERBOSITY: LowerStr = "verbose"

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -62,13 +62,9 @@ class AppSettings(EnvBase):
     ENV_MODE: UpperStr = "LOCAL"
     DEBUG: bool = False
 
-    # Migrations
-    # When True (default), run `alembic upgrade head` on FastAPI startup.
-    # Convenient for dev / single-pod / docker-compose. In multi-pod
-    # deployments (e.g. Kubernetes), every replica boot races for the
-    # alembic advisory lock and probes can time out, so it's recommended
-    # to set this to False and run migrations out-of-band via an init
-    # container, Helm pre-upgrade Job, or `aegra migrate`.
+    # Run alembic upgrade head on startup. Default True (dev / single-pod).
+    # Set False for multi-pod K8s to avoid advisory-lock probe timeouts;
+    # run migrations out-of-band via `aegra db upgrade`.
     RUN_MIGRATIONS_ON_STARTUP: bool = True
 
     # Logging

--- a/libs/aegra-api/tests/unit/test_main.py
+++ b/libs/aegra-api/tests/unit/test_main.py
@@ -103,3 +103,68 @@ async def test_lifespan_calls_required_initialization():
 
         # Verify cleanup
         mock_db_manager.close.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_lifespan_skips_migrations_when_disabled(monkeypatch):
+    """When RUN_MIGRATIONS_ON_STARTUP=false, lifespan must not call alembic."""
+    import aegra_api.main as main_module
+
+    importlib.reload(main_module)
+    from aegra_api.main import lifespan
+    from aegra_api.settings import settings
+
+    monkeypatch.setattr(settings.app, "RUN_MIGRATIONS_ON_STARTUP", False)
+
+    with (
+        patch("aegra_api.main.run_migrations_async", new_callable=AsyncMock) as mock_migrations,
+        patch("aegra_api.main.db_manager") as mock_db_manager,
+        patch("aegra_api.main.get_langgraph_service") as mock_get_langgraph_service,
+        patch("aegra_api.main.setup_observability"),
+    ):
+        mock_db_manager.initialize = AsyncMock()
+        mock_db_manager.close = AsyncMock()
+
+        mock_langgraph_service = MagicMock()
+        mock_langgraph_service.initialize = AsyncMock()
+        mock_get_langgraph_service.return_value = mock_langgraph_service
+
+        async with lifespan(MagicMock()):
+            pass
+
+        mock_migrations.assert_not_called()
+        # The rest of startup must still happen.
+        mock_db_manager.initialize.assert_called_once()
+        mock_langgraph_service.initialize.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_lifespan_runs_migrations_when_enabled(monkeypatch):
+    """Default (RUN_MIGRATIONS_ON_STARTUP=true) keeps the auto-migrate behavior."""
+    import aegra_api.main as main_module
+
+    importlib.reload(main_module)
+    from aegra_api.main import lifespan
+    from aegra_api.settings import settings
+
+    monkeypatch.setattr(settings.app, "RUN_MIGRATIONS_ON_STARTUP", True)
+
+    with (
+        patch("aegra_api.main.run_migrations_async", new_callable=AsyncMock) as mock_migrations,
+        patch("aegra_api.main.db_manager") as mock_db_manager,
+        patch("aegra_api.main.get_langgraph_service") as mock_get_langgraph_service,
+        patch("aegra_api.main.setup_observability"),
+    ):
+        mock_db_manager.initialize = AsyncMock()
+        mock_db_manager.close = AsyncMock()
+
+        mock_langgraph_service = MagicMock()
+        mock_langgraph_service.initialize = AsyncMock()
+        mock_get_langgraph_service.return_value = mock_langgraph_service
+
+        async with lifespan(MagicMock()):
+            pass
+
+        mock_migrations.assert_called_once()

--- a/libs/aegra-api/tests/unit/test_main.py
+++ b/libs/aegra-api/tests/unit/test_main.py
@@ -110,10 +110,9 @@ async def test_lifespan_calls_required_initialization():
 async def test_lifespan_skips_migrations_when_disabled(monkeypatch):
     """When RUN_MIGRATIONS_ON_STARTUP=false, lifespan must not call alembic."""
     import aegra_api.main as main_module
+    from aegra_api.settings import settings
 
     importlib.reload(main_module)
-    from aegra_api.main import lifespan
-    from aegra_api.settings import settings
 
     monkeypatch.setattr(settings.app, "RUN_MIGRATIONS_ON_STARTUP", False)
 
@@ -130,7 +129,7 @@ async def test_lifespan_skips_migrations_when_disabled(monkeypatch):
         mock_langgraph_service.initialize = AsyncMock()
         mock_get_langgraph_service.return_value = mock_langgraph_service
 
-        async with lifespan(MagicMock()):
+        async with main_module.lifespan(MagicMock()):
             pass
 
         mock_migrations.assert_not_called()
@@ -144,10 +143,9 @@ async def test_lifespan_skips_migrations_when_disabled(monkeypatch):
 async def test_lifespan_runs_migrations_when_enabled(monkeypatch):
     """Default (RUN_MIGRATIONS_ON_STARTUP=true) keeps the auto-migrate behavior."""
     import aegra_api.main as main_module
+    from aegra_api.settings import settings
 
     importlib.reload(main_module)
-    from aegra_api.main import lifespan
-    from aegra_api.settings import settings
 
     monkeypatch.setattr(settings.app, "RUN_MIGRATIONS_ON_STARTUP", True)
 
@@ -164,7 +162,7 @@ async def test_lifespan_runs_migrations_when_enabled(monkeypatch):
         mock_langgraph_service.initialize = AsyncMock()
         mock_get_langgraph_service.return_value = mock_langgraph_service
 
-        async with lifespan(MagicMock()):
+        async with main_module.lifespan(MagicMock()):
             pass
 
         mock_migrations.assert_called_once()

--- a/libs/aegra-api/tests/unit/test_main.py
+++ b/libs/aegra-api/tests/unit/test_main.py
@@ -34,7 +34,6 @@ async def test_lifespan_registers_otel_provider(monkeypatch):
     import aegra_api.main as main_module
 
     importlib.reload(main_module)
-    from aegra_api.main import lifespan
 
     # Mock all the dependencies
     with (
@@ -55,7 +54,7 @@ async def test_lifespan_registers_otel_provider(monkeypatch):
 
         mock_app = MagicMock()
 
-        async with lifespan(mock_app):
+        async with main_module.lifespan(mock_app):
             # Verify OpenTelemetryProvider is registered
             otel_providers = [p for p in manager._providers if isinstance(p, OpenTelemetryProvider)]
             assert len(otel_providers) == 1, "OpenTelemetry provider should be registered during lifespan startup"
@@ -71,7 +70,6 @@ async def test_lifespan_calls_required_initialization():
     import aegra_api.main as main_module
 
     importlib.reload(main_module)
-    from aegra_api.main import lifespan
 
     with (
         patch("aegra_api.main.run_migrations_async", new_callable=AsyncMock) as mock_migrations,
@@ -90,7 +88,7 @@ async def test_lifespan_calls_required_initialization():
         mock_app = MagicMock()
 
         # Run the lifespan function
-        async with lifespan(mock_app):
+        async with main_module.lifespan(mock_app):
             pass
 
         # Verify migrations run first, then initialization

--- a/libs/aegra-api/tests/unit/test_migrations.py
+++ b/libs/aegra-api/tests/unit/test_migrations.py
@@ -265,6 +265,22 @@ class TestIsDatabaseUpToDate:
         ):
             assert _is_database_up_to_date(cfg) is False
 
+    def test_returns_true_when_script_directory_empty(self):
+        """No revisions at all means nothing to apply; skip the upgrade path."""
+        from aegra_api.core.migrations import _is_database_up_to_date
+
+        cfg = MagicMock()
+        script = MagicMock()
+        script.get_current_head.return_value = None
+
+        with (
+            patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
+            patch("aegra_api.core.migrations.create_engine") as mock_create_engine,
+        ):
+            assert _is_database_up_to_date(cfg) is True
+            # Should short-circuit before opening any DB connection.
+            mock_create_engine.assert_not_called()
+
     def test_disposes_engine_on_success_and_failure(self):
         """The short-lived engine must be disposed even when revision lookup fails."""
         from aegra_api.core.migrations import _is_database_up_to_date

--- a/libs/aegra-api/tests/unit/test_migrations.py
+++ b/libs/aegra-api/tests/unit/test_migrations.py
@@ -286,10 +286,7 @@ class TestIsDatabaseUpToDate:
             mock_connect.assert_not_called()
 
     def test_uses_libpq_url_for_multihost_compatibility(self):
-        """The precheck must hand the libpq-style URL straight to psycopg
-        (not through SQLAlchemy's URL parser) so multi-host DATABASE_URL
-        values introduced by PR #299 keep working.
-        """
+        """Precheck hands libpq URL straight to psycopg (multi-host PR #299)."""
         from aegra_api.core.migrations import _is_database_up_to_date
 
         cfg = MagicMock()

--- a/libs/aegra-api/tests/unit/test_migrations.py
+++ b/libs/aegra-api/tests/unit/test_migrations.py
@@ -1,7 +1,7 @@
 """Tests for aegra_api.core.migrations module."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -134,10 +134,155 @@ class TestRunMigrations:
             assert args[0][1] == "head"  # Second positional arg is "head"
 
     @pytest.mark.asyncio
-    async def test_run_migrations_async_runs_in_thread(self):
-        """Should run migrations via asyncio.to_thread."""
+    async def test_run_migrations_async_dispatches_to_lockfree_path(self):
+        """run_migrations_async should hand off to the lock-free helper."""
         with patch("aegra_api.core.migrations.asyncio.to_thread") as mock_to_thread:
-            from aegra_api.core.migrations import run_migrations, run_migrations_async
+            from aegra_api.core.migrations import (
+                run_migrations_async,
+                run_migrations_if_needed,
+            )
 
             await run_migrations_async()
-            mock_to_thread.assert_called_once_with(run_migrations)
+            mock_to_thread.assert_called_once_with(run_migrations_if_needed)
+
+
+class TestRunMigrationsIfNeeded:
+    """Tests for the lock-free fast-path used at FastAPI startup."""
+
+    def _setup_alembic_ini(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "alembic.ini").write_text("[alembic]\nscript_location = alembic\n")
+        (tmp_path / "alembic").mkdir()
+
+    def test_skips_upgrade_when_database_at_head(self, tmp_path, monkeypatch):
+        """When current revision matches head, no upgrade is invoked."""
+        self._setup_alembic_ini(tmp_path, monkeypatch)
+
+        with (
+            patch("aegra_api.core.migrations._is_database_up_to_date", return_value=True) as mock_check,
+            patch("aegra_api.core.migrations.command") as mock_command,
+        ):
+            from aegra_api.core.migrations import run_migrations_if_needed
+
+            run_migrations_if_needed()
+
+            mock_check.assert_called_once()
+            mock_command.upgrade.assert_not_called()
+
+    def test_runs_upgrade_when_database_behind_head(self, tmp_path, monkeypatch):
+        """When the precheck reports drift, upgrade is invoked."""
+        self._setup_alembic_ini(tmp_path, monkeypatch)
+
+        with (
+            patch("aegra_api.core.migrations._is_database_up_to_date", return_value=False),
+            patch("aegra_api.core.migrations.command") as mock_command,
+        ):
+            from aegra_api.core.migrations import run_migrations_if_needed
+
+            run_migrations_if_needed()
+
+            mock_command.upgrade.assert_called_once()
+            assert mock_command.upgrade.call_args[0][1] == "head"
+
+    def test_falls_back_to_upgrade_when_precheck_fails(self, tmp_path, monkeypatch):
+        """If the precheck raises (e.g. alembic_version missing on first install)
+        the upgrade still runs so a fresh database can bootstrap.
+        """
+        self._setup_alembic_ini(tmp_path, monkeypatch)
+
+        with (
+            patch(
+                "aegra_api.core.migrations._is_database_up_to_date",
+                side_effect=RuntimeError("alembic_version table missing"),
+            ),
+            patch("aegra_api.core.migrations.command") as mock_command,
+        ):
+            from aegra_api.core.migrations import run_migrations_if_needed
+
+            run_migrations_if_needed()
+
+            mock_command.upgrade.assert_called_once()
+
+
+class TestIsDatabaseUpToDate:
+    """Tests for the lock-free revision precheck helper."""
+
+    def test_returns_true_when_revisions_match(self):
+        from aegra_api.core.migrations import _is_database_up_to_date
+
+        cfg = MagicMock()
+        engine = MagicMock()
+        connection = MagicMock()
+        engine.connect.return_value.__enter__.return_value = connection
+        ctx = MagicMock()
+        ctx.get_current_revision.return_value = "abc123"
+        script = MagicMock()
+        script.get_current_head.return_value = "abc123"
+
+        with (
+            patch("aegra_api.core.migrations.create_engine", return_value=engine),
+            patch("aegra_api.core.migrations.MigrationContext.configure", return_value=ctx),
+            patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
+        ):
+            assert _is_database_up_to_date(cfg) is True
+
+    def test_returns_false_when_revisions_differ(self):
+        from aegra_api.core.migrations import _is_database_up_to_date
+
+        cfg = MagicMock()
+        engine = MagicMock()
+        connection = MagicMock()
+        engine.connect.return_value.__enter__.return_value = connection
+        ctx = MagicMock()
+        ctx.get_current_revision.return_value = "abc123"
+        script = MagicMock()
+        script.get_current_head.return_value = "def456"
+
+        with (
+            patch("aegra_api.core.migrations.create_engine", return_value=engine),
+            patch("aegra_api.core.migrations.MigrationContext.configure", return_value=ctx),
+            patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
+        ):
+            assert _is_database_up_to_date(cfg) is False
+
+    def test_returns_false_when_no_current_revision(self):
+        """A fresh database with no alembic_version row needs the upgrade path."""
+        from aegra_api.core.migrations import _is_database_up_to_date
+
+        cfg = MagicMock()
+        engine = MagicMock()
+        connection = MagicMock()
+        engine.connect.return_value.__enter__.return_value = connection
+        ctx = MagicMock()
+        ctx.get_current_revision.return_value = None
+        script = MagicMock()
+        script.get_current_head.return_value = "abc123"
+
+        with (
+            patch("aegra_api.core.migrations.create_engine", return_value=engine),
+            patch("aegra_api.core.migrations.MigrationContext.configure", return_value=ctx),
+            patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
+        ):
+            assert _is_database_up_to_date(cfg) is False
+
+    def test_disposes_engine_on_success_and_failure(self):
+        """The short-lived engine must be disposed even when revision lookup fails."""
+        from aegra_api.core.migrations import _is_database_up_to_date
+
+        cfg = MagicMock()
+        engine = MagicMock()
+        connection = MagicMock()
+        engine.connect.return_value.__enter__.return_value = connection
+        engine.connect.return_value.__exit__.return_value = False
+
+        with (
+            patch("aegra_api.core.migrations.create_engine", return_value=engine),
+            patch(
+                "aegra_api.core.migrations.MigrationContext.configure",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=MagicMock()),
+            pytest.raises(RuntimeError),
+        ):
+            _is_database_up_to_date(cfg)
+        engine.dispose.assert_called_once()

--- a/libs/aegra-api/tests/unit/test_migrations.py
+++ b/libs/aegra-api/tests/unit/test_migrations.py
@@ -207,11 +207,24 @@ class TestRunMigrationsIfNeeded:
 class TestIsDatabaseUpToDate:
     """Tests for the lock-free revision precheck helper."""
 
-    def _patch_psycopg(self, current_revision: str | None) -> MagicMock:
-        """Build a `patch` for psycopg.connect that yields a context-managed
-        connection whose MigrationContext returns ``current_revision``.
+    def _patch_psycopg(self, current_revision: str | None, *, raises: Exception | None = None):
+        """Build a context-managed psycopg.connect mock whose cursor returns
+        a single-row alembic_version result of ``current_revision`` (or None
+        when the table is empty). Pass ``raises`` to simulate UndefinedTable.
         """
+        cursor = MagicMock()
+        if raises is not None:
+            cursor.execute.side_effect = raises
+        else:
+            cursor.fetchone.return_value = (current_revision,) if current_revision is not None else None
+
+        cursor_cm = MagicMock()
+        cursor_cm.__enter__.return_value = cursor
+        cursor_cm.__exit__.return_value = False
+
         connection = MagicMock()
+        connection.cursor.return_value = cursor_cm
+
         connect_cm = MagicMock()
         connect_cm.__enter__.return_value = connection
         connect_cm.__exit__.return_value = False
@@ -221,15 +234,12 @@ class TestIsDatabaseUpToDate:
         from aegra_api.core.migrations import _is_database_up_to_date
 
         cfg = MagicMock()
-        connection, connect_cm = self._patch_psycopg("abc123")
-        ctx = MagicMock()
-        ctx.get_current_revision.return_value = "abc123"
+        _, connect_cm = self._patch_psycopg("abc123")
         script = MagicMock()
         script.get_current_head.return_value = "abc123"
 
         with (
             patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
-            patch("aegra_api.core.migrations.MigrationContext.configure", return_value=ctx),
             patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
         ):
             assert _is_database_up_to_date(cfg) is True
@@ -239,14 +249,11 @@ class TestIsDatabaseUpToDate:
 
         cfg = MagicMock()
         _, connect_cm = self._patch_psycopg("abc123")
-        ctx = MagicMock()
-        ctx.get_current_revision.return_value = "abc123"
         script = MagicMock()
         script.get_current_head.return_value = "def456"
 
         with (
             patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
-            patch("aegra_api.core.migrations.MigrationContext.configure", return_value=ctx),
             patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
         ):
             assert _is_database_up_to_date(cfg) is False
@@ -257,14 +264,30 @@ class TestIsDatabaseUpToDate:
 
         cfg = MagicMock()
         _, connect_cm = self._patch_psycopg(None)
-        ctx = MagicMock()
-        ctx.get_current_revision.return_value = None
         script = MagicMock()
         script.get_current_head.return_value = "abc123"
 
         with (
             patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
-            patch("aegra_api.core.migrations.MigrationContext.configure", return_value=ctx),
+            patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
+        ):
+            assert _is_database_up_to_date(cfg) is False
+
+    def test_returns_false_when_alembic_version_table_missing(self):
+        """Fresh install: alembic_version doesn't exist yet. Treat as 'not up to date'
+        so the upgrade path runs and bootstraps the schema.
+        """
+        import psycopg
+
+        from aegra_api.core.migrations import _is_database_up_to_date
+
+        cfg = MagicMock()
+        _, connect_cm = self._patch_psycopg(None, raises=psycopg.errors.UndefinedTable("alembic_version"))
+        script = MagicMock()
+        script.get_current_head.return_value = "abc123"
+
+        with (
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
             patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
         ):
             assert _is_database_up_to_date(cfg) is False
@@ -291,14 +314,11 @@ class TestIsDatabaseUpToDate:
 
         cfg = MagicMock()
         _, connect_cm = self._patch_psycopg("abc123")
-        ctx = MagicMock()
-        ctx.get_current_revision.return_value = "abc123"
         script = MagicMock()
         script.get_current_head.return_value = "abc123"
 
         with (
             patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm) as mock_connect,
-            patch("aegra_api.core.migrations.MigrationContext.configure", return_value=ctx),
             patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
         ):
             _is_database_up_to_date(cfg)

--- a/libs/aegra-api/tests/unit/test_migrations.py
+++ b/libs/aegra-api/tests/unit/test_migrations.py
@@ -207,20 +207,28 @@ class TestRunMigrationsIfNeeded:
 class TestIsDatabaseUpToDate:
     """Tests for the lock-free revision precheck helper."""
 
+    def _patch_psycopg(self, current_revision: str | None) -> MagicMock:
+        """Build a `patch` for psycopg.connect that yields a context-managed
+        connection whose MigrationContext returns ``current_revision``.
+        """
+        connection = MagicMock()
+        connect_cm = MagicMock()
+        connect_cm.__enter__.return_value = connection
+        connect_cm.__exit__.return_value = False
+        return connection, connect_cm
+
     def test_returns_true_when_revisions_match(self):
         from aegra_api.core.migrations import _is_database_up_to_date
 
         cfg = MagicMock()
-        engine = MagicMock()
-        connection = MagicMock()
-        engine.connect.return_value.__enter__.return_value = connection
+        connection, connect_cm = self._patch_psycopg("abc123")
         ctx = MagicMock()
         ctx.get_current_revision.return_value = "abc123"
         script = MagicMock()
         script.get_current_head.return_value = "abc123"
 
         with (
-            patch("aegra_api.core.migrations.create_engine", return_value=engine),
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
             patch("aegra_api.core.migrations.MigrationContext.configure", return_value=ctx),
             patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
         ):
@@ -230,16 +238,14 @@ class TestIsDatabaseUpToDate:
         from aegra_api.core.migrations import _is_database_up_to_date
 
         cfg = MagicMock()
-        engine = MagicMock()
-        connection = MagicMock()
-        engine.connect.return_value.__enter__.return_value = connection
+        _, connect_cm = self._patch_psycopg("abc123")
         ctx = MagicMock()
         ctx.get_current_revision.return_value = "abc123"
         script = MagicMock()
         script.get_current_head.return_value = "def456"
 
         with (
-            patch("aegra_api.core.migrations.create_engine", return_value=engine),
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
             patch("aegra_api.core.migrations.MigrationContext.configure", return_value=ctx),
             patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
         ):
@@ -250,16 +256,14 @@ class TestIsDatabaseUpToDate:
         from aegra_api.core.migrations import _is_database_up_to_date
 
         cfg = MagicMock()
-        engine = MagicMock()
-        connection = MagicMock()
-        engine.connect.return_value.__enter__.return_value = connection
+        _, connect_cm = self._patch_psycopg(None)
         ctx = MagicMock()
         ctx.get_current_revision.return_value = None
         script = MagicMock()
         script.get_current_head.return_value = "abc123"
 
         with (
-            patch("aegra_api.core.migrations.create_engine", return_value=engine),
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
             patch("aegra_api.core.migrations.MigrationContext.configure", return_value=ctx),
             patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
         ):
@@ -275,30 +279,37 @@ class TestIsDatabaseUpToDate:
 
         with (
             patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
-            patch("aegra_api.core.migrations.create_engine") as mock_create_engine,
+            patch("aegra_api.core.migrations.psycopg.connect") as mock_connect,
         ):
             assert _is_database_up_to_date(cfg) is True
             # Should short-circuit before opening any DB connection.
-            mock_create_engine.assert_not_called()
+            mock_connect.assert_not_called()
 
-    def test_disposes_engine_on_success_and_failure(self):
-        """The short-lived engine must be disposed even when revision lookup fails."""
+    def test_uses_libpq_url_for_multihost_compatibility(self):
+        """The precheck must hand the libpq-style URL straight to psycopg
+        (not through SQLAlchemy's URL parser) so multi-host DATABASE_URL
+        values introduced by PR #299 keep working.
+        """
         from aegra_api.core.migrations import _is_database_up_to_date
 
         cfg = MagicMock()
-        engine = MagicMock()
-        connection = MagicMock()
-        engine.connect.return_value.__enter__.return_value = connection
-        engine.connect.return_value.__exit__.return_value = False
+        _, connect_cm = self._patch_psycopg("abc123")
+        ctx = MagicMock()
+        ctx.get_current_revision.return_value = "abc123"
+        script = MagicMock()
+        script.get_current_head.return_value = "abc123"
 
         with (
-            patch("aegra_api.core.migrations.create_engine", return_value=engine),
-            patch(
-                "aegra_api.core.migrations.MigrationContext.configure",
-                side_effect=RuntimeError("boom"),
-            ),
-            patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=MagicMock()),
-            pytest.raises(RuntimeError),
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm) as mock_connect,
+            patch("aegra_api.core.migrations.MigrationContext.configure", return_value=ctx),
+            patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
         ):
             _is_database_up_to_date(cfg)
-        engine.dispose.assert_called_once()
+
+        # Single positional arg, equal to settings.db.database_url_sync, no
+        # SQLAlchemy URL rewrite layered on top.
+        assert mock_connect.call_count == 1
+        passed_url = mock_connect.call_args.args[0]
+        from aegra_api.settings import settings
+
+        assert passed_url == settings.db.database_url_sync

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -383,6 +383,53 @@ class TestMultiHostDatabaseURL:
 
         assert db.database_url == "postgresql+asyncpg:///db?host=h1,h2&port=5432,5432"
 
+    def test_multihost_rewritten_url_parses_with_sqlalchemy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The rewritten asyncpg multi-host URL must be parseable by SQLAlchemy.
+
+        Alembic builds an async engine from this URL via
+        ``async_engine_from_config`` (see ``alembic/env.py``). SQLAlchemy's
+        URL parser does not understand libpq comma-host syntax, so the
+        rewritten query-param form is the only shape it can consume.
+        Locks in the contract so a future "small refactor" cannot quietly
+        feed libpq syntax to SQLAlchemy and silently break HA deployments.
+        """
+        from sqlalchemy.engine.url import make_url
+
+        monkeypatch.setenv(
+            "DATABASE_URL",
+            "postgresql://user:pass@h1:5432,h2:5432/db?target_session_attrs=read-write",
+        )
+
+        db = DatabaseSettings(_env_file=None)
+        url = make_url(db.database_url)
+
+        assert url.drivername == "postgresql+asyncpg"
+        assert url.database == "db"
+        # Multi-host details live in query params, not in url.host.
+        assert url.query["host"] == "h1,h2"
+        assert url.query["port"] == "5432,5432"
+        assert url.query["target_session_attrs"] == "read-write"
+
+    def test_database_url_sync_preserves_libpq_multihost(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``database_url_sync`` must keep the raw libpq multi-host syntax.
+
+        psycopg v3 (LangGraph checkpointer pool, migrations precheck) parses
+        comma-separated hosts natively via libpq. Rewriting into asyncpg
+        query-param form here would break those consumers.
+        """
+        monkeypatch.setenv(
+            "DATABASE_URL",
+            "postgresql://user:pass@h1:5432,h2:5432/db?target_session_attrs=read-write",
+        )
+
+        db = DatabaseSettings(_env_file=None)
+
+        # Raw libpq form: comma-separated hosts in the authority, no
+        # ``host=`` query param rewrite, no async driver suffix.
+        assert "h1:5432,h2:5432" in db.database_url_sync
+        assert "host=" not in db.database_url_sync
+        assert db.database_url_sync.startswith("postgresql://")
+
 
 class TestWorkerSettingsLeaseValidation:
     """Test that lease timing invariants are enforced at startup."""

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -3,6 +3,7 @@
 from urllib.parse import quote_plus
 
 import pytest
+from sqlalchemy.engine import make_url
 
 from aegra_api.settings import AppSettings, DatabaseSettings, WorkerSettings
 
@@ -385,8 +386,6 @@ class TestMultiHostDatabaseURL:
 
     def test_multihost_rewritten_url_parses_with_sqlalchemy(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Asyncpg multi-host URL must parse via SQLAlchemy (alembic env path)."""
-        from sqlalchemy.engine.url import make_url
-
         monkeypatch.setenv(
             "DATABASE_URL",
             "postgresql://user:pass@h1:5432,h2:5432/db?target_session_attrs=read-write",

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -384,15 +384,7 @@ class TestMultiHostDatabaseURL:
         assert db.database_url == "postgresql+asyncpg:///db?host=h1,h2&port=5432,5432"
 
     def test_multihost_rewritten_url_parses_with_sqlalchemy(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The rewritten asyncpg multi-host URL must be parseable by SQLAlchemy.
-
-        Alembic builds an async engine from this URL via
-        ``async_engine_from_config`` (see ``alembic/env.py``). SQLAlchemy's
-        URL parser does not understand libpq comma-host syntax, so the
-        rewritten query-param form is the only shape it can consume.
-        Locks in the contract so a future "small refactor" cannot quietly
-        feed libpq syntax to SQLAlchemy and silently break HA deployments.
-        """
+        """Asyncpg multi-host URL must parse via SQLAlchemy (alembic env path)."""
         from sqlalchemy.engine.url import make_url
 
         monkeypatch.setenv(
@@ -411,12 +403,7 @@ class TestMultiHostDatabaseURL:
         assert url.query["target_session_attrs"] == "read-write"
 
     def test_database_url_sync_preserves_libpq_multihost(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """``database_url_sync`` must keep the raw libpq multi-host syntax.
-
-        psycopg v3 (LangGraph checkpointer pool, migrations precheck) parses
-        comma-separated hosts natively via libpq. Rewriting into asyncpg
-        query-param form here would break those consumers.
-        """
+        """database_url_sync must preserve libpq comma-host syntax (psycopg consumers)."""
         monkeypatch.setenv(
             "DATABASE_URL",
             "postgresql://user:pass@h1:5432,h2:5432/db?target_session_attrs=read-write",

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.7"
+version = "0.9.8"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -17,6 +17,7 @@ from rich.table import Table
 
 from aegra_cli import __version__
 from aegra_cli.commands import init
+from aegra_cli.commands.db import db
 from aegra_cli.env import load_env_file
 from aegra_cli.templates import (
     get_docker_compose,
@@ -760,6 +761,7 @@ def down(compose_file: Path | None, volumes: bool):
 
 # Register command groups and commands from the commands package
 cli.add_command(init)
+cli.add_command(db)
 
 
 def main():

--- a/libs/aegra-cli/src/aegra_cli/commands/db.py
+++ b/libs/aegra-cli/src/aegra_cli/commands/db.py
@@ -1,11 +1,11 @@
-# NOTE: This module is intentionally retained but not registered on the CLI.
-# The db commands were removed in v0.5.x because migrations run automatically
-# on server startup. This file may be re-added when manual migration control
-# is needed (e.g., for rolling deployments with Redis-based worker architecture).
 """Database migration commands for Aegra.
 
 Uses alembic's Python API directly (instead of subprocess) so that
-script_location is resolved relative to the ini file — not the CWD.
+script_location is resolved relative to the ini file, not the CWD.
+
+These commands let operators run migrations out-of-band (init container,
+Helm pre-upgrade Job, scripted deploy) when ``RUN_MIGRATIONS_ON_STARTUP``
+is disabled in multi-pod environments.
 """
 
 import sys

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -6,6 +6,15 @@ DEBUG=true
 # [MANDATORY] Path to the main agent configuration file
 AEGRA_CONFIG=aegra.json
 
+# Migrations
+# Run `alembic upgrade head` automatically on FastAPI startup. The fast
+# path is lock-free when the database is already at head, so this is safe
+# and cheap for dev / single-pod / docker-compose deployments. Set to
+# `false` for multi-pod (Kubernetes) deployments and run migrations
+# out-of-band via `aegra db upgrade` (init container, Helm pre-upgrade
+# Job, etc.). See docs/guides/deployment.mdx.
+# RUN_MIGRATIONS_ON_STARTUP=true
+
 # --- Database ---
 # Option 1: Single connection string (standard for containers/cloud)
 # If your password contains special characters (@, /, #, %, +, etc.),

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -6,13 +6,8 @@ DEBUG=true
 # [MANDATORY] Path to the main agent configuration file
 AEGRA_CONFIG=aegra.json
 
-# Migrations
-# Run `alembic upgrade head` automatically on FastAPI startup. The fast
-# path is lock-free when the database is already at head, so this is safe
-# and cheap for dev / single-pod / docker-compose deployments. Set to
-# `false` for multi-pod (Kubernetes) deployments and run migrations
-# out-of-band via `aegra db upgrade` (init container, Helm pre-upgrade
-# Job, etc.). See docs/guides/deployment.mdx.
+# Auto-run migrations on startup. Set false for multi-pod K8s; run
+# `aegra db upgrade` out-of-band instead. See docs/guides/deployment.mdx.
 # RUN_MIGRATIONS_ON_STARTUP=true
 
 # --- Database ---

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.7"
+version = "0.9.8"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -96,7 +96,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.7"
+version = "0.9.8"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary

Multi-pod deployments (Kubernetes etc.) suffer when every replica boots and tries to run `alembic upgrade head` in parallel. Each pod queues on Alembic's advisory lock and probes time out before startup completes, producing a restart-loop cascade on every release. Reported by Shariq in Discord.

This PR ships two complementary fixes plus the CLI escape hatch needed to use them.

### 1. `RUN_MIGRATIONS_ON_STARTUP` flag

New `AppSettings.RUN_MIGRATIONS_ON_STARTUP: bool = True`. Default keeps current behavior so dev / single-pod / docker-compose users notice nothing. Set to `false` in multi-pod deployments and run migrations out-of-band.

### 2. Lock-free fast path

`run_migrations_if_needed()` first reads the current revision via a short-lived sync engine and compares against the script directory head. If they match — the steady-state case once a release has rolled — it returns without ever acquiring the alembic advisory lock. Falls back to the full upgrade path on first install (no `alembic_version` row yet) or any precheck error.

Net effect on a 10-replica rolling deploy where the schema is already at head: lock-free skip on every pod, ~50ms each instead of 1-2s queueing per pod.

### 3. `aegra db` CLI re-registered

The `aegra db upgrade | downgrade | current | history` group was already in the codebase but unhooked since v0.5.x. Re-registered so operators have a first-class command for out-of-band migrations (init containers, Helm pre-upgrade Jobs, deploy scripts).

## Files

- `libs/aegra-api/src/aegra_api/core/migrations.py` — new `_is_database_up_to_date` helper + `run_migrations_if_needed` fast path. `run_migrations` retained for unconditional/explicit use.
- `libs/aegra-api/src/aegra_api/main.py` — lifespan respects the flag.
- `libs/aegra-api/src/aegra_api/settings.py` — new field with prose explaining when to flip it.
- `libs/aegra-cli/src/aegra_cli/cli.py` + `commands/db.py` — re-register `aegra db` group, drop stale "removed in v0.5.x" comment.
- `.env.example` + CLI scaffold env template — both updated together per CLAUDE.md sync rule.
- `docs/guides/deployment.mdx` — new "Multi-pod (Kubernetes, etc.)" section under Migrations + new troubleshooting accordion for restart-loop on rolling deploy.

## Tests

- `tests/unit/test_migrations.py` — new `TestRunMigrationsIfNeeded` (skip when at head, run on drift, fallback when precheck raises) and `TestIsDatabaseUpToDate` (head match, head mismatch, no current revision, engine.dispose called on failure). Updated existing async-thread test to assert dispatch to the lock-free helper.
- `tests/unit/test_main.py` — two new lifespan tests asserting flag-on still calls migrations and flag-off skips them while keeping the rest of startup intact.
- Full regression: 1208 unit+integration aegra-api tests + 181 aegra-cli tests, all pass.

## Migration path for operators

For Kubernetes deployments hitting the issue today:

\`\`\`bash
# pod env
RUN_MIGRATIONS_ON_STARTUP=false
\`\`\`

Then run once per release via Helm pre-upgrade Job, init container, or CI step:

\`\`\`bash
aegra db upgrade
\`\`\`

Single-pod and docker-compose users don't need to change anything.

## Test plan

- [x] `make lint` clean
- [x] Full unit + integration regression green (1208 + 181)
- [ ] Smoke: run a real `docker compose up` against a clean DB with the flag default-on, verify migrations apply
- [ ] Smoke: re-run with the flag off, verify no migration log lines and that `aegra db upgrade` works against the live DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RUN_MIGRATIONS_ON_STARTUP to toggle automatic DB migrations on startup.
  * Added an aegra db CLI command to run migrations out-of-band.
  * Startup now skips migration work when the database is already at the latest revision to speed startup.

* **Documentation**
  * Expanded deployment guide with Kubernetes multi-pod guidance, troubleshooting for migration lock races, and examples for out-of-band migration workflows.
  * Added commented "Migrations" section to env example and repository DB/migrations guidance.

* **Tests**
  * Added unit tests covering startup migration gating and conditional migration precheck behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `RUN_MIGRATIONS_ON_STARTUP` flag, a lock-free fast-path (`_is_database_up_to_date`) that queries `alembic_version` directly via psycopg to avoid Alembic's advisory lock in steady-state, and re-registers the `aegra db` CLI group for out-of-band migration control. The implementation correctly follows the two-URL CLAUDE.md invariant, previous review issues (MigrationContext bypass, `None` head, stale docstrings) have been addressed, and the test coverage is thorough.

The one outstanding concern from a prior review — `aegra db upgrade --env-file .env` silently ignores the provided env file because `settings` is instantiated at `cli.py` import time before `load_env_file` runs — remains unaddressed in this PR.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the startup migration path; the outstanding `--env-file` P1 from the previous review remains open and should be tracked before `aegra db upgrade --env-file` is relied upon in production.

All previously flagged P1s (MigrationContext AttributeError, None head short-circuit, stale docstrings) were addressed in follow-up commits. The lock-free fast-path implementation correctly follows the two-URL CLAUDE.md invariant and is well-tested. Score is capped at 4 because the known `--env-file` P1 — where `settings` is instantiated before `load_env_file` runs, causing `aegra db upgrade --env-file .env` to silently migrate the wrong database — is still unresolved in this PR.

libs/aegra-cli/src/aegra_cli/commands/db.py — the `--env-file` option has no effect on the database URL due to early `settings` instantiation at import time.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/migrations.py | Adds `_is_database_up_to_date` (queries `alembic_version` directly via psycopg, bypassing MigrationContext and SQLAlchemy URL parsing) and `run_migrations_if_needed` fast path; previous issues all addressed. |
| libs/aegra-cli/src/aegra_cli/commands/db.py | Re-registers `aegra db` CLI group; `--env-file` option still cannot affect `settings.db.database_url` because `settings` is instantiated at module import time before `load_env_file` runs (known P1 flagged in previous review, not yet fixed). |
| libs/aegra-api/src/aegra_api/main.py | Lifespan correctly gates `run_migrations_async()` behind `settings.app.RUN_MIGRATIONS_ON_STARTUP`; stale doc comment was addressed in prior commits. |
| libs/aegra-api/src/aegra_api/settings.py | Adds `RUN_MIGRATIONS_ON_STARTUP: bool = True` with clear inline documentation; default-on preserves backward compatibility. |
| libs/aegra-api/tests/unit/test_migrations.py | Comprehensive new test classes for `_is_database_up_to_date` and `run_migrations_if_needed`, including multi-host URL assertion per CLAUDE.md guidance. |
| libs/aegra-api/tests/unit/test_main.py | Two new lifespan tests verify flag-off skips migrations while keeping rest of startup intact; flag-on asserts `run_migrations_async` is called. |
| libs/aegra-cli/src/aegra_cli/cli.py | Adds `cli.add_command(db)` to re-register the `aegra db` group; import of `db` triggers early `settings` instantiation which undermines `--env-file` in subcommands. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FastAPI as FastAPI lifespan
    participant Settings as settings.app
    participant MIF as run_migrations_if_needed()
    participant IDUD as _is_database_up_to_date()
    participant PG as Postgres (psycopg)
    participant Alembic as alembic command.upgrade

    FastAPI->>Settings: RUN_MIGRATIONS_ON_STARTUP?
    alt false
        Settings-->>FastAPI: skip (log & return)
    else true
        FastAPI->>MIF: run_migrations_if_needed() [via thread]
        MIF->>IDUD: _is_database_up_to_date(cfg)
        IDUD->>IDUD: ScriptDirectory.get_current_head()
        alt head is None (empty scripts)
            IDUD-->>MIF: True (skip)
        else head exists
            IDUD->>PG: psycopg.connect(database_url_sync)
            PG-->>IDUD: connection
            IDUD->>PG: SELECT version_num FROM alembic_version LIMIT 1
            alt UndefinedTable
                PG-->>IDUD: error
                IDUD->>PG: conn.rollback()
                IDUD-->>MIF: False (needs upgrade)
            else row found
                PG-->>IDUD: current_revision
                IDUD-->>MIF: current == head?
            end
        end
        alt already at head
            MIF-->>FastAPI: return (lock-free skip)
        else precheck False or raised
            MIF->>Alembic: command.upgrade(cfg, head)
            Alembic-->>MIF: done
            MIF-->>FastAPI: return
        end
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `libs/aegra-cli/src/aegra_cli/commands/db.py`, line 80-81 ([link](https://github.com/aegra/aegra/blob/7481e168d9bc52cd161559dda908473f74f5644e/libs/aegra-cli/src/aegra_cli/commands/db.py#L80-L81)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`--env-file` cannot affect the database URL — settings are instantiated before `load_env_file` runs**

   When the CLI starts, `cli.py` imports `from aegra_cli.commands.db import db`, which triggers `from aegra_api.core.migrations import get_alembic_config`, which triggers `from aegra_api.settings import settings`. That instantiates the pydantic-settings singleton — reading `DATABASE_URL` from `os.environ` at that moment.

   Only afterward does the `db` group callback call `load_env_file`, which puts the `.env` values into `os.environ`. But `settings.db.database_url` (and `database_url_sync`) are already computed and immutable.

   Downstream, `alembic/env.py` line 22 reads `config.set_main_option("sqlalchemy.url", settings.db.database_url)` — that value was baked in at CLI startup, so `aegra db upgrade --env-file .env` silently migrates the wrong database (typically the default `postgres:postgres@localhost/postgres`) whenever `DATABASE_URL` lives only in the `.env` file — the exact scenario the `--env-file` option is advertised for (CI steps, scripted deploys).

   The `aegra dev` / `aegra serve` commands sidestep this because they launch uvicorn as a subprocess after `load_env_file`, so the child process inherits the updated environment. The `db` commands call Python APIs inline and do not get that benefit.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-cli%2Fsrc%2Faegra_cli%2Fcommands%2Fdb.py%0ALine%3A%2080-81%0A%0AComment%3A%0A**%60--env-file%60%20cannot%20affect%20the%20database%20URL%20%E2%80%94%20settings%20are%20instantiated%20before%20%60load_env_file%60%20runs**%0A%0AWhen%20the%20CLI%20starts%2C%20%60cli.py%60%20imports%20%60from%20aegra_cli.commands.db%20import%20db%60%2C%20which%20triggers%20%60from%20aegra_api.core.migrations%20import%20get_alembic_config%60%2C%20which%20triggers%20%60from%20aegra_api.settings%20import%20settings%60.%20That%20instantiates%20the%20pydantic-settings%20singleton%20%E2%80%94%20reading%20%60DATABASE_URL%60%20from%20%60os.environ%60%20at%20that%20moment.%0A%0AOnly%20afterward%20does%20the%20%60db%60%20group%20callback%20call%20%60load_env_file%60%2C%20which%20puts%20the%20%60.env%60%20values%20into%20%60os.environ%60.%20But%20%60settings.db.database_url%60%20%28and%20%60database_url_sync%60%29%20are%20already%20computed%20and%20immutable.%0A%0ADownstream%2C%20%60alembic%2Fenv.py%60%20line%2022%20reads%20%60config.set_main_option%28%22sqlalchemy.url%22%2C%20settings.db.database_url%29%60%20%E2%80%94%20that%20value%20was%20baked%20in%20at%20CLI%20startup%2C%20so%20%60aegra%20db%20upgrade%20--env-file%20.env%60%20silently%20migrates%20the%20wrong%20database%20%28typically%20the%20default%20%60postgres%3Apostgres%40localhost%2Fpostgres%60%29%20whenever%20%60DATABASE_URL%60%20lives%20only%20in%20the%20%60.env%60%20file%20%E2%80%94%20the%20exact%20scenario%20the%20%60--env-file%60%20option%20is%20advertised%20for%20%28CI%20steps%2C%20scripted%20deploys%29.%0A%0AThe%20%60aegra%20dev%60%20%2F%20%60aegra%20serve%60%20commands%20sidestep%20this%20because%20they%20launch%20uvicorn%20as%20a%20subprocess%20after%20%60load_env_file%60%2C%20so%20the%20child%20process%20inherits%20the%20updated%20environment.%20The%20%60db%60%20commands%20call%20Python%20APIs%20inline%20and%20do%20not%20get%20that%20benefit.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-cli%2Fsrc%2Faegra_cli%2Fcommands%2Fdb.py%0ALine%3A%2080-81%0A%0AComment%3A%0A**%60--env-file%60%20cannot%20affect%20the%20database%20URL%20%E2%80%94%20settings%20are%20instantiated%20before%20%60load_env_file%60%20runs**%0A%0AWhen%20the%20CLI%20starts%2C%20%60cli.py%60%20imports%20%60from%20aegra_cli.commands.db%20import%20db%60%2C%20which%20triggers%20%60from%20aegra_api.core.migrations%20import%20get_alembic_config%60%2C%20which%20triggers%20%60from%20aegra_api.settings%20import%20settings%60.%20That%20instantiates%20the%20pydantic-settings%20singleton%20%E2%80%94%20reading%20%60DATABASE_URL%60%20from%20%60os.environ%60%20at%20that%20moment.%0A%0AOnly%20afterward%20does%20the%20%60db%60%20group%20callback%20call%20%60load_env_file%60%2C%20which%20puts%20the%20%60.env%60%20values%20into%20%60os.environ%60.%20But%20%60settings.db.database_url%60%20%28and%20%60database_url_sync%60%29%20are%20already%20computed%20and%20immutable.%0A%0ADownstream%2C%20%60alembic%2Fenv.py%60%20line%2022%20reads%20%60config.set_main_option%28%22sqlalchemy.url%22%2C%20settings.db.database_url%29%60%20%E2%80%94%20that%20value%20was%20baked%20in%20at%20CLI%20startup%2C%20so%20%60aegra%20db%20upgrade%20--env-file%20.env%60%20silently%20migrates%20the%20wrong%20database%20%28typically%20the%20default%20%60postgres%3Apostgres%40localhost%2Fpostgres%60%29%20whenever%20%60DATABASE_URL%60%20lives%20only%20in%20the%20%60.env%60%20file%20%E2%80%94%20the%20exact%20scenario%20the%20%60--env-file%60%20option%20is%20advertised%20for%20%28CI%20steps%2C%20scripted%20deploys%29.%0A%0AThe%20%60aegra%20dev%60%20%2F%20%60aegra%20serve%60%20commands%20sidestep%20this%20because%20they%20launch%20uvicorn%20as%20a%20subprocess%20after%20%60load_env_file%60%2C%20so%20the%20child%20process%20inherits%20the%20updated%20environment.%20The%20%60db%60%20commands%20call%20Python%20APIs%20inline%20and%20do%20not%20get%20that%20benefit.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fdisable-startup-migrations%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fdisable-startup-migrations%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-cli%2Fsrc%2Faegra_cli%2Fcommands%2Fdb.py%0ALine%3A%2080-81%0A%0AComment%3A%0A**%60--env-file%60%20cannot%20affect%20the%20database%20URL%20%E2%80%94%20settings%20are%20instantiated%20before%20%60load_env_file%60%20runs**%0A%0AWhen%20the%20CLI%20starts%2C%20%60cli.py%60%20imports%20%60from%20aegra_cli.commands.db%20import%20db%60%2C%20which%20triggers%20%60from%20aegra_api.core.migrations%20import%20get_alembic_config%60%2C%20which%20triggers%20%60from%20aegra_api.settings%20import%20settings%60.%20That%20instantiates%20the%20pydantic-settings%20singleton%20%E2%80%94%20reading%20%60DATABASE_URL%60%20from%20%60os.environ%60%20at%20that%20moment.%0A%0AOnly%20afterward%20does%20the%20%60db%60%20group%20callback%20call%20%60load_env_file%60%2C%20which%20puts%20the%20%60.env%60%20values%20into%20%60os.environ%60.%20But%20%60settings.db.database_url%60%20%28and%20%60database_url_sync%60%29%20are%20already%20computed%20and%20immutable.%0A%0ADownstream%2C%20%60alembic%2Fenv.py%60%20line%2022%20reads%20%60config.set_main_option%28%22sqlalchemy.url%22%2C%20settings.db.database_url%29%60%20%E2%80%94%20that%20value%20was%20baked%20in%20at%20CLI%20startup%2C%20so%20%60aegra%20db%20upgrade%20--env-file%20.env%60%20silently%20migrates%20the%20wrong%20database%20%28typically%20the%20default%20%60postgres%3Apostgres%40localhost%2Fpostgres%60%29%20whenever%20%60DATABASE_URL%60%20lives%20only%20in%20the%20%60.env%60%20file%20%E2%80%94%20the%20exact%20scenario%20the%20%60--env-file%60%20option%20is%20advertised%20for%20%28CI%20steps%2C%20scripted%20deploys%29.%0A%0AThe%20%60aegra%20dev%60%20%2F%20%60aegra%20serve%60%20commands%20sidestep%20this%20because%20they%20launch%20uvicorn%20as%20a%20subprocess%20after%20%60load_env_file%60%2C%20so%20the%20child%20process%20inherits%20the%20updated%20environment.%20The%20%60db%60%20commands%20call%20Python%20APIs%20inline%20and%20do%20not%20get%20that%20benefit.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["chore: bump version to 0.9.8"](https://github.com/aegra/aegra/commit/3e0854816c4a357774ac2f1f1c112647fe790dd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30596436)</sub>

<!-- /greptile_comment -->