### PR TITLE
fix: checkpoint-fork follow-ups + bump 0.9.10

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,12 @@ def process(items): ...
 - Use absolute imports with `aegra_api.*` prefix.
 - **ALWAYS place imports at the top of the file.** Never use inline/lazy imports inside functions unless there is a **proven circular dependency** (confirmed by actual `ImportError`) or the import is from an **optional dependency** that may not be installed (wrapped in `try/except ImportError`). "Might be slow" or "only used here" are NOT valid reasons for inline imports. If unsure, put it at the top — only move inline after confirming the import cycle with an actual error.
 
+### Code Comments (STRICT)
+- **Max 2 lines per comment. 3 only when truly unavoidable.** If you can't say it in 2 lines, the code is the wrong shape or you're over-explaining. Delete the comment, rename a variable, or split the function.
+- Comments answer **why** the code exists or **why this weird shape**. They never restate what the code obviously does, narrate history ("previously X, now Y"), or apologize. Git blame holds the history.
+- No JSDoc/docstring filler on self-describing names. The signature IS the doc.
+- Optimize for future readers grepping for intent, not for narrative.
+
 ### Linter Suppressions (`noqa`, `type: ignore`)
 - **NEVER suppress a lint warning when the underlying issue can be fixed.** `# noqa: F401` on a dead re-export means you should delete the re-export and fix the importers. `# type: ignore` on a type mismatch means you should fix the types.
 - Suppressions are **only acceptable** when:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.9"
+    "version": "0.9.10"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.9"
+version = "0.9.10"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -438,7 +438,17 @@ async def update_thread_state(
     any state change — used to anchor a subsequent run as a fork of that
     checkpoint rather than of the thread's latest state.
     """
-    if request.values is None and request.as_node is None:
+    # Short-circuit to GET semantics ONLY when the body carries no
+    # mutation intent AND no checkpoint targeting. A body-only checkpoint
+    # field (checkpoint_id / checkpoint) MUST flow through to the update
+    # path so the caller's selected checkpoint is honored — otherwise
+    # the GET shim reads query params and silently drops the body fields.
+    if (
+        request.values is None
+        and request.as_node is None
+        and request.checkpoint_id is None
+        and not request.checkpoint
+    ):
         return await get_thread_state(
             thread_id=thread_id,
             subgraphs=request.subgraphs or False,

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -438,11 +438,7 @@ async def update_thread_state(
     any state change — used to anchor a subsequent run as a fork of that
     checkpoint rather than of the thread's latest state.
     """
-    # Short-circuit to GET semantics ONLY when the body carries no
-    # mutation intent AND no checkpoint targeting. A body-only checkpoint
-    # field (checkpoint_id / checkpoint) MUST flow through to the update
-    # path so the caller's selected checkpoint is honored — otherwise
-    # the GET shim reads query params and silently drops the body fields.
+    # GET-shim only fires when body has no mutation or checkpoint targeting.
     if request.values is None and request.as_node is None and request.checkpoint_id is None and not request.checkpoint:
         return await get_thread_state(
             thread_id=thread_id,

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -443,12 +443,7 @@ async def update_thread_state(
     # field (checkpoint_id / checkpoint) MUST flow through to the update
     # path so the caller's selected checkpoint is honored — otherwise
     # the GET shim reads query params and silently drops the body fields.
-    if (
-        request.values is None
-        and request.as_node is None
-        and request.checkpoint_id is None
-        and not request.checkpoint
-    ):
+    if request.values is None and request.as_node is None and request.checkpoint_id is None and not request.checkpoint:
         return await get_thread_state(
             thread_id=thread_id,
             subgraphs=request.subgraphs or False,

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -82,7 +82,7 @@ class RunCreate(BaseModel):
         # Checkpoint-only resume keeps input=None so Pregel resumes from next=[...]
         # instead of restarting from __start__ with an empty input.
         if self.input is None and self.command is None and self.checkpoint is None:
-            raise ValueError("Must specify either 'input' or 'command'")
+            raise ValueError("Must specify at least one of 'input', 'command', or 'checkpoint'")
         return self
 
 

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -72,22 +72,17 @@ class RunCreate(BaseModel):
 
     @model_validator(mode="after")
     def validate_input_command_exclusivity(self) -> Self:
-        """Ensure input and command are mutually exclusive"""
-        # Allow empty input dict when command is present (frontend compatibility)
+        """Ensure input and command are mutually exclusive."""
+        # Empty input dict alongside command: drop it for frontend compatibility.
         if self.input is not None and self.command is not None:
-            # If input is just an empty dict, treat it as None for compatibility
             if self.input == {}:
                 self.input = None
             else:
                 raise ValueError("Cannot specify both 'input' and 'command' - they are mutually exclusive")
-        if self.input is None and self.command is None:
-            if self.checkpoint is not None:
-                # Keep input as None so LangGraph resumes from the checkpoint.
-                # Coercing to {} makes Pregel treat it as fresh input and restart
-                # from __start__ instead of continuing from next=[...].
-                pass
-            else:
-                raise ValueError("Must specify either 'input' or 'command'")
+        # Checkpoint-only resume keeps input=None so Pregel resumes from next=[...]
+        # instead of restarting from __start__ with an empty input.
+        if self.input is None and self.command is None and self.checkpoint is None:
+            raise ValueError("Must specify either 'input' or 'command'")
         return self
 
 

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -256,7 +256,7 @@ async def _prepare_run(
         thread_id=thread_id,
         assistant_id=resolved_assistant_id,
         status=initial_status,
-        input=request.input or {},
+        input=request.input,  # preserve None for checkpoint-only resume; matches RunExecution.input_data
         config=config,
         context=context,
         user_id=user.identity,

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -766,6 +766,45 @@ class TestThreadUpdateState:
             assert values is None
             assert cfg["configurable"]["checkpoint_id"] == "body-cp"
 
+    def test_update_state_body_checkpoint_dict_routes_to_update_path(self):
+        """Same as above but exercises the `checkpoint` dict variant of the gate.
+
+        The gate guards both `checkpoint_id` and `checkpoint` body fields.
+        Covering only one half could let the other regress silently.
+        """
+        app = create_test_app(include_runs=False, include_threads=True)
+        thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt):
+                return thread
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        mock_agent = AsyncMock()
+        mock_agent.aupdate_state.return_value = {"configurable": {"checkpoint_id": "new-cp", "checkpoint_ns": ""}}
+        mock_agent.with_config = Mock(return_value=mock_agent)
+
+        with patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_get_service:
+            mock_service = mock_get_service.return_value
+            mock_service.get_graph = create_get_graph_mock(return_value=mock_agent)
+
+            resp = client.post(
+                "/threads/test-123/state",
+                json={
+                    "values": None,
+                    "as_node": None,
+                    "checkpoint": {"checkpoint_id": "body-cp", "checkpoint_ns": ""},
+                },
+            )
+
+            assert resp.status_code == 200
+            mock_agent.aupdate_state.assert_called_once()
+            cfg, values, *_ = mock_agent.aupdate_state.call_args[0]
+            assert values is None
+            assert cfg["configurable"]["checkpoint_id"] == "body-cp"
+
 
 class TestThreadStateCheckpoint:
     """Test GET /threads/{thread_id}/state/{checkpoint_id} endpoint"""

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -728,15 +728,8 @@ class TestThreadUpdateState:
             assert mock_agent.aupdate_state.call_args[1]["as_node"] == "__copy__"
 
     def test_update_state_body_checkpoint_id_routes_to_update_path(self):
-        """values=None + as_node=None + checkpoint_id must NOT short-circuit to GET.
-
-        Regression test: a body-only checkpoint targeting payload
-        (without values or as_node) used to fall through the GET-shim
-        gate, which reads query params and ignores body checkpoint
-        fields. The caller's selected checkpoint was silently dropped.
-        Now the gate also checks checkpoint_id / checkpoint, so the
-        request flows to aupdate_state with the body checkpoint honored.
-        """
+        """Body-only checkpoint_id must flow to aupdate_state, not the GET shim
+        which reads query params and would silently drop the body field."""
         app = create_test_app(include_runs=False, include_threads=True)
         thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
 
@@ -767,11 +760,8 @@ class TestThreadUpdateState:
             assert cfg["configurable"]["checkpoint_id"] == "body-cp"
 
     def test_update_state_body_checkpoint_dict_routes_to_update_path(self):
-        """Same as above but exercises the `checkpoint` dict variant of the gate.
-
-        The gate guards both `checkpoint_id` and `checkpoint` body fields.
-        Covering only one half could let the other regress silently.
-        """
+        """Mirror of the checkpoint_id case for the `checkpoint` dict variant
+        so neither half of the gate condition can regress silently."""
         app = create_test_app(include_runs=False, include_threads=True)
         thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
 

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -727,7 +727,6 @@ class TestThreadUpdateState:
             assert cfg["configurable"]["checkpoint_id"] == "original-cp"
             assert mock_agent.aupdate_state.call_args[1]["as_node"] == "__copy__"
 
-
     def test_update_state_body_checkpoint_id_routes_to_update_path(self):
         """values=None + as_node=None + checkpoint_id must NOT short-circuit to GET.
 

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -728,6 +728,46 @@ class TestThreadUpdateState:
             assert mock_agent.aupdate_state.call_args[1]["as_node"] == "__copy__"
 
 
+    def test_update_state_body_checkpoint_id_routes_to_update_path(self):
+        """values=None + as_node=None + checkpoint_id must NOT short-circuit to GET.
+
+        Regression test: a body-only checkpoint targeting payload
+        (without values or as_node) used to fall through the GET-shim
+        gate, which reads query params and ignores body checkpoint
+        fields. The caller's selected checkpoint was silently dropped.
+        Now the gate also checks checkpoint_id / checkpoint, so the
+        request flows to aupdate_state with the body checkpoint honored.
+        """
+        app = create_test_app(include_runs=False, include_threads=True)
+        thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt):
+                return thread
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        mock_agent = AsyncMock()
+        mock_agent.aupdate_state.return_value = {"configurable": {"checkpoint_id": "new-cp", "checkpoint_ns": ""}}
+        mock_agent.with_config = Mock(return_value=mock_agent)
+
+        with patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_get_service:
+            mock_service = mock_get_service.return_value
+            mock_service.get_graph = create_get_graph_mock(return_value=mock_agent)
+
+            resp = client.post(
+                "/threads/test-123/state",
+                json={"values": None, "as_node": None, "checkpoint_id": "body-cp"},
+            )
+
+            assert resp.status_code == 200
+            mock_agent.aupdate_state.assert_called_once()
+            cfg, values, *_ = mock_agent.aupdate_state.call_args[0]
+            assert values is None
+            assert cfg["configurable"]["checkpoint_id"] == "body-cp"
+
+
 class TestThreadStateCheckpoint:
     """Test GET /threads/{thread_id}/state/{checkpoint_id} endpoint"""
 

--- a/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
@@ -27,5 +27,5 @@ class TestRunCreateValidation:
 
     def test_rejects_payload_without_input_command_or_checkpoint(self):
         """Ensure payloads with no input, command, or checkpoint are rejected."""
-        with pytest.raises(ValueError, match="Must specify either 'input' or 'command'"):
+        with pytest.raises(ValueError, match="Must specify at least one of 'input', 'command', or 'checkpoint'"):
             RunCreate(assistant_id="agent")

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.9"
+version = "0.9.10"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.9"
+version = "0.9.10"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -96,7 +96,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.9"
+version = "0.9.10"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary

Three small follow-ups from PR #321 review plus version bump to 0.9.10.

- **Tighten POST /threads/{id}/state gate.** Body-only checkpoint targeting payload (`{values: null, as_node: null, checkpoint_id: X}`) used to fall through the GET-shim and silently drop the body checkpoint, since `get_thread_state` reads query params. Now the gate also checks `checkpoint_id` and `checkpoint`, so body-only checkpoint requests flow to `aupdate_state` with the supplied checkpoint honored.
- **Align None handling in run_preparation.py.** `RunORM.input` column was still coerced to `{}` while sibling `RunExecution.input_data` correctly preserved None. Now both store None for checkpoint-only resumes. Stops forensic confusion where `execution_params` shows `null` while the `runs.input` column shows `{}` for the same row.
- **Drop dead `pass`-branch in RunCreate validator.** Replaced the if/else with a single guard clause checking input + command + checkpoint all None.

Bumps `aegra-api` and `aegra-cli` to 0.9.10. Patch bump (additive cleanup, no behavior change beyond the gate-tightening, which only makes a previously-broken request shape work).

## Test plan

- [x] `uv run --package aegra-api python -m pytest libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py libs/aegra-api/tests/integration/test_api/test_threads_crud.py` (51 passed)
- [x] `uv run ruff check libs/aegra-api/src libs/aegra-api/tests` (clean)
- [x] Regression test added for tightened gate path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve checkpoint selection when updating thread state; require at least one of input, command, or checkpoint when creating runs; preserve None input for checkpoint-only resume.

* **Tests**
  * Added integration tests for checkpoint routing on thread state updates and unit test expecting the expanded run-creation validation.

* **Documentation**
  * Added strict code comment guidelines.

* **Chores**
  * Version and OpenAPI metadata bumped to 0.9.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers three targeted follow-ups to checkpoint-fork support: tightening the POST `/threads/{id}/state` GET-shim gate to honour body-only `checkpoint_id`/`checkpoint` fields, preserving `None` in `RunORM.input` for checkpoint-only resumes, and simplifying the `RunCreate` guard clause. The logic changes are correct and the new regression tests cover both gate branches.

**Heads-up:** the `Run.input` field at line 103 of `models/runs.py` is still typed `dict[str, Any] = Field(...)` (non-nullable). `run_preparation.py` now stores `None` there for checkpoint-only runs, so `Run.model_validate(run_orm)` at line 272 will raise a Pydantic `ValidationError` for every checkpoint-only resume — this was flagged in the previous review and remains unaddressed in this PR.

<h3>Confidence Score: 3/5</h3>

Not safe to merge while `Run.input` remains non-nullable — every checkpoint-only resume will 500 on `Run.model_validate(run_orm)`.

The gate-tightening and validator simplification are correct, but the pre-existing P1 flagged in the prior review (`Run.input: dict[str, Any] = Field(...)` at line 103) is still unresolved. `run_preparation.py` now stores `None` in `RunORM.input`, making the ValidationError on `Run.model_validate(run_orm)` a guaranteed runtime failure for every checkpoint-only resume path this PR is intended to fix.

libs/aegra-api/src/aegra_api/models/runs.py — `Run.input` field must be made nullable (`dict[str, Any] | None = Field(None, ...)`) before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/models/runs.py | Validator simplified to a clean guard clause. However, `Run.input` (line 103) remains `dict[str, Any] = Field(...)` (non-nullable), which will cause a Pydantic ValidationError when `model_validate` is called with None — flagged in the prior review, still unresolved. |
| libs/aegra-api/src/aegra_api/services/run_preparation.py | Single-line change from `request.input or {}` to `request.input` preserves None correctly for checkpoint-only resumes; aligns with RunExecution.input_data. |
| libs/aegra-api/src/aegra_api/api/threads.py | Gate condition extended with `checkpoint_id is None and not request.checkpoint` — correctly prevents body-only checkpoint requests from hitting the GET shim. |
| libs/aegra-api/tests/integration/test_api/test_threads_crud.py | Two new regression tests added: one for the `checkpoint_id` string path and one for the `checkpoint` dict path, covering both halves of the tightened gate condition. |
| libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py | Error message string updated to match the new consolidated guard clause — straightforward sync. |
| CLAUDE.md | New strict code-comment guidelines added (max 2 lines, why not what, no docstring filler). |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["POST /threads/{id}/state"] --> B{values is None\nAND as_node is None\nAND checkpoint_id is None\nAND NOT checkpoint?}
    B -- "Yes (GET-shim)" --> C["get_thread_state()\n(reads query params)"]
    B -- "No (mutation/targeting)" --> D[Build configurable config]
    D --> E{checkpoint_id\npresent?}
    E -- Yes --> F["config.configurable\n['checkpoint_id'] = request.checkpoint_id"]
    E -- No --> G{checkpoint dict\npresent?}
    F --> G
    G -- Yes --> H["config.configurable\n.update(request.checkpoint)"]
    G -- No --> I[aupdate_state\nvalues, as_node]
    H --> I
    I --> J[ThreadStateUpdateResponse]
    C --> K[ThreadState]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `libs/aegra-api/src/aegra_api/models/runs.py`, line 103 ([link](https://github.com/aegra/aegra/blob/b493b1012a54135fd42007f102057aa2f58e1e51/libs/aegra-api/src/aegra_api/models/runs.py#L103)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`Run.input` rejects `None`, breaking checkpoint-only resumes**

   `Run.input` is typed `dict[str, Any]` (non-nullable), but `run_preparation.py` now stores `None` for checkpoint-only runs. `Run.model_validate(run_orm)` at line 272 of `run_preparation.py` will raise a Pydantic validation error for any checkpoint-only resume, turning every such request into a 500.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fruns.py%0ALine%3A%20103%0A%0AComment%3A%0A**%60Run.input%60%20rejects%20%60None%60%2C%20breaking%20checkpoint-only%20resumes**%0A%0A%60Run.input%60%20is%20typed%20%60dict%5Bstr%2C%20Any%5D%60%20%28non-nullable%29%2C%20but%20%60run_preparation.py%60%20now%20stores%20%60None%60%20for%20checkpoint-only%20runs.%20%60Run.model_validate%28run_orm%29%60%20at%20line%20272%20of%20%60run_preparation.py%60%20will%20raise%20a%20Pydantic%20validation%20error%20for%20any%20checkpoint-only%20resume%2C%20turning%20every%20such%20request%20into%20a%20500.%0A%0A%60%60%60suggestion%0A%20%20%20%20input%3A%20dict%5Bstr%2C%20Any%5D%20%7C%20None%20%3D%20Field%28None%2C%20description%3D%22Input%20data%20provided%20to%20the%20run.%22%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=346&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fruns.py%0ALine%3A%20103%0A%0AComment%3A%0A**%60Run.input%60%20rejects%20%60None%60%2C%20breaking%20checkpoint-only%20resumes**%0A%0A%60Run.input%60%20is%20typed%20%60dict%5Bstr%2C%20Any%5D%60%20%28non-nullable%29%2C%20but%20%60run_preparation.py%60%20now%20stores%20%60None%60%20for%20checkpoint-only%20runs.%20%60Run.model_validate%28run_orm%29%60%20at%20line%20272%20of%20%60run_preparation.py%60%20will%20raise%20a%20Pydantic%20validation%20error%20for%20any%20checkpoint-only%20resume%2C%20turning%20every%20such%20request%20into%20a%20500.%0A%0A%60%60%60suggestion%0A%20%20%20%20input%3A%20dict%5Bstr%2C%20Any%5D%20%7C%20None%20%3D%20Field%28None%2C%20description%3D%22Input%20data%20provided%20to%20the%20run.%22%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=346&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fcheckpoint-fork-followups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcheckpoint-fork-followups%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fruns.py%0ALine%3A%20103%0A%0AComment%3A%0A**%60Run.input%60%20rejects%20%60None%60%2C%20breaking%20checkpoint-only%20resumes**%0A%0A%60Run.input%60%20is%20typed%20%60dict%5Bstr%2C%20Any%5D%60%20%28non-nullable%29%2C%20but%20%60run_preparation.py%60%20now%20stores%20%60None%60%20for%20checkpoint-only%20runs.%20%60Run.model_validate%28run_orm%29%60%20at%20line%20272%20of%20%60run_preparation.py%60%20will%20raise%20a%20Pydantic%20validation%20error%20for%20any%20checkpoint-only%20resume%2C%20turning%20every%20such%20request%20into%20a%20500.%0A%0A%60%60%60suggestion%0A%20%20%20%20input%3A%20dict%5Bstr%2C%20Any%5D%20%7C%20None%20%3D%20Field%28None%2C%20description%3D%22Input%20data%20provided%20to%20the%20run.%22%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

2. `libs/aegra-api/src/aegra_api/models/runs.py`, line 103 ([link](https://github.com/aegra/aegra/blob/160bb7014b69bcee0d3cd13d2e89452337db816f/libs/aegra-api/src/aegra_api/models/runs.py#L103)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`Run.input` is non-nullable, breaking checkpoint-only resumes**

   `run_preparation.py` now stores `request.input` as `None` for checkpoint-only runs, but `Run.input` is typed `dict[str, Any]` with a required `...` default. `Run.model_validate(run_orm)` at line 272 of `run_preparation.py` will raise a Pydantic `ValidationError` for every checkpoint-only resume, turning those requests into 500s.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fruns.py%0ALine%3A%20103%0A%0AComment%3A%0A**%60Run.input%60%20is%20non-nullable%2C%20breaking%20checkpoint-only%20resumes**%0A%0A%60run_preparation.py%60%20now%20stores%20%60request.input%60%20as%20%60None%60%20for%20checkpoint-only%20runs%2C%20but%20%60Run.input%60%20is%20typed%20%60dict%5Bstr%2C%20Any%5D%60%20with%20a%20required%20%60...%60%20default.%20%60Run.model_validate%28run_orm%29%60%20at%20line%20272%20of%20%60run_preparation.py%60%20will%20raise%20a%20Pydantic%20%60ValidationError%60%20for%20every%20checkpoint-only%20resume%2C%20turning%20those%20requests%20into%20500s.%0A%0A%60%60%60suggestion%0A%20%20%20%20input%3A%20dict%5Bstr%2C%20Any%5D%20%7C%20None%20%3D%20Field%28None%2C%20description%3D%22Input%20data%20provided%20to%20the%20run.%22%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=346&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fruns.py%0ALine%3A%20103%0A%0AComment%3A%0A**%60Run.input%60%20is%20non-nullable%2C%20breaking%20checkpoint-only%20resumes**%0A%0A%60run_preparation.py%60%20now%20stores%20%60request.input%60%20as%20%60None%60%20for%20checkpoint-only%20runs%2C%20but%20%60Run.input%60%20is%20typed%20%60dict%5Bstr%2C%20Any%5D%60%20with%20a%20required%20%60...%60%20default.%20%60Run.model_validate%28run_orm%29%60%20at%20line%20272%20of%20%60run_preparation.py%60%20will%20raise%20a%20Pydantic%20%60ValidationError%60%20for%20every%20checkpoint-only%20resume%2C%20turning%20those%20requests%20into%20500s.%0A%0A%60%60%60suggestion%0A%20%20%20%20input%3A%20dict%5Bstr%2C%20Any%5D%20%7C%20None%20%3D%20Field%28None%2C%20description%3D%22Input%20data%20provided%20to%20the%20run.%22%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=346&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fcheckpoint-fork-followups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcheckpoint-fork-followups%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fruns.py%0ALine%3A%20103%0A%0AComment%3A%0A**%60Run.input%60%20is%20non-nullable%2C%20breaking%20checkpoint-only%20resumes**%0A%0A%60run_preparation.py%60%20now%20stores%20%60request.input%60%20as%20%60None%60%20for%20checkpoint-only%20runs%2C%20but%20%60Run.input%60%20is%20typed%20%60dict%5Bstr%2C%20Any%5D%60%20with%20a%20required%20%60...%60%20default.%20%60Run.model_validate%28run_orm%29%60%20at%20line%20272%20of%20%60run_preparation.py%60%20will%20raise%20a%20Pydantic%20%60ValidationError%60%20for%20every%20checkpoint-only%20resume%2C%20turning%20those%20requests%20into%20500s.%0A%0A%60%60%60suggestion%0A%20%20%20%20input%3A%20dict%5Bstr%2C%20Any%5D%20%7C%20None%20%3D%20Field%28None%2C%20description%3D%22Input%20data%20provided%20to%20the%20run.%22%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["fix: include &#39;checkpoint&#39; in RunCreate e..."](https://github.com/aegra/aegra/commit/7227b410b9f166a17ccc5972d412a080ac563039) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30610668)</sub>

<!-- /greptile_comment -->