### PR TITLE
fix: make Run.input nullable for checkpoint-only resume (0.9.11)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.10"
+    "version": "0.9.11"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.10"
+version = "0.9.11"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -100,7 +100,9 @@ class Run(BaseModel):
     status: str = Field(
         "pending", description="Current run status: pending, running, error, success, timeout, or interrupted."
     )
-    input: dict[str, Any] = Field(..., description="Input data provided to the run.")
+    input: dict[str, Any] | None = Field(
+        None, description="Input data provided to the run. None for checkpoint-only resume."
+    )
     output: dict[str, Any] | None = Field(
         None, description="Final output produced by the run, or null if not yet complete."
     )

--- a/libs/aegra-api/tests/unit/test_models/test_run_input_nullable.py
+++ b/libs/aegra-api/tests/unit/test_models/test_run_input_nullable.py
@@ -1,0 +1,25 @@
+"""Regression: Run.input must accept None for checkpoint-only resume."""
+
+from datetime import UTC, datetime
+
+from aegra_api.models.runs import Run
+
+
+def test_run_accepts_none_input() -> None:
+    """Run rows from checkpoint-only resume have input=None in the ORM.
+
+    Regression: Run.input was non-nullable, causing 500s when serializing
+    resumed runs back through GET /runs/{id} or POST /runs/wait.
+    """
+    now = datetime.now(UTC)
+    run = Run(
+        run_id="r-1",
+        thread_id="t-1",
+        assistant_id="agent",
+        status="pending",
+        input=None,
+        user_id="u-1",
+        created_at=now,
+        updated_at=now,
+    )
+    assert run.input is None

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.10"
+version = "0.9.11"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.10"
+version = "0.9.11"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -96,7 +96,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.10"
+version = "0.9.11"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary

Hotfix for E2E regression introduced by #346.

PR #346 correctly preserved \`input=None\` on \`RunCreate\`/\`RunExecution\` so LangGraph Pregel resumes from the checkpoint's \`next=[...]\` instead of restarting from \`__start__\`. The \`Run\` response model still required \`input: dict[str, Any]\` (non-nullable), so any subsequent serialization of those rows (GET \`/runs/{id}\`, POST \`/runs/wait\`) blew up:

\`\`\`
1 validation error for Run
input
  Input should be a valid dictionary [type=dict_type, input_value=None, input_type=NoneType]
\`\`\`

This broke \`test_human_in_the_loop\` (5 cases) + \`test_latest_state_with_subgraphs_e2e\` on main.

## Fix

Make \`Run.input\` \`dict[str, Any] | None\`, matching \`RunCreate.input\` and \`RunExecution.input_data\` (both already nullable, ORM column already nullable too).

## Version

Bumps both packages 0.9.10 -> 0.9.11. 0.9.10 already published to PyPI so we can't reuse the version.

## Test plan

- [x] \`pytest libs/aegra-api/tests/unit/test_models/\` (added regression test for nullable Run.input)
- [ ] E2E green in CI on both dev + prod modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run objects now support an optional input field, enabling checkpoint-only resume workflows.

* **Tests**
  * Added test coverage for nullable input handling in Run objects.

* **Chores**
  * Incremented version to 0.9.11 with updated API specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix makes `Run.input` nullable (`dict[str, Any] | None`) so that checkpoint-only resume rows (where `input=None` in the ORM) can be serialized without a Pydantic validation error on `GET /runs/{id}` and `POST /runs/wait`. The Python model and test changes are correct and well-targeted.

- `docs/openapi.json` was not regenerated: the `Run` schema still types `input` as a non-nullable `object` and still lists it in `required[]`, so any client code-generated from this spec will expect a non-null `input` and fail to parse null responses.

<h3>Confidence Score: 3/5</h3>

Safe to merge only after regenerating or manually patching the OpenAPI spec for the Run.input field

The core Python fix is correct and directly addresses the regression. However, openapi.json was not updated: Run.input is still marked as required and non-nullable in the spec, which will cause downstream SDK/client breakage for any consumer relying on the published schema. This P1 prevents the fix from being fully effective end-to-end.

docs/openapi.json — Run.input must be updated to anyOf [object, null] and removed from the required array

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/openapi.json | Run.input schema not updated: still typed as non-nullable object and listed in required[], diverging from the Python model fix |
| libs/aegra-api/src/aegra_api/models/runs.py | Correct fix: Run.input changed from dict[str, Any] to dict[str, Any] | None, matching RunCreate.input and the nullable ORM column |
| libs/aegra-api/tests/unit/test_models/test_run_input_nullable.py | New regression test verifying Run accepts input=None; straightforward and accurate |
| libs/aegra-api/pyproject.toml | Version bumped 0.9.10 → 0.9.11 as required since 0.9.10 is already published |
| libs/aegra-cli/pyproject.toml | Version bumped 0.9.10 → 0.9.11 to match aegra-api |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API
    participant Pydantic as Run Model
    participant ORM

    Client->>API: POST /runs (checkpoint-only, input=None)
    API->>ORM: INSERT run (input_data=NULL)
    ORM-->>API: run row

    Client->>API: GET /runs/{id}
    API->>ORM: SELECT run
    ORM-->>API: run row (input=NULL)
    API->>Pydantic: Run(**row)
    Note over Pydantic: Before fix: ValueError — input required<br/>After fix: Run(input=None) ✓
    Pydantic-->>API: Run instance
    API-->>Client: 200 {"input": null, ...}
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/openapi.json`, line 3388-3472 ([link](https://github.com/aegra/aegra/blob/b457fc4c34fc0c7f9d7c70cca5db1dfd48fa9e7f/docs/openapi.json#L3388-L3472)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **OpenAPI spec not updated to match nullable `input`**

   The `Run` schema in `openapi.json` still declares `input` as a plain non-nullable `object` (lines 3388–3393) and still lists it in the `required` array (line 3468). The Python model was made nullable, but this file was not regenerated. Any client that code-generates types from this spec (SDKs, frontend, mock servers) will still expect `input` to be a required, non-null dict and will either fail to parse a null `input` or produce incorrect types. Compare against the correctly-updated `RunCreate.input` in the same file (line 3483+) which already uses `anyOf` with `null`.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fopenapi.json%0ALine%3A%203388-3472%0A%0AComment%3A%0A**OpenAPI%20spec%20not%20updated%20to%20match%20nullable%20%60input%60**%0A%0AThe%20%60Run%60%20schema%20in%20%60openapi.json%60%20still%20declares%20%60input%60%20as%20a%20plain%20non-nullable%20%60object%60%20%28lines%203388%E2%80%933393%29%20and%20still%20lists%20it%20in%20the%20%60required%60%20array%20%28line%203468%29.%20The%20Python%20model%20was%20made%20nullable%2C%20but%20this%20file%20was%20not%20regenerated.%20Any%20client%20that%20code-generates%20types%20from%20this%20spec%20%28SDKs%2C%20frontend%2C%20mock%20servers%29%20will%20still%20expect%20%60input%60%20to%20be%20a%20required%2C%20non-null%20dict%20and%20will%20either%20fail%20to%20parse%20a%20null%20%60input%60%20or%20produce%20incorrect%20types.%20Compare%20against%20the%20correctly-updated%20%60RunCreate.input%60%20in%20the%20same%20file%20%28line%203483%2B%29%20which%20already%20uses%20%60anyOf%60%20with%20%60null%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=347&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fopenapi.json%0ALine%3A%203388-3472%0A%0AComment%3A%0A**OpenAPI%20spec%20not%20updated%20to%20match%20nullable%20%60input%60**%0A%0AThe%20%60Run%60%20schema%20in%20%60openapi.json%60%20still%20declares%20%60input%60%20as%20a%20plain%20non-nullable%20%60object%60%20%28lines%203388%E2%80%933393%29%20and%20still%20lists%20it%20in%20the%20%60required%60%20array%20%28line%203468%29.%20The%20Python%20model%20was%20made%20nullable%2C%20but%20this%20file%20was%20not%20regenerated.%20Any%20client%20that%20code-generates%20types%20from%20this%20spec%20%28SDKs%2C%20frontend%2C%20mock%20servers%29%20will%20still%20expect%20%60input%60%20to%20be%20a%20required%2C%20non-null%20dict%20and%20will%20either%20fail%20to%20parse%20a%20null%20%60input%60%20or%20produce%20incorrect%20types.%20Compare%20against%20the%20correctly-updated%20%60RunCreate.input%60%20in%20the%20same%20file%20%28line%203483%2B%29%20which%20already%20uses%20%60anyOf%60%20with%20%60null%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=347&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Frun-input-nullable-resume%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frun-input-nullable-resume%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fopenapi.json%0ALine%3A%203388-3472%0A%0AComment%3A%0A**OpenAPI%20spec%20not%20updated%20to%20match%20nullable%20%60input%60**%0A%0AThe%20%60Run%60%20schema%20in%20%60openapi.json%60%20still%20declares%20%60input%60%20as%20a%20plain%20non-nullable%20%60object%60%20%28lines%203388%E2%80%933393%29%20and%20still%20lists%20it%20in%20the%20%60required%60%20array%20%28line%203468%29.%20The%20Python%20model%20was%20made%20nullable%2C%20but%20this%20file%20was%20not%20regenerated.%20Any%20client%20that%20code-generates%20types%20from%20this%20spec%20%28SDKs%2C%20frontend%2C%20mock%20servers%29%20will%20still%20expect%20%60input%60%20to%20be%20a%20required%2C%20non-null%20dict%20and%20will%20either%20fail%20to%20parse%20a%20null%20%60input%60%20or%20produce%20incorrect%20types.%20Compare%20against%20the%20correctly-updated%20%60RunCreate.input%60%20in%20the%20same%20file%20%28line%203483%2B%29%20which%20already%20uses%20%60anyOf%60%20with%20%60null%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fopenapi.json%3A3388-3472%0A**OpenAPI%20spec%20not%20updated%20to%20match%20nullable%20%60input%60**%0A%0AThe%20%60Run%60%20schema%20in%20%60openapi.json%60%20still%20declares%20%60input%60%20as%20a%20plain%20non-nullable%20%60object%60%20%28lines%203388%E2%80%933393%29%20and%20still%20lists%20it%20in%20the%20%60required%60%20array%20%28line%203468%29.%20The%20Python%20model%20was%20made%20nullable%2C%20but%20this%20file%20was%20not%20regenerated.%20Any%20client%20that%20code-generates%20types%20from%20this%20spec%20%28SDKs%2C%20frontend%2C%20mock%20servers%29%20will%20still%20expect%20%60input%60%20to%20be%20a%20required%2C%20non-null%20dict%20and%20will%20either%20fail%20to%20parse%20a%20null%20%60input%60%20or%20produce%20incorrect%20types.%20Compare%20against%20the%20correctly-updated%20%60RunCreate.input%60%20in%20the%20same%20file%20%28line%203483%2B%29%20which%20already%20uses%20%60anyOf%60%20with%20%60null%60.%0A%0A&repo=aegra%2Faegra&pr=347&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fopenapi.json%3A3388-3472%0A**OpenAPI%20spec%20not%20updated%20to%20match%20nullable%20%60input%60**%0A%0AThe%20%60Run%60%20schema%20in%20%60openapi.json%60%20still%20declares%20%60input%60%20as%20a%20plain%20non-nullable%20%60object%60%20%28lines%203388%E2%80%933393%29%20and%20still%20lists%20it%20in%20the%20%60required%60%20array%20%28line%203468%29.%20The%20Python%20model%20was%20made%20nullable%2C%20but%20this%20file%20was%20not%20regenerated.%20Any%20client%20that%20code-generates%20types%20from%20this%20spec%20%28SDKs%2C%20frontend%2C%20mock%20servers%29%20will%20still%20expect%20%60input%60%20to%20be%20a%20required%2C%20non-null%20dict%20and%20will%20either%20fail%20to%20parse%20a%20null%20%60input%60%20or%20produce%20incorrect%20types.%20Compare%20against%20the%20correctly-updated%20%60RunCreate.input%60%20in%20the%20same%20file%20%28line%203483%2B%29%20which%20already%20uses%20%60anyOf%60%20with%20%60null%60.%0A%0A&pr=347&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Frun-input-nullable-resume%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frun-input-nullable-resume%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fopenapi.json%3A3388-3472%0A**OpenAPI%20spec%20not%20updated%20to%20match%20nullable%20%60input%60**%0A%0AThe%20%60Run%60%20schema%20in%20%60openapi.json%60%20still%20declares%20%60input%60%20as%20a%20plain%20non-nullable%20%60object%60%20%28lines%203388%E2%80%933393%29%20and%20still%20lists%20it%20in%20the%20%60required%60%20array%20%28line%203468%29.%20The%20Python%20model%20was%20made%20nullable%2C%20but%20this%20file%20was%20not%20regenerated.%20Any%20client%20that%20code-generates%20types%20from%20this%20spec%20%28SDKs%2C%20frontend%2C%20mock%20servers%29%20will%20still%20expect%20%60input%60%20to%20be%20a%20required%2C%20non-null%20dict%20and%20will%20either%20fail%20to%20parse%20a%20null%20%60input%60%20or%20produce%20incorrect%20types.%20Compare%20against%20the%20correctly-updated%20%60RunCreate.input%60%20in%20the%20same%20file%20%28line%203483%2B%29%20which%20already%20uses%20%60anyOf%60%20with%20%60null%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: make Run.input nullable for checkpo..."](https://github.com/aegra/aegra/commit/b457fc4c34fc0c7f9d7c70cca5db1dfd48fa9e7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30655552)</sub>

<!-- /greptile_comment -->