### PR TITLE
fix(cli): aegra db ignores project .env (broken in 0.9.8)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.8"
+    "version": "0.9.9"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.8"
+version = "0.9.9"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.8"
+version = "0.9.9"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/src/aegra_cli/commands/db.py
+++ b/libs/aegra-cli/src/aegra_cli/commands/db.py
@@ -6,6 +6,14 @@ script_location is resolved relative to the ini file, not the CWD.
 These commands let operators run migrations out-of-band (init container,
 Helm pre-upgrade Job, scripted deploy) when ``RUN_MIGRATIONS_ON_STARTUP``
 is disabled in multi-pod environments.
+
+Import-order note: ``aegra_api.*`` is imported inside each subcommand
+callback, not at module top. The ``db`` group's callback runs
+``load_env_file`` before any subcommand callback fires, so deferring the
+import lets ``aegra_api.settings`` read the freshly populated
+``os.environ`` instead of the empty pre-CLI env. Top-level imports here
+would freeze ``settings`` to defaults before the user's .env loads,
+breaking ``aegra db <cmd>`` against any non-default database.
 """
 
 import sys
@@ -15,12 +23,8 @@ from pathlib import Path
 
 import click
 import structlog
-from aegra_api.core.migrations import get_alembic_config
-from alembic import command
-from alembic.util import CommandError
 from rich.console import Console
 from rich.panel import Panel
-from sqlalchemy.exc import SQLAlchemyError
 
 from aegra_cli.env import load_env_file
 
@@ -43,6 +47,11 @@ def _run_alembic(
         success_msg: Message to display on success
         error_prefix: Prefix for error message
     """
+    # Imported here (not at module top) so this module can be imported
+    # before .env loads — see import-order note in module docstring.
+    from alembic.util import CommandError
+    from sqlalchemy.exc import SQLAlchemyError
+
     try:
         fn()
         console.print(f"\n[bold green]{success_msg}[/bold green]")
@@ -100,6 +109,9 @@ def upgrade() -> None:
         )
     )
 
+    from aegra_api.core.migrations import get_alembic_config
+    from alembic import command
+
     cfg = get_alembic_config()
 
     def run() -> None:
@@ -146,6 +158,9 @@ def downgrade(revision: str) -> None:
     if revision == "base":
         console.print("[yellow]Warning:[/yellow] Downgrading to 'base' will remove all migrations!")
 
+    from aegra_api.core.migrations import get_alembic_config
+    from alembic import command
+
     cfg = get_alembic_config()
 
     def run() -> None:
@@ -177,6 +192,9 @@ def current() -> None:
             border_style="cyan",
         )
     )
+
+    from aegra_api.core.migrations import get_alembic_config
+    from alembic import command
 
     cfg = get_alembic_config()
     # Capture alembic output to stdout
@@ -223,6 +241,9 @@ def history(verbose: bool) -> None:
             border_style="cyan",
         )
     )
+
+    from aegra_api.core.migrations import get_alembic_config
+    from alembic import command
 
     cfg = get_alembic_config()
     output = StringIO()

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.8"
+version = "0.9.9"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -96,7 +96,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.8"
+version = "0.9.9"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary

`aegra db current/upgrade/downgrade/history` (re-registered in #344, shipped in 0.9.8) ignores the project `.env` and connects with default `postgres@localhost:5432/aegra`. Every non-default deployment hits `InvalidPasswordError` immediately.

## Root cause

Module load order:

1. `aegra_cli.cli` import → `from aegra_cli.commands.db import db`
2. `db.py` top-level → `from aegra_api.core.migrations import get_alembic_config`
3. `migrations.py` → `from aegra_api.settings import settings`
4. `settings.py` → `settings = Settings()` reads from **empty** `os.environ`
5. Click parses argv, runs `db()` group callback → `load_env_file(...)` populates `os.environ`
6. Subcommand callback fires → alembic uses `settings.db.database_url` → **frozen value from step 4**

`aegra dev` / `aegra serve` don't hit this because uvicorn/docker load `.env` before Python imports anything.

## Fix

Move `from aegra_api.core.migrations import get_alembic_config` and `from alembic import command` from db.py top-level into each subcommand body. Group callback loads `.env` → subcommand callback fires → import cascades → settings reads populated `os.environ`.

`-e/--env-file` flag still works (no argv hacks). Module docstring documents why the imports are deferred.

## Verification

End-to-end against a fresh `aegra init` project + local wheel:
- `aegra db current` → `b7c8d9e0f123 (head)` (was: `InvalidPasswordError`)
- `aegra db upgrade` → applies pending migrations
- `aegra db downgrade -- -1` + re-run precheck: returns `False` → upgrade fires → returns `True`
- `aegra db history` → full chain

181 cli tests + 942 api unit tests pass. Ruff clean.

## Versioning

Bumps to **0.9.9** since 0.9.8 shipped this regression. Constraint `aegra-api~=0.9.0` already covers it.

## Test plan

- [x] Unit tests pass (`make test`)
- [x] Lint clean (`make lint`)
- [x] E2E verified against fresh project + published 0.9.8 + local wheel of this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 0.9.9 across API and CLI packages and documentation.

* **Refactor**
  * Optimized import handling in CLI database commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression introduced in 0.9.8 where `aegra db` subcommands ignored the project `.env` file and connected with default credentials. The fix defers `aegra_api.*` imports from module top-level into each subcommand callback body, ensuring `load_env_file` in the `db` group callback populates `os.environ` before `aegra_api.settings.Settings()` is instantiated. Version is bumped to 0.9.9 across both packages and lockfile.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the deferred-import fix is correct and directly addresses the regression. No P0 or P1 issues found.

The root cause analysis in the PR description matches the fix exactly. Deferring the import chain to inside subcommand callbacks is the right solution; Python's module cache ensures `Settings()` only runs once and after `.env` is loaded. Only P2-level observations exist. Score is 4 rather than 5 because this is a regression fix that touches runtime import order — a subtle area worth extra care.

libs/aegra-cli/src/aegra_cli/commands/db.py — only file with logic changes; everything else is version bookkeeping.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-cli/src/aegra_cli/commands/db.py | Core fix: defers `get_alembic_config`, `command`, `CommandError`, and `SQLAlchemyError` imports into subcommand/helper bodies so settings are read after `.env` loads. Logic is correct and well-documented. |
| libs/aegra-api/pyproject.toml | Version bump from 0.9.8 → 0.9.9 only. |
| libs/aegra-cli/pyproject.toml | Version bump from 0.9.8 → 0.9.9 only. |
| docs/openapi.json | Version string updated from 0.9.8 → 0.9.9 in OpenAPI info block. |
| uv.lock | Lockfile updated to reflect 0.9.9 versions for both aegra-api and aegra-cli. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as aegra_cli.cli
    participant DB as commands/db.py
    participant ENV as load_env_file
    participant MIG as aegra_api.core.migrations
    participant SET as aegra_api.settings

    note over CLI,SET: ❌ Before fix (0.9.8)
    CLI->>DB: import db (module load)
    DB->>MIG: import get_alembic_config (top-level)
    MIG->>SET: import settings
    SET-->>SET: Settings() → reads empty os.environ → frozen defaults
    CLI->>ENV: db() group callback → load_env_file()
    ENV-->>ENV: os.environ populated (too late)
    CLI->>DB: subcommand callback fires
    DB-->>SET: settings.db.database_url → frozen default → InvalidPasswordError

    note over CLI,SET: ✅ After fix (0.9.9)
    CLI->>DB: import db (module load)
    note right of DB: no aegra_api.* imported here
    CLI->>ENV: db() group callback → load_env_file()
    ENV-->>ENV: os.environ populated ✓
    CLI->>DB: subcommand callback fires
    DB->>MIG: import get_alembic_config (deferred)
    MIG->>SET: import settings
    SET-->>SET: Settings() → reads populated os.environ ✓
    DB-->>CLI: alembic uses correct DATABASE_URL
```

<sub>Reviews (1): Last reviewed commit: ["fix(cli): defer aegra\_api imports in \`ae..."](https://github.com/aegra/aegra/commit/e4a7252609e26c67c4b4d6b4a330ba876927653e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30600932)</sub>

<!-- /greptile_comment -->