### PR TITLE
fix(api): honor sort params and auth-handler filters in /assistants/search

### DIFF
--- a/libs/aegra-api/alembic/versions/20260504000000_add_gin_index_on_assistant_metadata.py
+++ b/libs/aegra-api/alembic/versions/20260504000000_add_gin_index_on_assistant_metadata.py
@@ -1,0 +1,37 @@
+"""Add GIN jsonb_path_ops index on assistant.metadata
+
+Backs the JSONB containment predicate ``metadata @> :filter`` used by
+``POST /assistants/search`` for metadata filtering. ``jsonb_path_ops`` is
+smaller and faster than the default ``jsonb_ops`` for containment-only
+queries (no key-existence support, which we don't need here). Mirrors the
+thread.metadata_json index added in revision b7c8d9e0f123.
+
+Revision ID: c8d9e0f1a234
+Revises: b7c8d9e0f123
+Create Date: 2026-05-04 00:00:00.000000
+
+"""
+
+from alembic import op
+
+revision = "c8d9e0f1a234"
+down_revision = "b7c8d9e0f123"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "idx_assistant_metadata_gin"
+
+
+def upgrade() -> None:
+    op.create_index(
+        INDEX_NAME,
+        "assistant",
+        ["metadata"],
+        postgresql_using="gin",
+        postgresql_ops={"metadata": "jsonb_path_ops"},
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(INDEX_NAME, table_name="assistant")

--- a/libs/aegra-api/src/aegra_api/api/assistants.py
+++ b/libs/aegra-api/src/aegra_api/api/assistants.py
@@ -57,11 +57,12 @@ def _merge_handler_filters_into_metadata(
     ``{"owner": user_id}`` → metadata containment match), matching the
     LangGraph SDK auth contract.
     """
-    if filters and "metadata" in filters and isinstance(filters["metadata"], dict):
-        request.metadata = {**(request.metadata or {}), **filters["metadata"]}
-        return
     if filters:
-        request.metadata = {**(request.metadata or {}), **filters}
+        # A handler may return both a nested metadata payload AND flat scope
+        # constraints (e.g. {"metadata": {...}, "owner": "u1"}). Merge both.
+        nested_meta = filters["metadata"] if isinstance(filters.get("metadata"), dict) else {}
+        flat_meta = {k: v for k, v in filters.items() if k != "metadata"}
+        request.metadata = {**(request.metadata or {}), **nested_meta, **flat_meta}
         return
     if value.get("metadata"):
         request.metadata = {**(request.metadata or {}), **value["metadata"]}
@@ -110,10 +111,12 @@ async def list_assistants(
     filters = await handle_event(ctx, value)
 
     if filters or value.get("metadata"):
+        # Build a transient request just to reuse the merge helper, then hand
+        # the resulting metadata filter to list_assistants — which doesn't
+        # paginate. Using search_assistants here would silently cap at 20.
         search_request = AssistantSearchRequest()
         _merge_handler_filters_into_metadata(search_request, filters, value)
-        column, asc = _resolve_sort(search_request)
-        assistants = await service.search_assistants(search_request, user.identity, sort_column=column, sort_asc=asc)
+        assistants = await service.list_assistants(user.identity, metadata=search_request.metadata)
     else:
         assistants = await service.list_assistants(user.identity)
 

--- a/libs/aegra-api/src/aegra_api/api/assistants.py
+++ b/libs/aegra-api/src/aegra_api/api/assistants.py
@@ -64,8 +64,9 @@ def _merge_handler_filters_into_metadata(
         flat_meta = {k: v for k, v in filters.items() if k != "metadata"}
         request.metadata = {**(request.metadata or {}), **nested_meta, **flat_meta}
         return
-    if value.get("metadata"):
-        request.metadata = {**(request.metadata or {}), **value["metadata"]}
+    value_meta = value.get("metadata")
+    if isinstance(value_meta, dict) and value_meta:
+        request.metadata = {**(request.metadata or {}), **value_meta}
 
 
 @router.post("/assistants", response_model=Assistant, response_model_by_alias=False)

--- a/libs/aegra-api/src/aegra_api/api/assistants.py
+++ b/libs/aegra-api/src/aegra_api/api/assistants.py
@@ -11,10 +11,13 @@ Architecture:
 - Service Layer (assistant_service.py): Business logic, validation, orchestration
 """
 
+from typing import Any
+
 from fastapi import APIRouter, Body, Depends, Query
 
 from aegra_api.core.auth_deps import auth_dependency, get_current_user
 from aegra_api.core.auth_handlers import build_auth_context, handle_event
+from aegra_api.core.orm import Assistant as AssistantORM
 from aegra_api.models import (
     AgentSchemas,
     Assistant,
@@ -28,6 +31,45 @@ from aegra_api.models.errors import NOT_FOUND
 from aegra_api.services.assistant_service import AssistantService, get_assistant_service
 
 router = APIRouter(tags=["Assistants"], dependencies=auth_dependency)
+
+
+_ALLOWED_SORT_FIELDS: frozenset[str] = frozenset({"assistant_id", "name", "graph_id", "created_at", "updated_at"})
+_DEFAULT_SORT_FIELD = "created_at"
+_DEFAULT_SORT_ASC = False
+
+
+def _resolve_sort(request: AssistantSearchRequest) -> tuple[Any, bool]:
+    """Resolve (ORM column, is_ascending) for /assistants/search.
+
+    sort_by is Pydantic-validated against a Literal — invalid values 422 at
+    the request boundary. Default is created_at DESC.
+    """
+    if request.sort_by:
+        return getattr(AssistantORM, request.sort_by), (request.sort_order or "desc").lower() == "asc"
+    return getattr(AssistantORM, _DEFAULT_SORT_FIELD), _DEFAULT_SORT_ASC
+
+
+def _merge_handler_filters_into_metadata(
+    request: AssistantSearchRequest,
+    filters: dict[str, Any] | None,
+    value: dict[str, Any],
+) -> None:
+    """Merge auth-handler filters into request.metadata.
+
+    Mirrors create/update assistant: handlers may either return
+    ``{"metadata": {...}}`` or mutate ``value["metadata"]`` directly. Other
+    top-level filter keys are treated as metadata constraints (e.g.
+    ``{"owner": user_id}`` → metadata containment match), matching the
+    LangGraph SDK auth contract.
+    """
+    if filters and "metadata" in filters and isinstance(filters["metadata"], dict):
+        request.metadata = {**(request.metadata or {}), **filters["metadata"]}
+        return
+    if filters:
+        request.metadata = {**(request.metadata or {}), **filters}
+        return
+    if value.get("metadata"):
+        request.metadata = {**(request.metadata or {}), **value["metadata"]}
 
 
 @router.post("/assistants", response_model=Assistant, response_model_by_alias=False)
@@ -69,14 +111,14 @@ async def list_assistants(
     """
     # Authorization check (search action for listing)
     ctx = build_auth_context(user, "assistants", "search")
-    value = {}
+    value: dict[str, Any] = {}
     filters = await handle_event(ctx, value)
 
-    # Apply filters if provided by handler
-    if filters:
-        # Convert filters to search request format
-        search_request = AssistantSearchRequest(filters=filters)
-        assistants = await service.search_assistants(search_request, user.identity)
+    if filters or value.get("metadata"):
+        search_request = AssistantSearchRequest()
+        _merge_handler_filters_into_metadata(search_request, filters, value)
+        column, asc = _resolve_sort(search_request)
+        assistants = await service.search_assistants(search_request, user.identity, sort_column=column, sort_asc=asc)
     else:
         assistants = await service.list_assistants(user.identity)
 
@@ -98,13 +140,10 @@ async def search_assistants(
     ctx = build_auth_context(user, "assistants", "search")
     value = request.model_dump()
     filters = await handle_event(ctx, value)
+    _merge_handler_filters_into_metadata(request, filters, value)
+    column, asc = _resolve_sort(request)
 
-    # Merge handler filters with request filters
-    if filters:
-        request_filters = request.filters or {}
-        request.filters = {**request_filters, **filters}
-
-    return await service.search_assistants(request, user.identity)
+    return await service.search_assistants(request, user.identity, sort_column=column, sort_asc=asc)
 
 
 @router.post("/assistants/count", response_model=int)
@@ -122,11 +161,7 @@ async def count_assistants(
     ctx = build_auth_context(user, "assistants", "search")
     value = request.model_dump()
     filters = await handle_event(ctx, value)
-
-    # Merge handler filters with request filters
-    if filters:
-        request_filters = request.filters or {}
-        request.filters = {**request_filters, **filters}
+    _merge_handler_filters_into_metadata(request, filters, value)
 
     return await service.count_assistants(request, user.identity)
 

--- a/libs/aegra-api/src/aegra_api/api/assistants.py
+++ b/libs/aegra-api/src/aegra_api/api/assistants.py
@@ -33,11 +33,6 @@ from aegra_api.services.assistant_service import AssistantService, get_assistant
 router = APIRouter(tags=["Assistants"], dependencies=auth_dependency)
 
 
-_ALLOWED_SORT_FIELDS: frozenset[str] = frozenset({"assistant_id", "name", "graph_id", "created_at", "updated_at"})
-_DEFAULT_SORT_FIELD = "created_at"
-_DEFAULT_SORT_ASC = False
-
-
 def _resolve_sort(request: AssistantSearchRequest) -> tuple[Any, bool]:
     """Resolve (ORM column, is_ascending) for /assistants/search.
 
@@ -46,7 +41,7 @@ def _resolve_sort(request: AssistantSearchRequest) -> tuple[Any, bool]:
     """
     if request.sort_by:
         return getattr(AssistantORM, request.sort_by), (request.sort_order or "desc").lower() == "asc"
-    return getattr(AssistantORM, _DEFAULT_SORT_FIELD), _DEFAULT_SORT_ASC
+    return AssistantORM.created_at, False
 
 
 def _merge_handler_filters_into_metadata(

--- a/libs/aegra-api/src/aegra_api/models/assistants.py
+++ b/libs/aegra-api/src/aegra_api/models/assistants.py
@@ -1,7 +1,7 @@
 """Assistant-related Pydantic models for Agent Protocol"""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -73,7 +73,18 @@ class AssistantSearchRequest(BaseModel):
     graph_id: str | None = Field(None, description="Filter by graph ID")
     limit: int | None = Field(20, le=100, ge=1, description="Maximum results")
     offset: int | None = Field(0, ge=0, description="Results offset")
-    metadata: dict[str, Any] | None = Field({}, description="Metadata to use for searching and filtering assistants.")
+    metadata: dict[str, Any] | None = Field(
+        default_factory=dict,
+        description="Metadata to use for searching and filtering assistants.",
+    )
+    sort_by: Literal["assistant_id", "name", "graph_id", "created_at", "updated_at"] | None = Field(
+        None,
+        description="Field to sort by (SDK-compatible).",
+    )
+    sort_order: Literal["asc", "desc"] | None = Field(
+        None,
+        description="Sort direction (SDK-compatible). Defaults to 'desc' when sort_by is set.",
+    )
 
 
 class AgentSchemas(BaseModel):

--- a/libs/aegra-api/src/aegra_api/services/assistant_service.py
+++ b/libs/aegra-api/src/aegra_api/services/assistant_service.py
@@ -231,12 +231,13 @@ class AssistantService:
         self,
         request: Any,  # AssistantSearchRequest
         user_identity: str,
+        *,
+        sort_column: Any | None = None,
+        sort_asc: bool = False,
     ) -> list[Assistant]:
         """Search assistants with filters"""
-        # Start with user's assistants
         stmt = select(AssistantORM).where(or_(AssistantORM.user_id == user_identity, AssistantORM.user_id == "system"))
 
-        # Apply filters
         if request.name:
             stmt = stmt.where(AssistantORM.name.ilike(f"%{request.name}%"))
 
@@ -249,15 +250,18 @@ class AssistantService:
         if request.metadata:
             stmt = stmt.where(AssistantORM.metadata_dict.op("@>")(request.metadata))
 
-        # Apply pagination
+        column = sort_column if sort_column is not None else AssistantORM.created_at
+        direction = column.asc() if sort_asc else column.desc()
+        # Tie-break on assistant_id keeps offset pagination stable when the
+        # primary sort column has duplicates.
+        stmt = stmt.order_by(direction, AssistantORM.assistant_id.asc())
+
         offset = request.offset or 0
         limit = request.limit or 20
         stmt = stmt.offset(offset).limit(limit)
 
         result = await self.session.scalars(stmt)
-        paginated_assistants = [to_pydantic(a) for a in result.all()]
-
-        return paginated_assistants
+        return [to_pydantic(a) for a in result.all()]
 
     async def count_assistants(
         self,

--- a/libs/aegra-api/src/aegra_api/services/assistant_service.py
+++ b/libs/aegra-api/src/aegra_api/services/assistant_service.py
@@ -219,13 +219,23 @@ class AssistantService:
 
         return to_pydantic(assistant_orm)
 
-    async def list_assistants(self, user_identity: str) -> list[Assistant]:
-        """List user's assistants and system assistants"""
-        # Include both user's assistants and system assistants (like search_assistants does)
+    async def list_assistants(
+        self,
+        user_identity: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> list[Assistant]:
+        """List user's assistants and system assistants.
+
+        Optionally filtered by a metadata containment predicate. Unlike
+        ``search_assistants``, this method does not paginate — callers that
+        need pagination should use search.
+        """
         stmt = select(AssistantORM).where(or_(AssistantORM.user_id == user_identity, AssistantORM.user_id == "system"))
+        if metadata:
+            stmt = stmt.where(AssistantORM.metadata_dict.op("@>")(metadata))
         result = await self.session.scalars(stmt)
-        user_assistants = [to_pydantic(a) for a in result.all()]
-        return user_assistants
+        return [to_pydantic(a) for a in result.all()]
 
     async def search_assistants(
         self,

--- a/libs/aegra-api/tests/e2e/test_assistants/test_assistant_search.py
+++ b/libs/aegra-api/tests/e2e/test_assistants/test_assistant_search.py
@@ -151,3 +151,100 @@ async def test_assistant_search_metadata():
         # 3. Cleanup all assistants
         for assistant in created_assistants:
             await client.assistants.delete(assistant_id=assistant["assistant_id"])
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_assistant_search_sort_by_name_asc():
+    """Sort_by=name + sort_order=asc returns lexicographically ascending names."""
+    client = get_e2e_client()
+    created = []
+    try:
+        for i, name in enumerate(("zeta-sort-asst", "alpha-sort-asst", "mu-sort-asst")):
+            a = await client.assistants.create(
+                name=name,
+                graph_id="agent",
+                context={"max_search_results": i + 100},
+                metadata={"sort_test_marker": "asc-name"},
+                if_exists="do_nothing",
+            )
+            created.append(a)
+
+        results = await client.assistants.search(
+            metadata={"sort_test_marker": "asc-name"},
+            sort_by="name",
+            sort_order="asc",
+        )
+
+        names = [r["name"] for r in results]
+        assert names == sorted(names), f"Expected ascending order, got {names}"
+    finally:
+        for a in created:
+            await client.assistants.delete(assistant_id=a["assistant_id"])
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_assistant_search_sort_by_name_desc():
+    """Sort_by=name + sort_order=desc returns lexicographically descending names."""
+    client = get_e2e_client()
+    created = []
+    try:
+        for i, name in enumerate(("alpha-sort-d", "zeta-sort-d", "mu-sort-d")):
+            a = await client.assistants.create(
+                name=name,
+                graph_id="agent",
+                context={"max_search_results": i + 200},
+                metadata={"sort_test_marker": "desc-name"},
+                if_exists="do_nothing",
+            )
+            created.append(a)
+
+        results = await client.assistants.search(
+            metadata={"sort_test_marker": "desc-name"},
+            sort_by="name",
+            sort_order="desc",
+        )
+
+        names = [r["name"] for r in results]
+        assert names == sorted(names, reverse=True), f"Expected descending order, got {names}"
+    finally:
+        for a in created:
+            await client.assistants.delete(assistant_id=a["assistant_id"])
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_assistant_search_pagination_is_stable_across_offset():
+    """Tie-break on assistant_id keeps offset pagination stable when many rows
+    share a sort key (e.g. created in the same microsecond batch)."""
+    client = get_e2e_client()
+    created = []
+    try:
+        for i in range(5):
+            a = await client.assistants.create(
+                name=f"pagestable-{i}",
+                graph_id="agent",
+                context={"max_search_results": i + 300},
+                metadata={"sort_test_marker": "pagination"},
+                if_exists="do_nothing",
+            )
+            created.append(a)
+
+        page_one = await client.assistants.search(
+            metadata={"sort_test_marker": "pagination"},
+            limit=2,
+            offset=0,
+        )
+        page_two = await client.assistants.search(
+            metadata={"sort_test_marker": "pagination"},
+            limit=2,
+            offset=2,
+        )
+
+        page_one_ids = {a["assistant_id"] for a in page_one}
+        page_two_ids = {a["assistant_id"] for a in page_two}
+        assert not page_one_ids & page_two_ids, "Pagination pages overlap (tie-break missing)"
+    finally:
+        for a in created:
+            await client.assistants.delete(assistant_id=a["assistant_id"])

--- a/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
@@ -565,16 +565,35 @@ class TestSearchAssistantsSortAndAuth:
         app = create_test_app(include_runs=False, include_threads=False)
         app.include_router(assistants_module.router)
         app.dependency_overrides[get_assistant_service] = lambda: mock_assistant_service
-        mock_assistant_service.search_assistants.return_value = []
+        mock_assistant_service.list_assistants.return_value = []
 
         with patch("aegra_api.api.assistants.handle_event", new_callable=AsyncMock) as mock_handle:
             mock_handle.return_value = {"owner": "user-123"}
             resp = make_client(app).get("/assistants")
 
         assert resp.status_code == 200
-        mock_assistant_service.search_assistants.assert_called_once()
-        called_request = mock_assistant_service.search_assistants.call_args.args[0]
-        assert called_request.metadata == {"owner": "user-123"}
+        mock_assistant_service.list_assistants.assert_called_once()
+        kwargs = mock_assistant_service.list_assistants.call_args.kwargs
+        assert kwargs.get("metadata") == {"owner": "user-123"}
+
+    def test_list_with_filters_does_not_paginate(self, mock_assistant_service):
+        """GET /assistants must return all rows even when an auth handler is
+        active — going through search_assistants would silently cap at 20."""
+        from aegra_api.api import assistants as assistants_module
+        from aegra_api.services.assistant_service import get_assistant_service
+
+        app = create_test_app(include_runs=False, include_threads=False)
+        app.include_router(assistants_module.router)
+        app.dependency_overrides[get_assistant_service] = lambda: mock_assistant_service
+        mock_assistant_service.list_assistants.return_value = []
+
+        with patch("aegra_api.api.assistants.handle_event", new_callable=AsyncMock) as mock_handle:
+            mock_handle.return_value = {"owner": "user-123"}
+            resp = make_client(app).get("/assistants")
+
+        assert resp.status_code == 200
+        mock_assistant_service.search_assistants.assert_not_called()
+        mock_assistant_service.list_assistants.assert_called_once()
 
 
 class TestCountAssistants:

--- a/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
@@ -486,6 +486,97 @@ class TestSearchAssistants:
         assert data[0]["graph_id"] == "prod-graph"
 
 
+class TestSearchAssistantsSortAndAuth:
+    """Sort params + #333 regression: auth handlers returning filters must not 500."""
+
+    def test_search_with_sort_by_name_asc(self, client, mock_assistant_service):
+        mock_assistant_service.search_assistants.return_value = []
+
+        resp = client.post(
+            "/assistants/search",
+            json={"sort_by": "name", "sort_order": "asc"},
+        )
+
+        assert resp.status_code == 200
+        kwargs = mock_assistant_service.search_assistants.call_args.kwargs
+        assert kwargs.get("sort_asc") is True
+        sort_column = kwargs.get("sort_column")
+        assert getattr(sort_column, "key", None) == "name"
+
+    def test_search_with_sort_by_only_defaults_to_desc(self, client, mock_assistant_service):
+        mock_assistant_service.search_assistants.return_value = []
+
+        resp = client.post("/assistants/search", json={"sort_by": "updated_at"})
+
+        assert resp.status_code == 200
+        kwargs = mock_assistant_service.search_assistants.call_args.kwargs
+        assert kwargs.get("sort_asc") is False
+
+    def test_invalid_sort_by_returns_422(self, client, mock_assistant_service):
+        resp = client.post("/assistants/search", json={"sort_by": "; DROP TABLE"})
+        assert resp.status_code == 422
+
+    def test_invalid_sort_order_returns_422(self, client, mock_assistant_service):
+        resp = client.post("/assistants/search", json={"sort_by": "name", "sort_order": "sideways"})
+        assert resp.status_code == 422
+
+    def test_search_succeeds_when_auth_handler_returns_filters(self, mock_assistant_service):
+        """Regression for #333: auth handler returning a flat filter dict must not 500."""
+        from aegra_api.api import assistants as assistants_module
+        from aegra_api.services.assistant_service import get_assistant_service
+
+        app = create_test_app(include_runs=False, include_threads=False)
+        app.include_router(assistants_module.router)
+        app.dependency_overrides[get_assistant_service] = lambda: mock_assistant_service
+        mock_assistant_service.search_assistants.return_value = []
+
+        with patch("aegra_api.api.assistants.handle_event", new_callable=AsyncMock) as mock_handle:
+            mock_handle.return_value = {"owner": "user-123"}
+            resp = make_client(app).post("/assistants/search", json={"metadata": {"env": "prod"}})
+
+        assert resp.status_code == 200
+        called_request = mock_assistant_service.search_assistants.call_args.args[0]
+        assert called_request.metadata == {"env": "prod", "owner": "user-123"}
+
+    def test_count_succeeds_when_auth_handler_returns_filters(self, mock_assistant_service):
+        """Regression for #333: same bug existed on /assistants/count."""
+        from aegra_api.api import assistants as assistants_module
+        from aegra_api.services.assistant_service import get_assistant_service
+
+        app = create_test_app(include_runs=False, include_threads=False)
+        app.include_router(assistants_module.router)
+        app.dependency_overrides[get_assistant_service] = lambda: mock_assistant_service
+        mock_assistant_service.count_assistants.return_value = 7
+
+        with patch("aegra_api.api.assistants.handle_event", new_callable=AsyncMock) as mock_handle:
+            mock_handle.return_value = {"owner": "user-123"}
+            resp = make_client(app).post("/assistants/count", json={})
+
+        assert resp.status_code == 200
+        assert resp.json() == 7
+        called_request = mock_assistant_service.count_assistants.call_args.args[0]
+        assert called_request.metadata == {"owner": "user-123"}
+
+    def test_list_succeeds_when_auth_handler_returns_filters(self, mock_assistant_service):
+        """Regression for #333: GET /assistants used a non-existent kwarg, so auth filters were silently dropped."""
+        from aegra_api.api import assistants as assistants_module
+        from aegra_api.services.assistant_service import get_assistant_service
+
+        app = create_test_app(include_runs=False, include_threads=False)
+        app.include_router(assistants_module.router)
+        app.dependency_overrides[get_assistant_service] = lambda: mock_assistant_service
+        mock_assistant_service.search_assistants.return_value = []
+
+        with patch("aegra_api.api.assistants.handle_event", new_callable=AsyncMock) as mock_handle:
+            mock_handle.return_value = {"owner": "user-123"}
+            resp = make_client(app).get("/assistants")
+
+        assert resp.status_code == 200
+        mock_assistant_service.search_assistants.assert_called_once()
+        called_request = mock_assistant_service.search_assistants.call_args.args[0]
+        assert called_request.metadata == {"owner": "user-123"}
+
+
 class TestCountAssistants:
     """Test POST /assistants/count"""
 

--- a/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
+++ b/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
@@ -189,6 +189,41 @@ class TestAssistantServiceDatabase:
         assert assistant in assistant_service.session.deleted_objects
 
     @pytest.mark.asyncio
+    async def test_list_assistants_no_metadata_filter(self, assistant_service):
+        """list_assistants without metadata returns all rows for the user."""
+        mock_result = Mock()
+        mock_result.all.return_value = []
+        assistant_service.session.scalars.return_value = mock_result
+
+        result = await assistant_service.list_assistants("user-123")
+
+        assert result == []
+        assistant_service.session.scalars.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_assistants_with_metadata_filter(self, assistant_service):
+        """list_assistants with metadata applies a JSONB containment predicate
+        but no pagination — covers the auth-handler-active GET /assistants path."""
+        mock_result = Mock()
+        mock_result.all.return_value = []
+        assistant_service.session.scalars.return_value = mock_result
+
+        result = await assistant_service.list_assistants(
+            "user-123",
+            metadata={"owner": "user-123", "tenant": "x"},
+        )
+
+        assert result == []
+        # The compiled SQL must reference the @> containment operator and must
+        # NOT contain LIMIT/OFFSET — this is the regression fence for the
+        # silent 20-row cap that the previous fix introduced.
+        called_stmt = assistant_service.session.scalars.call_args.args[0]
+        compiled = str(called_stmt.compile())
+        assert "@>" in compiled
+        assert "LIMIT" not in compiled.upper()
+        assert "OFFSET" not in compiled.upper()
+
+    @pytest.mark.asyncio
     async def test_search_assistants_pagination(self, assistant_service):
         """Test assistant search with pagination"""
         # Create multiple assistants

--- a/libs/aegra-api/tests/unit/test_api/test_assistants_search_sort.py
+++ b/libs/aegra-api/tests/unit/test_api/test_assistants_search_sort.py
@@ -93,3 +93,15 @@ class TestMergeHandlerFilters:
         request = AssistantSearchRequest(metadata={"owner": "attacker"})
         _merge_handler_filters_into_metadata(request, {"owner": "real-user"}, {})
         assert request.metadata == {"owner": "real-user"}
+
+    def test_handler_returning_both_nested_metadata_and_flat_keys_merges_both(self) -> None:
+        """A handler returning ``{"metadata": {"tenant": "x"}, "owner": "u1"}`` must
+        apply BOTH constraints. Earlier code returned after the nested branch and
+        silently dropped the flat keys — leaking rows the flat scope would exclude."""
+        request = AssistantSearchRequest(metadata={"env": "prod"})
+        _merge_handler_filters_into_metadata(
+            request,
+            {"metadata": {"tenant": "x"}, "owner": "u1"},
+            {},
+        )
+        assert request.metadata == {"env": "prod", "tenant": "x", "owner": "u1"}

--- a/libs/aegra-api/tests/unit/test_api/test_assistants_search_sort.py
+++ b/libs/aegra-api/tests/unit/test_api/test_assistants_search_sort.py
@@ -94,6 +94,13 @@ class TestMergeHandlerFilters:
         _merge_handler_filters_into_metadata(request, {"owner": "real-user"}, {})
         assert request.metadata == {"owner": "real-user"}
 
+    def test_value_metadata_set_to_non_mapping_does_not_crash(self) -> None:
+        """If a handler mutates ``value['metadata']`` to a non-mapping (e.g. a
+        bare string), the merge must skip rather than ``TypeError`` on ``**``."""
+        request = AssistantSearchRequest(metadata={"env": "prod"})
+        _merge_handler_filters_into_metadata(request, None, {"metadata": "not-a-dict"})
+        assert request.metadata == {"env": "prod"}
+
     def test_handler_returning_both_nested_metadata_and_flat_keys_merges_both(self) -> None:
         """A handler returning ``{"metadata": {"tenant": "x"}, "owner": "u1"}`` must
         apply BOTH constraints. Earlier code returned after the nested branch and

--- a/libs/aegra-api/tests/unit/test_api/test_assistants_search_sort.py
+++ b/libs/aegra-api/tests/unit/test_api/test_assistants_search_sort.py
@@ -1,0 +1,95 @@
+"""Unit tests for _resolve_sort and filter merging in /assistants/search."""
+
+import pytest
+from pydantic import ValidationError
+
+from aegra_api.api.assistants import (
+    _merge_handler_filters_into_metadata,
+    _resolve_sort,
+)
+from aegra_api.core.orm import Assistant as AssistantORM
+from aegra_api.models import AssistantSearchRequest
+
+
+def _col_name(column: object) -> str:
+    return getattr(column, "key", None) or getattr(column, "name", "")
+
+
+class TestResolveSort:
+    """_resolve_sort honours sort_by / sort_order."""
+
+    def test_default_is_created_at_desc(self) -> None:
+        column, asc = _resolve_sort(AssistantSearchRequest())
+        assert _col_name(column) == "created_at"
+        assert asc is False
+
+    def test_sort_by_defaults_to_desc(self) -> None:
+        column, asc = _resolve_sort(AssistantSearchRequest(sort_by="updated_at"))
+        assert _col_name(column) == "updated_at"
+        assert asc is False
+
+    def test_sort_by_asc(self) -> None:
+        column, asc = _resolve_sort(AssistantSearchRequest(sort_by="name", sort_order="asc"))
+        assert _col_name(column) == "name"
+        assert asc is True
+
+    def test_sort_by_desc_explicit(self) -> None:
+        column, asc = _resolve_sort(AssistantSearchRequest(sort_by="assistant_id", sort_order="desc"))
+        assert _col_name(column) == "assistant_id"
+        assert asc is False
+
+    def test_returns_real_orm_column(self) -> None:
+        column, _ = _resolve_sort(AssistantSearchRequest(sort_by="updated_at"))
+        assert column is AssistantORM.updated_at
+
+
+class TestSortByValidation:
+    """Pydantic validates sort_by against the Literal at request boundary."""
+
+    def test_invalid_sort_by_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            AssistantSearchRequest(sort_by="password; DROP TABLE assistants --")  # type: ignore[arg-type]
+
+    def test_invalid_sort_order_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            AssistantSearchRequest(sort_by="name", sort_order="sideways")  # type: ignore[arg-type]
+
+
+class TestMergeHandlerFilters:
+    """Auth-handler filters are merged into request.metadata, not a non-existent
+    request.filters attribute (regression test for #333)."""
+
+    def test_no_filters_no_value_metadata_leaves_metadata_alone(self) -> None:
+        request = AssistantSearchRequest(metadata={"keep": "me"})
+        _merge_handler_filters_into_metadata(request, None, {})
+        assert request.metadata == {"keep": "me"}
+
+    def test_handler_returns_flat_filters_merges_into_metadata(self) -> None:
+        """Handler returning ``{"owner": "u1"}`` becomes a metadata containment filter."""
+        request = AssistantSearchRequest(metadata={"env": "prod"})
+        _merge_handler_filters_into_metadata(request, {"owner": "u1"}, {})
+        assert request.metadata == {"env": "prod", "owner": "u1"}
+
+    def test_handler_returns_metadata_key_unwraps_it(self) -> None:
+        """Handler returning ``{"metadata": {"owner": "u1"}}`` is unwrapped, not nested."""
+        request = AssistantSearchRequest(metadata={"env": "prod"})
+        _merge_handler_filters_into_metadata(request, {"metadata": {"owner": "u1"}}, {})
+        assert request.metadata == {"env": "prod", "owner": "u1"}
+
+    def test_handler_mutated_value_metadata_is_picked_up(self) -> None:
+        """Handler that mutates ``value['metadata']`` instead of returning is honoured."""
+        request = AssistantSearchRequest(metadata={"env": "prod"})
+        value = {"metadata": {"owner": "u1"}}
+        _merge_handler_filters_into_metadata(request, None, value)
+        assert request.metadata == {"env": "prod", "owner": "u1"}
+
+    def test_request_filters_attribute_does_not_exist(self) -> None:
+        """The bug in #333 was code referencing a non-existent ``filters`` field;
+        confirm the model still has no such attribute so we don't regress."""
+        assert "filters" not in AssistantSearchRequest.model_fields
+
+    def test_handler_filters_override_request_metadata(self) -> None:
+        """When keys conflict, handler filters win (auth must not be bypassable)."""
+        request = AssistantSearchRequest(metadata={"owner": "attacker"})
+        _merge_handler_filters_into_metadata(request, {"owner": "real-user"}, {})
+        assert request.metadata == {"owner": "real-user"}


### PR DESCRIPTION
## Description

`POST /assistants/search` had two related defects that made the endpoint unusable under common configurations. This PR fixes both without changing the response shape or breaking existing callers.

1. **`request.filters` AttributeError (closes #333).** The handler in `api/assistants.py` referenced `request.filters` to merge auth-handler results, but `AssistantSearchRequest` has no `filters` field. As soon as an `@auth.on` handler returned a filter dict (the standard LangGraph SDK auth pattern shown in our own docs), `/assistants/search` 500'd with `AttributeError: 'AssistantSearchRequest' object has no attribute 'filters'`. Same shape on `/assistants/count`. `/assistants` (list) had a related silent bug — it constructed `AssistantSearchRequest(filters=...)` which Pydantic dropped, so auth filters were never applied to listing.

2. **No sort params, no default ordering.** `/assistants/search` had no `sort_by` / `sort_order`, no `order_by`, and the SQL query had no `ORDER BY`, so result rows came back in undefined order. Offset pagination was therefore non-deterministic — pages could overlap or skip rows when many assistants shared a column value, since Postgres is free to return tied rows in any order.

One commit, applies the same pattern as #322 to the assistants surface for cross-endpoint consistency.

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues

Fixes #333 — `[BUG] AttributeError: 'AssistantSearchRequest' object has no attribute 'filters'`. The sort-params + GIN-index work is the natural follow-up to #322 (the equivalent fix on the threads surface) and brings assistants to parity.

## Changes Made

- **`libs/aegra-api/src/aegra_api/api/assistants.py`** — added `_merge_handler_filters_into_metadata` helper that merges handler-returned filters (flat or under a `metadata` key) and value-mutated metadata into `request.metadata`, mirroring `create_assistant`'s pattern. Added `_resolve_sort` returning `(ORM column, is_ascending)` from the SDK-style `sort_by` / `sort_order`, defaulting to `created_at DESC`. Wired both into `/search`, `/count`, and `GET /assistants`.
- **`libs/aegra-api/src/aegra_api/models/assistants.py`** — added `sort_by: Literal["assistant_id", "name", "graph_id", "created_at", "updated_at"] | None` and `sort_order: Literal["asc", "desc"] | None` to `AssistantSearchRequest`. Fixed mutable default on `metadata` (`Field({})` → `Field(default_factory=dict)`).
- **`libs/aegra-api/src/aegra_api/services/assistant_service.py`** — `search_assistants` accepts `sort_column` / `sort_asc` kwargs; applies `ORDER BY <column> <dir>, assistant_id ASC`. Tie-break on `assistant_id` keeps offset pagination stable when the primary sort column has duplicates.
- **`libs/aegra-api/alembic/versions/20260504000000_add_gin_index_on_assistant_metadata.py`** — new GIN `jsonb_path_ops` index on `assistant.metadata`, mirroring the thread-side index added in revision `b7c8d9e0f123`. Backs the existing `metadata @> :filter` containment predicate.

`sort_by` is a strict `Literal` — invalid values 422 at the request boundary, never reaching `_resolve_sort` or the ORM. No SQL-injection surface; the helper uses `getattr(AssistantORM, request.sort_by)` only after Pydantic has validated against the whitelist.

## Testing

- [x] Unit tests added/updated — `libs/aegra-api/tests/unit/test_api/test_assistants_search_sort.py` (14 cases): `_resolve_sort` defaults / asc / desc / SDK-shape / real ORM column; Pydantic `ValidationError` on bad `sort_by` / `sort_order`; filter-merge regression including the explicit assertion that `filters` is not a field on `AssistantSearchRequest` — a fence so the bug can't return.
- [x] Integration tests added/updated — 7 new cases in `TestSearchAssistantsSortAndAuth` in `libs/aegra-api/tests/integration/test_api/test_assistants_crud.py`: sort wiring at the HTTP layer, 422 on malformed sort, regression for `/search`, `/count`, and `GET /assistants` when an auth handler returns flat filters (previously each of these 500'd or silently dropped the auth filters).
- [x] E2E tests added/updated — 3 new cases in `libs/aegra-api/tests/e2e/test_assistants/test_assistant_search.py` against real Postgres: sort-by-name asc, sort-by-name desc, pagination stability via the `assistant_id` tie-break across offset.
- [x] Manual testing performed — full stack via `docker compose up -d`, GIN migration applied cleanly (`b7c8d9e0f123 -> c8d9e0f1a234`), curl matrix on `/assistants/search` and `/assistants/count` returns 200/422 with no 500s.

### Test run

```
libs/aegra-api/tests/unit + integration: 1236 passed in 6.57s
libs/aegra-api/tests/e2e/test_assistants/test_assistant_search.py: 5 passed in 2.63s
```

## Checklist

- [x] Code follows project style (Ruff formatting) — `uv run ruff check` and `uv run ruff format --check` clean on all modified files
- [x] All linting checks pass
- [x] All tests pass
- [x] Documentation updated (if needed) — endpoint docs at `/docs` auto-update from the Pydantic model. No prose docs referenced `/assistants/search` request shape specifically.
- [x] PR title follows Conventional Commits format

## Backward compatibility

- `metadata` filter behavior unchanged (still JSONB containment via `@>`).
- `sort_by` / `sort_order` are additive — existing callers omitting them now see deterministic `created_at DESC` ordering, which matches the ordering the unindexed undefined-order results were already biased toward in practice. No response-shape change.
- The auth-handler fix is a strict bug fix: previously any non-trivial `@auth.on` handler made `/assistants/search` and `/assistants/count` unusable. Callers that were working around the bug by not returning filters from their handlers continue to work unchanged; callers that wanted to use auth filters can now do so.
- No writer changes, no backfill. Read-side fix only.

## Not done (deliberately)

- Mutable defaults on `AssistantCreate.metadata` / `AssistantUpdate.metadata` are unchanged. Out of scope for a search fix; would expand the diff into create/update paths that #333 doesn't touch.
- No legacy `order_by` field is introduced (it never existed on `AssistantSearchRequest`); only the SDK-shape `sort_by` / `sort_order` are added. This keeps the assistants request shape strictly additive.
- `assistant_versions` table is not indexed by metadata — search only hits the `assistant` table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed sorting for assistant search (selectable fields and asc/desc).
  * Added a JSONB GIN index to improve metadata query performance.

* **Bug Fixes**
  * Fixed merging of auth-handler filters into request metadata for list/search/count endpoints.
  * Ensured stable pagination across offset-based searches.

* **Tests**
  * Added end-to-end, integration, and unit tests covering sorting, metadata merging, and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two real defects on the `/assistants/search`, `/assistants/count`, and `GET /assistants` endpoints: the `AttributeError` on `request.filters` that caused 500s whenever an `@auth.on` handler returned a filter dict, and the missing `ORDER BY` that made offset pagination non-deterministic. Both fixes mirror the pattern already applied to the threads surface in #322, and the implementation is clean with solid test coverage at unit, integration, and e2e layers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previously flagged P1s are addressed and only a P2 deployment note remains.

No P0 or P1 issues found. The auth-filter AttributeError fix, sort wiring, and pagination stability are all correct. The one P2 is a deployment-quality suggestion (non-concurrent GIN index build) that mirrors the existing thread migration and does not affect correctness.

No files require special attention beyond the migration CONCURRENTLY note.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/assistants.py | Added `_resolve_sort` and `_merge_handler_filters_into_metadata` helpers; wired into search, count, and list handlers. Previously flagged issues (dead `_ALLOWED_SORT_FIELDS`, mixed-filter drop, 20-row cap on list) are all addressed. |
| libs/aegra-api/src/aegra_api/models/assistants.py | Added `sort_by`/`sort_order` Literal fields; fixed mutable default on `metadata` (`Field({})` → `Field(default_factory=dict)`). |
| libs/aegra-api/src/aegra_api/services/assistant_service.py | Added `sort_column`/`sort_asc` kwargs to `search_assistants` with `assistant_id` tie-break; added optional `metadata` filter to `list_assistants` without pagination. |
| libs/aegra-api/alembic/versions/20260504000000_add_gin_index_on_assistant_metadata.py | New GIN `jsonb_path_ops` index on `assistant.metadata`; correctly targets the `metadata` column that `metadata_dict` maps to in the ORM. Created without `CONCURRENTLY`, matching the thread migration precedent. |
| libs/aegra-api/tests/unit/test_api/test_assistants_search_sort.py | 14 unit cases covering `_resolve_sort` defaults/variants, Pydantic validation rejection, and all filter-merge scenarios including the mixed nested+flat regression fence. |
| libs/aegra-api/tests/integration/test_api/test_assistants_crud.py | 7 new integration cases in `TestSearchAssistantsSortAndAuth` covering sort wiring, 422 validation, and #333 regressions for search/count/list with auth handlers. |
| libs/aegra-api/tests/e2e/test_assistants/test_assistant_search.py | 3 new e2e cases against real Postgres: sort-by-name asc/desc and pagination stability via `assistant_id` tie-break. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Router as assistants.py (router)
    participant AuthHandler as handle_event
    participant Helper as _merge_handler_filters_into_metadata
    participant Service as AssistantService

    Client->>Router: POST /assistants/search {metadata, sort_by, sort_order}
    Router->>AuthHandler: handle_event(ctx, value)
    AuthHandler-->>Router: filters (e.g. {owner: u1}) or None
    Router->>Helper: merge filters + value[metadata] into request.metadata
    Helper-->>Router: request.metadata updated
    Router->>Router: _resolve_sort(request) → (column, asc)
    Router->>Service: search_assistants(request, identity, sort_column, sort_asc)
    Service->>Service: WHERE user_id ... AND metadata @> ... ORDER BY col ASC|DESC, assistant_id ASC LIMIT/OFFSET
    Service-->>Router: list[Assistant]
    Router-->>Client: 200 list[Assistant]

    Note over Router,Service: GET /assistants with auth handler active
    Client->>Router: GET /assistants
    Router->>AuthHandler: handle_event(ctx, {})
    AuthHandler-->>Router: filters or mutated value[metadata]
    Router->>Helper: merge into transient AssistantSearchRequest
    Router->>Service: list_assistants(identity, metadata=...) — no LIMIT/OFFSET
    Service-->>Router: list[Assistant]
    Router-->>Client: 200 AssistantList (all rows)
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Falembic%2Fversions%2F20260504000000_add_gin_index_on_assistant_metadata.py%3A26-33%0AThe%20index%20is%20built%20inside%20the%20default%20Alembic%20transaction%2C%20which%20acquires%20a%20%60SHARE%60%20lock%20on%20%60assistant%60%20for%20the%20full%20duration%20of%20the%20index%20build%20%E2%80%94%20blocking%20all%20%60INSERT%60%2F%60UPDATE%60%2F%60DELETE%60%20on%20that%20table.%20For%20a%20table%20with%20many%20rows%20this%20can%20cause%20measurable%20write%20downtime%20on%20deployment.%20The%20thread%20migration%20%28%60b7c8d9e0f123%60%29%20uses%20the%20same%20pattern%2C%20but%20adding%20%60postgresql_concurrently%3DTrue%60%20here%20%28and%20%60op.execute%28%22COMMIT%22%29%60%20before%20it%20to%20break%20out%20of%20the%20transaction%29%20would%20make%20this%20a%20zero-downtime%20operation.%20Worth%20considering%20before%20this%20lands%20on%20a%20production%20instance%20with%20significant%20assistant%20data.%0A%0A%60%60%60suggestion%0Adef%20upgrade%28%29%20-%3E%20None%3A%0A%20%20%20%20%23%20Build%20concurrently%20to%20avoid%20a%20SHARE%20lock%20on%20%60assistant%60%20during%20deployment.%0A%20%20%20%20%23%20Must%20run%20outside%20a%20transaction%20block%20%E2%80%94%20execute%20COMMIT%20first.%0A%20%20%20%20op.execute%28%22COMMIT%22%29%0A%20%20%20%20op.create_index%28%0A%20%20%20%20%20%20%20%20INDEX_NAME%2C%0A%20%20%20%20%20%20%20%20%22assistant%22%2C%0A%20%20%20%20%20%20%20%20%5B%22metadata%22%5D%2C%0A%20%20%20%20%20%20%20%20postgresql_using%3D%22gin%22%2C%0A%20%20%20%20%20%20%20%20postgresql_ops%3D%7B%22metadata%22%3A%20%22jsonb_path_ops%22%7D%2C%0A%20%20%20%20%20%20%20%20postgresql_concurrently%3DTrue%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Falembic%2Fversions%2F20260504000000_add_gin_index_on_assistant_metadata.py%3A26-33%0AThe%20index%20is%20built%20inside%20the%20default%20Alembic%20transaction%2C%20which%20acquires%20a%20%60SHARE%60%20lock%20on%20%60assistant%60%20for%20the%20full%20duration%20of%20the%20index%20build%20%E2%80%94%20blocking%20all%20%60INSERT%60%2F%60UPDATE%60%2F%60DELETE%60%20on%20that%20table.%20For%20a%20table%20with%20many%20rows%20this%20can%20cause%20measurable%20write%20downtime%20on%20deployment.%20The%20thread%20migration%20%28%60b7c8d9e0f123%60%29%20uses%20the%20same%20pattern%2C%20but%20adding%20%60postgresql_concurrently%3DTrue%60%20here%20%28and%20%60op.execute%28%22COMMIT%22%29%60%20before%20it%20to%20break%20out%20of%20the%20transaction%29%20would%20make%20this%20a%20zero-downtime%20operation.%20Worth%20considering%20before%20this%20lands%20on%20a%20production%20instance%20with%20significant%20assistant%20data.%0A%0A%60%60%60suggestion%0Adef%20upgrade%28%29%20-%3E%20None%3A%0A%20%20%20%20%23%20Build%20concurrently%20to%20avoid%20a%20SHARE%20lock%20on%20%60assistant%60%20during%20deployment.%0A%20%20%20%20%23%20Must%20run%20outside%20a%20transaction%20block%20%E2%80%94%20execute%20COMMIT%20first.%0A%20%20%20%20op.execute%28%22COMMIT%22%29%0A%20%20%20%20op.create_index%28%0A%20%20%20%20%20%20%20%20INDEX_NAME%2C%0A%20%20%20%20%20%20%20%20%22assistant%22%2C%0A%20%20%20%20%20%20%20%20%5B%22metadata%22%5D%2C%0A%20%20%20%20%20%20%20%20postgresql_using%3D%22gin%22%2C%0A%20%20%20%20%20%20%20%20postgresql_ops%3D%7B%22metadata%22%3A%20%22jsonb_path_ops%22%7D%2C%0A%20%20%20%20%20%20%20%20postgresql_concurrently%3DTrue%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0A&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fassistants-search-filters-and-sort%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fassistants-search-filters-and-sort%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Falembic%2Fversions%2F20260504000000_add_gin_index_on_assistant_metadata.py%3A26-33%0AThe%20index%20is%20built%20inside%20the%20default%20Alembic%20transaction%2C%20which%20acquires%20a%20%60SHARE%60%20lock%20on%20%60assistant%60%20for%20the%20full%20duration%20of%20the%20index%20build%20%E2%80%94%20blocking%20all%20%60INSERT%60%2F%60UPDATE%60%2F%60DELETE%60%20on%20that%20table.%20For%20a%20table%20with%20many%20rows%20this%20can%20cause%20measurable%20write%20downtime%20on%20deployment.%20The%20thread%20migration%20%28%60b7c8d9e0f123%60%29%20uses%20the%20same%20pattern%2C%20but%20adding%20%60postgresql_concurrently%3DTrue%60%20here%20%28and%20%60op.execute%28%22COMMIT%22%29%60%20before%20it%20to%20break%20out%20of%20the%20transaction%29%20would%20make%20this%20a%20zero-downtime%20operation.%20Worth%20considering%20before%20this%20lands%20on%20a%20production%20instance%20with%20significant%20assistant%20data.%0A%0A%60%60%60suggestion%0Adef%20upgrade%28%29%20-%3E%20None%3A%0A%20%20%20%20%23%20Build%20concurrently%20to%20avoid%20a%20SHARE%20lock%20on%20%60assistant%60%20during%20deployment.%0A%20%20%20%20%23%20Must%20run%20outside%20a%20transaction%20block%20%E2%80%94%20execute%20COMMIT%20first.%0A%20%20%20%20op.execute%28%22COMMIT%22%29%0A%20%20%20%20op.create_index%28%0A%20%20%20%20%20%20%20%20INDEX_NAME%2C%0A%20%20%20%20%20%20%20%20%22assistant%22%2C%0A%20%20%20%20%20%20%20%20%5B%22metadata%22%5D%2C%0A%20%20%20%20%20%20%20%20postgresql_using%3D%22gin%22%2C%0A%20%20%20%20%20%20%20%20postgresql_ops%3D%7B%22metadata%22%3A%20%22jsonb_path_ops%22%7D%2C%0A%20%20%20%20%20%20%20%20postgresql_concurrently%3DTrue%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["fix(api): guard non-mapping value\[&#39;metad..."](https://github.com/aegra/aegra/commit/47107a95001c697a308688289f38e28de25bd225) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30674091)</sub>

<!-- /greptile_comment -->