### PR TITLE
feat(api): add POST /threads/{id}/copy endpoint

### DIFF
--- a/docs/guides/threads-and-state.mdx
+++ b/docs/guides/threads-and-state.mdx
@@ -152,6 +152,35 @@ Deleting a thread cancels any active runs and removes all state:
 await client.threads.delete(thread_id)
 ```
 
+## Copying threads
+
+`POST /threads/{thread_id}/copy` produces a new thread whose checkpoint history is identical to the source, matching the `client.threads.copy()` semantics on LangSmith Deployments. The `checkpoint_id` and `parent_checkpoint_id` chain are preserved verbatim, so the new thread can be queried by the same checkpoint identifiers as the source and `get_state_at_checkpoint(...)` returns the same values on both sides.
+
+```python
+new_thread = await client.threads.copy(thread_id)
+print(new_thread["thread_id"])  # freshly generated UUID
+```
+
+### What is preserved
+
+- The full checkpoint history (`checkpoints`, `checkpoint_writes`, `checkpoint_blobs` rows) under the new `thread_id`.
+- Thread `status` from the source — including non-idle states like `running` or `error` if present at the time of the copy.
+- Thread metadata, with two adjustments described below.
+
+### What is regenerated
+
+- `thread_id`: a fresh UUID is always generated server-side.
+- `created_at` and `updated_at`: set to the time of the copy, not inherited from the source.
+- `metadata.owner`: rewritten to the caller's identity, matching `POST /threads` (creation) behaviour. The source thread's owner attribution is intentionally not inherited so any code reading `metadata.owner` instead of the canonical `user_id` column stays consistent.
+
+### Atomicity
+
+Both the new thread row and the three checkpoint-table `INSERT...SELECT` statements run inside a single Postgres transaction at `REPEATABLE READ` isolation on the checkpointer pool. A concurrent writer on the source thread (for example a run mid-execution) cannot leave the new thread with a partially-copied checkpoint history: the snapshot is pinned at transaction start, and on any failure the whole copy is rolled back. There is no intermediate state where a new thread row exists without its checkpoint chain or vice versa.
+
+### Authorization
+
+The endpoint requires the caller to own the source thread (`user_id == user.identity`); a missing or non-owned source thread returns `404`. Custom auth handlers registered for `threads:create` see the new `thread_id` in the event payload (alongside `src_thread_id`) so they can provision per-thread resources keyed to the new row.
+
 ## Thread metadata
 
 Threads automatically track metadata about their usage:

--- a/docs/guides/threads-and-state.mdx
+++ b/docs/guides/threads-and-state.mdx
@@ -164,22 +164,23 @@ print(new_thread["thread_id"])  # freshly generated UUID
 ### What is preserved
 
 - The full checkpoint history (`checkpoints`, `checkpoint_writes`, `checkpoint_blobs` rows) under the new `thread_id`.
-- Thread `status` from the source — including non-idle states like `running` or `error` if present at the time of the copy.
-- Thread metadata, with two adjustments described below.
+- Thread metadata, inherited as-is except for the two adjustments below. This includes keys written by previous runs, auth handlers, or admin tooling — if a key must not propagate to copies, strip it in a `threads:create` handler.
+- `assistant_id` / `graph_id` in metadata are kept intentionally, so a copy can continue the same conversation (fork use case).
 
 ### What is regenerated
 
 - `thread_id`: a fresh UUID is always generated server-side.
 - `created_at` and `updated_at`: set to the time of the copy, not inherited from the source.
+- `status`: active states (`busy`/`running`) reset to `idle`; other states (`idle`, `error`, `interrupted`) copy verbatim. The copy has no `runs` row, so an inherited active status would never transition and the thread would appear permanently stuck.
 - `metadata.owner`: rewritten to the caller's identity, matching `POST /threads` (creation) behaviour. The source thread's owner attribution is intentionally not inherited so any code reading `metadata.owner` instead of the canonical `user_id` column stays consistent.
 
 ### Atomicity
 
-Both the new thread row and the three checkpoint-table `INSERT...SELECT` statements run inside a single Postgres transaction at `REPEATABLE READ` isolation on the checkpointer pool. A concurrent writer on the source thread (for example a run mid-execution) cannot leave the new thread with a partially-copied checkpoint history: the snapshot is pinned at transaction start, and on any failure the whole copy is rolled back. There is no intermediate state where a new thread row exists without its checkpoint chain or vice versa.
+The new thread row and the three checkpoint-table `INSERT...SELECT` statements all run inside a single Postgres transaction at `REPEATABLE READ` isolation on the checkpointer pool, reading the source thread row and its checkpoint history from one pinned snapshot. A concurrent writer on the source (for example a run mid-execution) cannot leave the copy with a partially-copied history or a thread row inconsistent with it: the snapshot is fixed at transaction start, and any failure rolls the whole copy back. There is no intermediate state where a new thread row exists without its checkpoint chain or vice versa.
 
 ### Authorization
 
-The endpoint requires the caller to own the source thread (`user_id == user.identity`); a missing or non-owned source thread returns `404`. Custom auth handlers registered for `threads:create` see the new `thread_id` in the event payload (alongside `src_thread_id`) so they can provision per-thread resources keyed to the new row.
+The endpoint requires the caller to own the source thread (`user_id == user.identity`); a missing or non-owned source thread returns `404`. Copies reuse the `threads:create` auth event rather than a dedicated `threads:copy` hook: handlers see the new `thread_id` alongside `src_thread_id` in the payload, so a handler that needs copy-specific policy (blocking cross-tenant copies, a separate quota counter) can branch on the presence of `src_thread_id`.
 
 ## Thread metadata
 

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -890,13 +890,21 @@ async def copy_thread(
     # Atomic INSERT thread row + checkpoint INSERT...SELECT inside a single
     # Postgres transaction on the checkpointer pool. Avoids the cross-pool
     # split that would leave orphaned checkpoint rows on partial failure.
-    await copy_thread_atomically(
-        src_thread_id=thread_id,
-        new_thread_id=new_id,
-        src_status=src.status,
-        src_metadata=src.metadata_json or {},
-        user_identity=user.identity,
-    )
+    try:
+        await copy_thread_atomically(
+            src_thread_id=thread_id,
+            new_thread_id=new_id,
+            src_status=src.status,
+            src_metadata=src.metadata_json or {},
+            user_identity=user.identity,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to copy thread",
+            src_thread_id=thread_id,
+            new_thread_id=new_id,
+        )
+        raise HTTPException(500, "Failed to copy thread") from None
 
     # Reload the freshly-inserted row through the ORM so the response is
     # built from the same shape ``_serialize_thread`` expects elsewhere.

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -906,6 +906,14 @@ async def copy_thread(
         )
         raise HTTPException(500, "Failed to copy thread") from None
 
+    # End the implicit session transaction before reloading. Postgres' default
+    # READ COMMITTED snapshot would let the lg_pool INSERT show through anyway,
+    # but stricter isolation levels (REPEATABLE READ / SERIALIZABLE) freeze the
+    # session snapshot at transaction start and the new row would be invisible.
+    # Committing here makes the reload robust regardless of the engine's
+    # isolation_level setting.
+    await session.commit()
+
     # Reload the freshly-inserted row through the ORM so the response is
     # built from the same shape ``_serialize_thread`` expects elsewhere.
     new_thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == new_id))

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -873,8 +873,19 @@ async def copy_thread(
     are regenerated to the time of the copy.
     """
     # Authorization check — modelled on POST /threads (creation event).
+    # We generate ``new_id`` up-front and pass it inside the event payload
+    # so handlers that provision per-thread resources (tenant_id, quota
+    # markers, billing tags) key those resources to the new row rather
+    # than the source.  We also capture the handler return value the same
+    # way ``create_thread`` does, so handler-enforced metadata mutations
+    # propagate to the copy — without that capture, ``/copy`` would be a
+    # bypass path for invariants every directly-created thread carries.
+    new_id = str(uuid4())
     ctx = build_auth_context(user, "threads", "create")
-    await handle_event(ctx, {"thread_id": thread_id})
+    filters = await handle_event(
+        ctx,
+        {"thread_id": new_id, "src_thread_id": thread_id},
+    )
 
     src = await session.scalar(
         select(ThreadORM).where(
@@ -885,7 +896,16 @@ async def copy_thread(
     if not src:
         raise HTTPException(404, f"Thread '{thread_id}' not found")
 
-    new_id = str(uuid4())
+    # Apply handler-returned metadata mutations on top of the source's
+    # metadata before the copy lands.  Mirrors ``create_thread`` lines
+    # 172–180.  ``copy_thread_atomically`` then rewrites
+    # ``metadata["owner"] = user.identity`` last, so the security
+    # invariant wins over any owner field a handler might inject.
+    src_metadata = dict(src.metadata_json or {})
+    if filters and "metadata" in filters:
+        handler_meta = filters["metadata"]
+        if isinstance(handler_meta, dict):
+            src_metadata = {**src_metadata, **handler_meta}
 
     # Atomic INSERT thread row + checkpoint INSERT...SELECT inside a single
     # Postgres transaction on the checkpointer pool. Avoids the cross-pool
@@ -895,7 +915,7 @@ async def copy_thread(
             src_thread_id=thread_id,
             new_thread_id=new_id,
             src_status=src.status,
-            src_metadata=src.metadata_json or {},
+            src_metadata=src_metadata,
             user_identity=user.identity,
         )
     except Exception:

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -861,25 +861,13 @@ async def copy_thread(
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
 ) -> Thread:
-    """Deep-copy a thread, preserving its checkpoint history.
+    """Deep-copy a thread, preserving its ``checkpoint_id`` chain.
 
-    Creates a new thread with a freshly generated ``thread_id`` whose
-    checkpoint chain is identical to the source: ``checkpoint_id`` and
-    ``parent_checkpoint_id`` are kept as-is so the new thread can be
-    queried by the same checkpoint identifiers as the source. Thread-level
-    metadata and status are deep-copied as-is — including statuses such
-    as ``running`` or ``error`` if present on the source — matching
-    LangSmith Deployments behaviour. ``created_at`` and ``updated_at``
-    are regenerated to the time of the copy.
+    Status and metadata are inherited from the source (including ``running``
+    or ``error``); ``created_at``/``updated_at`` are regenerated.
     """
-    # Authorization check — modelled on POST /threads (creation event).
-    # We generate ``new_id`` up-front and pass it inside the event payload
-    # so handlers that provision per-thread resources (tenant_id, quota
-    # markers, billing tags) key those resources to the new row rather
-    # than the source.  We also capture the handler return value the same
-    # way ``create_thread`` does, so handler-enforced metadata mutations
-    # propagate to the copy — without that capture, ``/copy`` would be a
-    # bypass path for invariants every directly-created thread carries.
+    # ``new_id`` is generated up-front and exposed to the auth event so handlers
+    # can key per-thread resources (tenant, quota, billing) to the new row.
     new_id = str(uuid4())
     ctx = build_auth_context(user, "threads", "create")
     filters = await handle_event(
@@ -896,20 +884,14 @@ async def copy_thread(
     if not src:
         raise HTTPException(404, f"Thread '{thread_id}' not found")
 
-    # Apply handler-returned metadata mutations on top of the source's
-    # metadata before the copy lands.  Mirrors ``create_thread`` lines
-    # 172–180.  ``copy_thread_atomically`` then rewrites
-    # ``metadata["owner"] = user.identity`` last, so the security
-    # invariant wins over any owner field a handler might inject.
+    # Mirror ``create_thread``: handler metadata wins over source, then
+    # ``copy_thread_atomically`` rewrites ``owner`` last as security invariant.
     src_metadata = dict(src.metadata_json or {})
     if filters and "metadata" in filters:
         handler_meta = filters["metadata"]
         if isinstance(handler_meta, dict):
             src_metadata = {**src_metadata, **handler_meta}
 
-    # Atomic INSERT thread row + checkpoint INSERT...SELECT inside a single
-    # Postgres transaction on the checkpointer pool. Avoids the cross-pool
-    # split that would leave orphaned checkpoint rows on partial failure.
     try:
         await copy_thread_atomically(
             src_thread_id=thread_id,
@@ -926,19 +908,13 @@ async def copy_thread(
         )
         raise HTTPException(500, "Failed to copy thread") from None
 
-    # End the implicit session transaction before reloading. Postgres' default
-    # READ COMMITTED snapshot would let the lg_pool INSERT show through anyway,
-    # but stricter isolation levels (REPEATABLE READ / SERIALIZABLE) freeze the
-    # session snapshot at transaction start and the new row would be invisible.
-    # Committing here makes the reload robust regardless of the engine's
-    # isolation_level setting.
+    # Commit before reload so REPEATABLE READ/SERIALIZABLE engines see the row
+    # (the lg_pool INSERT is invisible to a frozen session snapshot otherwise).
     await session.commit()
 
-    # Reload the freshly-inserted row through the ORM so the response is
-    # built from the same shape ``_serialize_thread`` expects elsewhere.
     new_thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == new_id))
     if new_thread is None:
-        # Should be unreachable: the atomic INSERT just committed.
+        # Unreachable: the atomic INSERT just committed.
         raise HTTPException(500, "Thread copy committed but the row could not be reloaded")
 
     return _serialize_thread(new_thread)

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -35,6 +35,7 @@ from aegra_api.models import (
 )
 from aegra_api.models.errors import CONFLICT, NOT_FOUND
 from aegra_api.services.streaming_service import streaming_service
+from aegra_api.services.thread_copy import copy_thread_atomically
 from aegra_api.services.thread_state_service import ThreadStateService
 from aegra_api.utils.run_utils import strip_pinned_config_keys
 
@@ -852,6 +853,59 @@ async def delete_thread(
     await session.commit()
 
     return {"status": "deleted"}
+
+
+@router.post("/threads/{thread_id}/copy", response_model=Thread, responses={**NOT_FOUND})
+async def copy_thread(
+    thread_id: str,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> Thread:
+    """Deep-copy a thread, preserving its checkpoint history.
+
+    Creates a new thread with a freshly generated ``thread_id`` whose
+    checkpoint chain is identical to the source: ``checkpoint_id`` and
+    ``parent_checkpoint_id`` are kept as-is so the new thread can be
+    queried by the same checkpoint identifiers as the source. Thread-level
+    metadata and status are deep-copied as-is — including statuses such
+    as ``running`` or ``error`` if present on the source — matching
+    LangSmith Deployments behaviour. ``created_at`` and ``updated_at``
+    are regenerated to the time of the copy.
+    """
+    # Authorization check — modelled on POST /threads (creation event).
+    ctx = build_auth_context(user, "threads", "create")
+    await handle_event(ctx, {"thread_id": thread_id})
+
+    src = await session.scalar(
+        select(ThreadORM).where(
+            ThreadORM.thread_id == thread_id,
+            ThreadORM.user_id == user.identity,
+        )
+    )
+    if not src:
+        raise HTTPException(404, f"Thread '{thread_id}' not found")
+
+    new_id = str(uuid4())
+
+    # Atomic INSERT thread row + checkpoint INSERT...SELECT inside a single
+    # Postgres transaction on the checkpointer pool. Avoids the cross-pool
+    # split that would leave orphaned checkpoint rows on partial failure.
+    await copy_thread_atomically(
+        src_thread_id=thread_id,
+        new_thread_id=new_id,
+        src_status=src.status,
+        src_metadata=src.metadata_json or {},
+        user_identity=user.identity,
+    )
+
+    # Reload the freshly-inserted row through the ORM so the response is
+    # built from the same shape ``_serialize_thread`` expects elsewhere.
+    new_thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == new_id))
+    if new_thread is None:
+        # Should be unreachable: the atomic INSERT just committed.
+        raise HTTPException(500, "Thread copy committed but the row could not be reloaded")
+
+    return _serialize_thread(new_thread)
 
 
 @router.post("/threads/search", response_model=list[Thread])

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -863,11 +863,14 @@ async def copy_thread(
 ) -> Thread:
     """Deep-copy a thread, preserving its ``checkpoint_id`` chain.
 
-    Status and metadata are inherited from the source (including ``running``
-    or ``error``); ``created_at``/``updated_at`` are regenerated.
+    Metadata is inherited from the source; ``created_at``/``updated_at`` are
+    regenerated and active ``status`` (``busy``/``running``) resets to
+    ``idle`` since the copy has no run to advance it.
     """
     # ``new_id`` is generated up-front and exposed to the auth event so handlers
     # can key per-thread resources (tenant, quota, billing) to the new row.
+    # ``threads:create`` fires for copies too; ``src_thread_id`` in the payload
+    # lets a handler apply copy-specific policy without a dedicated event.
     new_id = str(uuid4())
     ctx = build_auth_context(user, "threads", "create")
     filters = await handle_event(
@@ -884,32 +887,31 @@ async def copy_thread(
     if not src:
         raise HTTPException(404, f"Thread '{thread_id}' not found")
 
-    # Mirror ``create_thread``: handler metadata wins over source, then
-    # ``copy_thread_atomically`` rewrites ``owner`` last as security invariant.
-    src_metadata = dict(src.metadata_json or {})
-    if filters and "metadata" in filters:
+    # Only the handler overrides travel to the copy; source metadata is read
+    # inside the snapshot by ``copy_thread_atomically`` and merged there, with
+    # ``owner`` rewritten to the caller last as a security invariant.
+    handler_meta: dict[str, Any] = {}
+    if filters and isinstance(filters.get("metadata"), dict):
         handler_meta = filters["metadata"]
-        if isinstance(handler_meta, dict):
-            src_metadata = {**src_metadata, **handler_meta}
 
     try:
         await copy_thread_atomically(
             src_thread_id=thread_id,
             new_thread_id=new_id,
-            src_status=src.status,
-            src_metadata=src_metadata,
             user_identity=user.identity,
+            metadata_overrides=handler_meta,
         )
-    except Exception:
+    except Exception as e:
         logger.exception(
             "Failed to copy thread",
             src_thread_id=thread_id,
             new_thread_id=new_id,
         )
-        raise HTTPException(500, "Failed to copy thread") from None
+        raise HTTPException(500, "Failed to copy thread") from e
 
-    # Commit before reload so REPEATABLE READ/SERIALIZABLE engines see the row
-    # (the lg_pool INSERT is invisible to a frozen session snapshot otherwise).
+    # ``copy_thread_atomically`` already committed via lg_pool — the source of
+    # truth. Do not ``session.add(...)`` above this line: an ORM rollback would
+    # orphan the durable copy. Commit so the reload snapshot sees the new row.
     await session.commit()
 
     new_thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == new_id))

--- a/libs/aegra-api/src/aegra_api/services/thread_copy.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_copy.py
@@ -7,27 +7,43 @@ semantics of ``POST /threads/{id}/copy`` on LangSmith Deployments.
 
 Both the thread row INSERT and the three checkpoint-table INSERT...SELECT
 statements run inside a single Postgres transaction on the
-``langgraph-checkpoint-postgres`` connection pool, so the copy is atomic:
-either the new thread and its full checkpoint history land together, or
-nothing does. Going through one pool also avoids cross-pool tx coordination
-between SQLAlchemy and the checkpointer pool, which would otherwise leave
+``langgraph-checkpoint-postgres`` connection pool, raised to
+REPEATABLE READ isolation. Without that level, a concurrent writer on the
+source thread (e.g. a run mid-execution) could commit between the three
+INSERT...SELECT statements, leaving the new thread with an inconsistent
+slice of the checkpoint history. REPEATABLE READ pins the snapshot at
+transaction start so the three SELECTs see the same consistent view, and
+on any failure the whole copy is rolled back.
+
+Going through one pool also avoids cross-pool tx coordination between
+SQLAlchemy and the checkpointer pool, which would otherwise leave
 orphaned checkpoint rows on partial failures.
 
 Column lists for the checkpoint tables are introspected at runtime via
-``information_schema`` so the copy stays correct if the upstream
-``langgraph-checkpoint-postgres`` schema gains columns (``task_path`` was
-one such recent addition).
+``pg_catalog.pg_attribute`` keyed on ``to_regclass(<table>)``. This is
+the same path the unqualified ``INSERT INTO <table>`` statements use to
+resolve their target relation — they both follow the connection's
+``search_path``. Using ``information_schema.columns`` filtered by
+``current_schema()`` would only inspect the *first* schema in the
+search path, which is fine for default deployments but breaks under
+non-default ``search_path`` configurations (the introspection returns
+zero rows even though the unqualified DML still finds the table in a
+later schema). Forward-compat: new columns added upstream
+(``task_path`` was one such recent addition) are picked up automatically.
 """
 
-import json
 from typing import TYPE_CHECKING, Any
 
+import structlog
 from psycopg import sql as pgsql
+from psycopg.types.json import Jsonb
 
 from aegra_api.core.database import db_manager
 
 if TYPE_CHECKING:
     from psycopg import AsyncConnection
+
+logger = structlog.getLogger(__name__)
 
 # Tables managed by langgraph-checkpoint-postgres. Each has ``thread_id``
 # as a non-PK leading column; the copy preserves all other columns verbatim.
@@ -37,15 +53,22 @@ _CHECKPOINT_TABLES: tuple[str, ...] = ("checkpoints", "checkpoint_writes", "chec
 async def _table_columns(conn: "AsyncConnection", table: str) -> list[str]:
     """Return the column names of ``table`` in declaration order.
 
+    Resolves ``table`` through ``to_regclass`` so the introspection
+    follows the connection's ``search_path`` exactly the way an
+    unqualified ``INSERT INTO <table>`` would. Filters out dropped
+    columns via ``attisdropped`` — ``pg_attribute`` retains tombstone
+    rows for dropped columns, unlike ``information_schema.columns``.
+
     The aegra connection pool is configured with ``dict_row`` (see
     ``core/database.py`` — LangGraph requires dictionary rows), so each
-    fetched row is a ``dict``. Access columns by name to stay compatible
-    with the pool factory rather than relying on positional indexing.
+    fetched row is a ``dict``. The ``AS column_name`` alias preserves
+    that contract for callers (and existing tests).
     """
     cur = await conn.execute(
-        "SELECT column_name FROM information_schema.columns "
-        "WHERE table_schema = current_schema() AND table_name = %s "
-        "ORDER BY ordinal_position",
+        "SELECT attname AS column_name FROM pg_catalog.pg_attribute "
+        "WHERE attrelid = to_regclass(%s) "
+        "AND attnum > 0 AND NOT attisdropped "
+        "ORDER BY attnum",
         (table,),
     )
     rows = await cur.fetchall()
@@ -68,7 +91,7 @@ async def _copy_checkpoint_table(
 
     Identifiers (table name + column names) are composed via
     ``psycopg.sql.Identifier`` rather than f-string quoting. The inputs
-    come from ``information_schema``, so an exotic identifier containing a
+    come from ``pg_attribute``, so an exotic identifier containing a
     literal double-quote would silently break naive ``f'"{c}"'`` quoting;
     using the typed composer eliminates that class of bug.
     """
@@ -95,27 +118,55 @@ async def copy_thread_atomically(
     """Atomically insert the new thread row and copy the checkpoint history.
 
     Runs the thread-row INSERT and the three checkpoint INSERT...SELECT
-    statements inside one Postgres transaction. On any failure the whole
-    copy is rolled back, preventing orphaned checkpoint rows or a thread
-    row without its history.
+    statements inside one Postgres transaction at REPEATABLE READ
+    isolation. On any failure the whole copy is rolled back, preventing
+    orphaned checkpoint rows or a thread row without its history.
 
-    ``created_at`` and ``updated_at`` are set to ``NOW()`` to mark the time
-    of the copy (matching LangSmith Deployments behaviour) rather than
-    inheriting the source timestamps. Status and metadata are inherited
-    from the source as-is — including statuses such as ``running`` or
-    ``error`` if present.
+    The new thread's ``metadata.owner`` is rewritten to ``user_identity``
+    (mirroring ``create_thread``, which enforces the same invariant for
+    fresh threads). Without this, the source thread's owner attribution
+    would be inherited by the copy — an internal-consistency bug for any
+    code that reads ``metadata.owner`` instead of the canonical
+    ``thread.user_id`` column. ``user_id`` is correctly bound to the
+    caller via the dedicated parameter.
+
+    ``created_at`` and ``updated_at`` are set to ``NOW()`` to mark the
+    time of the copy (matching LangSmith Deployments behaviour) rather
+    than inheriting the source timestamps. Status is inherited from the
+    source as-is — including statuses such as ``running`` or ``error``
+    if present.
     """
     if db_manager.lg_pool is None:
         raise RuntimeError("Checkpoint pool is not initialized")
 
-    metadata_json = json.dumps(src_metadata or {})
+    # Shallow copy is sufficient — we only mutate the top-level ``owner``
+    # key, so any nested values shared with the caller's dict are safe to
+    # alias.  ``dict(None or {})`` also defends against a ``None`` argument
+    # without an explicit branch.
+    metadata = dict(src_metadata or {})
+    metadata["owner"] = user_identity
 
     async with db_manager.lg_pool.connection() as conn, conn.transaction():
+        # Pin the transaction snapshot so the three checkpoint INSERT...SELECT
+        # statements see a consistent view of the source thread, even if a
+        # concurrent run on that thread is committing checkpoints. Must be
+        # the first statement in the transaction for PostgreSQL to honour it.
+        await conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
         await conn.execute(
             'INSERT INTO "thread" ("thread_id", "status", "metadata_json", "user_id", '
             '"created_at", "updated_at") '
-            "VALUES (%s, %s, %s::jsonb, %s, NOW(), NOW())",
-            (new_thread_id, src_status, metadata_json, user_identity),
+            "VALUES (%s, %s, %s, %s, NOW(), NOW())",
+            (new_thread_id, src_status, Jsonb(metadata), user_identity),
         )
         for table in _CHECKPOINT_TABLES:
             await _copy_checkpoint_table(conn, table, src_thread_id, new_thread_id)
+    # Audit log on success — ISO 27017/27018 expect data-duplication events
+    # to be traceable to caller, source, target, and timestamp. The failure
+    # path emits ``logger.exception`` from the API layer; this completes the
+    # pair so the operation is observable in both outcomes.
+    logger.info(
+        "thread.copy",
+        src_thread_id=src_thread_id,
+        new_thread_id=new_thread_id,
+        user_identity=user_identity,
+    )

--- a/libs/aegra-api/src/aegra_api/services/thread_copy.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_copy.py
@@ -1,0 +1,104 @@
+"""Thread copy service.
+
+Implements deep-copy of a thread (its row in ``thread`` plus its checkpoint
+history) at the SQL level so that ``checkpoint_id`` and the
+``parent_checkpoint_id`` chain are preserved end-to-end, matching the
+semantics of ``POST /threads/{id}/copy`` on LangSmith Deployments.
+
+Both the thread row INSERT and the three checkpoint-table INSERT...SELECT
+statements run inside a single Postgres transaction on the
+``langgraph-checkpoint-postgres`` connection pool, so the copy is atomic:
+either the new thread and its full checkpoint history land together, or
+nothing does. Going through one pool also avoids cross-pool tx coordination
+between SQLAlchemy and the checkpointer pool, which would otherwise leave
+orphaned checkpoint rows on partial failures.
+
+Column lists for the checkpoint tables are introspected at runtime via
+``information_schema`` so the copy stays correct if the upstream
+``langgraph-checkpoint-postgres`` schema gains columns (``task_path`` was
+one such recent addition).
+"""
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from aegra_api.core.database import db_manager
+
+if TYPE_CHECKING:
+    from psycopg import AsyncConnection
+
+# Tables managed by langgraph-checkpoint-postgres. Each has ``thread_id``
+# as a non-PK leading column; the copy preserves all other columns verbatim.
+_CHECKPOINT_TABLES: tuple[str, ...] = ("checkpoints", "checkpoint_writes", "checkpoint_blobs")
+
+
+async def _table_columns(conn: "AsyncConnection", table: str) -> list[str]:
+    """Return the column names of ``table`` in declaration order.
+
+    The aegra connection pool is configured with ``dict_row`` (see
+    ``core/database.py`` — LangGraph requires dictionary rows), so each
+    fetched row is a ``dict``. Access columns by name to stay compatible
+    with the pool factory rather than relying on positional indexing.
+    """
+    cur = await conn.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = current_schema() AND table_name = %s "
+        "ORDER BY ordinal_position",
+        (table,),
+    )
+    rows = await cur.fetchall()
+    return [r["column_name"] for r in rows]
+
+
+async def _copy_checkpoint_table(
+    conn: "AsyncConnection",
+    table: str,
+    src_thread_id: str,
+    new_thread_id: str,
+) -> None:
+    """Copy all rows of ``table`` matching ``src_thread_id`` under ``new_thread_id``."""
+    cols = await _table_columns(conn, table)
+    if "thread_id" not in cols:
+        # Defensive: schema unexpected, skip rather than raise to avoid
+        # breaking the whole copy on a transient introspection issue.
+        return
+    other_cols = [c for c in cols if c != "thread_id"]
+    cols_csv = ", ".join(f'"{c}"' for c in other_cols)
+    sql = f'INSERT INTO "{table}" ("thread_id", {cols_csv}) SELECT %s, {cols_csv} FROM "{table}" WHERE thread_id = %s'
+    await conn.execute(sql, (new_thread_id, src_thread_id))
+
+
+async def copy_thread_atomically(
+    src_thread_id: str,
+    new_thread_id: str,
+    src_status: str,
+    src_metadata: dict[str, Any],
+    user_identity: str,
+) -> None:
+    """Atomically insert the new thread row and copy the checkpoint history.
+
+    Runs the thread-row INSERT and the three checkpoint INSERT...SELECT
+    statements inside one Postgres transaction. On any failure the whole
+    copy is rolled back, preventing orphaned checkpoint rows or a thread
+    row without its history.
+
+    ``created_at`` and ``updated_at`` are set to ``NOW()`` to mark the time
+    of the copy (matching LangSmith Deployments behaviour) rather than
+    inheriting the source timestamps. Status and metadata are inherited
+    from the source as-is — including statuses such as ``running`` or
+    ``error`` if present.
+    """
+    if db_manager.lg_pool is None:
+        raise RuntimeError("Checkpoint pool is not initialized")
+
+    metadata_json = json.dumps(src_metadata or {})
+
+    async with db_manager.lg_pool.connection() as conn, conn.transaction():
+        await conn.execute(
+            'INSERT INTO "thread" ("thread_id", "status", "metadata_json", "user_id", '
+            '"created_at", "updated_at") '
+            "VALUES (%s, %s, %s::jsonb, %s, NOW(), NOW())",
+            (new_thread_id, src_status, metadata_json, user_identity),
+        )
+        for table in _CHECKPOINT_TABLES:
+            await _copy_checkpoint_table(conn, table, src_thread_id, new_thread_id)

--- a/libs/aegra-api/src/aegra_api/services/thread_copy.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_copy.py
@@ -22,6 +22,8 @@ one such recent addition).
 import json
 from typing import TYPE_CHECKING, Any
 
+from psycopg import sql as pgsql
+
 from aegra_api.core.database import db_manager
 
 if TYPE_CHECKING:
@@ -56,16 +58,31 @@ async def _copy_checkpoint_table(
     src_thread_id: str,
     new_thread_id: str,
 ) -> None:
-    """Copy all rows of ``table`` matching ``src_thread_id`` under ``new_thread_id``."""
+    """Copy all rows of ``table`` matching ``src_thread_id`` under ``new_thread_id``.
+
+    Raises ``RuntimeError`` if the introspected schema lacks ``thread_id`` —
+    a silent skip would let the surrounding transaction commit a partial
+    copy (the new thread row plus the tables that did succeed), violating
+    the atomicity guarantee. Raising lets ``conn.transaction()`` roll back
+    the whole operation.
+
+    Identifiers (table name + column names) are composed via
+    ``psycopg.sql.Identifier`` rather than f-string quoting. The inputs
+    come from ``information_schema``, so an exotic identifier containing a
+    literal double-quote would silently break naive ``f'"{c}"'`` quoting;
+    using the typed composer eliminates that class of bug.
+    """
     cols = await _table_columns(conn, table)
     if "thread_id" not in cols:
-        # Defensive: schema unexpected, skip rather than raise to avoid
-        # breaking the whole copy on a transient introspection issue.
-        return
+        raise RuntimeError(f"Table {table!r} has no 'thread_id' column; aborting copy to preserve atomicity")
     other_cols = [c for c in cols if c != "thread_id"]
-    cols_csv = ", ".join(f'"{c}"' for c in other_cols)
-    sql = f'INSERT INTO "{table}" ("thread_id", {cols_csv}) SELECT %s, {cols_csv} FROM "{table}" WHERE thread_id = %s'
-    await conn.execute(sql, (new_thread_id, src_thread_id))
+    table_id = pgsql.Identifier(table)
+    tid_id = pgsql.Identifier("thread_id")
+    cols_composed = pgsql.SQL(", ").join(pgsql.Identifier(c) for c in other_cols)
+    stmt = pgsql.SQL("INSERT INTO {table} ({tid}, {cols}) SELECT %s, {cols} FROM {table} WHERE thread_id = %s").format(
+        table=table_id, tid=tid_id, cols=cols_composed
+    )
+    await conn.execute(stmt, (new_thread_id, src_thread_id))
 
 
 async def copy_thread_atomically(

--- a/libs/aegra-api/src/aegra_api/services/thread_copy.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_copy.py
@@ -1,35 +1,11 @@
-"""Thread copy service.
+"""SQL-level deep-copy of a thread row + its checkpoint history.
 
-Implements deep-copy of a thread (its row in ``thread`` plus its checkpoint
-history) at the SQL level so that ``checkpoint_id`` and the
-``parent_checkpoint_id`` chain are preserved end-to-end, matching the
-semantics of ``POST /threads/{id}/copy`` on LangSmith Deployments.
-
-Both the thread row INSERT and the three checkpoint-table INSERT...SELECT
-statements run inside a single Postgres transaction on the
-``langgraph-checkpoint-postgres`` connection pool, raised to
-REPEATABLE READ isolation. Without that level, a concurrent writer on the
-source thread (e.g. a run mid-execution) could commit between the three
-INSERT...SELECT statements, leaving the new thread with an inconsistent
-slice of the checkpoint history. REPEATABLE READ pins the snapshot at
-transaction start so the three SELECTs see the same consistent view, and
-on any failure the whole copy is rolled back.
-
-Going through one pool also avoids cross-pool tx coordination between
-SQLAlchemy and the checkpointer pool, which would otherwise leave
-orphaned checkpoint rows on partial failures.
-
-Column lists for the checkpoint tables are introspected at runtime via
-``pg_catalog.pg_attribute`` keyed on ``to_regclass(<table>)``. This is
-the same path the unqualified ``INSERT INTO <table>`` statements use to
-resolve their target relation — they both follow the connection's
-``search_path``. Using ``information_schema.columns`` filtered by
-``current_schema()`` would only inspect the *first* schema in the
-search path, which is fine for default deployments but breaks under
-non-default ``search_path`` configurations (the introspection returns
-zero rows even though the unqualified DML still finds the table in a
-later schema). Forward-compat: new columns added upstream
-(``task_path`` was one such recent addition) are picked up automatically.
+One Postgres transaction on the checkpointer pool at REPEATABLE READ:
+no cross-pool coordination, no orphan rows on failure, snapshot pinned
+against concurrent writers. Column lists resolved via
+``pg_catalog.pg_attribute`` + ``to_regclass`` so introspection follows
+the same ``search_path`` as the unqualified DML (forward-compat with
+upstream column additions).
 """
 
 from typing import TYPE_CHECKING, Any
@@ -51,18 +27,10 @@ _CHECKPOINT_TABLES: tuple[str, ...] = ("checkpoints", "checkpoint_writes", "chec
 
 
 async def _table_columns(conn: "AsyncConnection", table: str) -> list[str]:
-    """Return the column names of ``table`` in declaration order.
+    """Return live column names of ``table`` via ``pg_attribute``+``to_regclass``.
 
-    Resolves ``table`` through ``to_regclass`` so the introspection
-    follows the connection's ``search_path`` exactly the way an
-    unqualified ``INSERT INTO <table>`` would. Filters out dropped
-    columns via ``attisdropped`` — ``pg_attribute`` retains tombstone
-    rows for dropped columns, unlike ``information_schema.columns``.
-
-    The aegra connection pool is configured with ``dict_row`` (see
-    ``core/database.py`` — LangGraph requires dictionary rows), so each
-    fetched row is a ``dict``. The ``AS column_name`` alias preserves
-    that contract for callers (and existing tests).
+    Filters dropped-column tombstones (``attisdropped``); ``AS column_name``
+    matches the pool's ``dict_row`` factory used by callers.
     """
     cur = await conn.execute(
         "SELECT attname AS column_name FROM pg_catalog.pg_attribute "
@@ -81,19 +49,11 @@ async def _copy_checkpoint_table(
     src_thread_id: str,
     new_thread_id: str,
 ) -> None:
-    """Copy all rows of ``table`` matching ``src_thread_id`` under ``new_thread_id``.
+    """Copy ``src_thread_id`` rows of ``table`` under ``new_thread_id``.
 
-    Raises ``RuntimeError`` if the introspected schema lacks ``thread_id`` —
-    a silent skip would let the surrounding transaction commit a partial
-    copy (the new thread row plus the tables that did succeed), violating
-    the atomicity guarantee. Raising lets ``conn.transaction()`` roll back
-    the whole operation.
-
-    Identifiers (table name + column names) are composed via
-    ``psycopg.sql.Identifier`` rather than f-string quoting. The inputs
-    come from ``pg_attribute``, so an exotic identifier containing a
-    literal double-quote would silently break naive ``f'"{c}"'`` quoting;
-    using the typed composer eliminates that class of bug.
+    Raises on missing ``thread_id`` so the outer transaction rolls back;
+    identifiers composed via ``psycopg.sql.Identifier`` (input from
+    ``pg_attribute`` may contain quotes that break f-string quoting).
     """
     cols = await _table_columns(conn, table)
     if "thread_id" not in cols:
@@ -109,48 +69,28 @@ async def _copy_checkpoint_table(
 
 
 async def copy_thread_atomically(
+    *,
     src_thread_id: str,
     new_thread_id: str,
     src_status: str,
     src_metadata: dict[str, Any],
     user_identity: str,
 ) -> None:
-    """Atomically insert the new thread row and copy the checkpoint history.
+    """Insert thread row + copy checkpoint history in one REPEATABLE READ tx.
 
-    Runs the thread-row INSERT and the three checkpoint INSERT...SELECT
-    statements inside one Postgres transaction at REPEATABLE READ
-    isolation. On any failure the whole copy is rolled back, preventing
-    orphaned checkpoint rows or a thread row without its history.
-
-    The new thread's ``metadata.owner`` is rewritten to ``user_identity``
-    (mirroring ``create_thread``, which enforces the same invariant for
-    fresh threads). Without this, the source thread's owner attribution
-    would be inherited by the copy — an internal-consistency bug for any
-    code that reads ``metadata.owner`` instead of the canonical
-    ``thread.user_id`` column. ``user_id`` is correctly bound to the
-    caller via the dedicated parameter.
-
-    ``created_at`` and ``updated_at`` are set to ``NOW()`` to mark the
-    time of the copy (matching LangSmith Deployments behaviour) rather
-    than inheriting the source timestamps. Status is inherited from the
-    source as-is — including statuses such as ``running`` or ``error``
-    if present.
+    ``metadata["owner"]`` is rewritten to ``user_identity`` (mirrors
+    ``create_thread``), timestamps regenerated to copy time, status
+    inherited from source.
     """
     if db_manager.lg_pool is None:
         raise RuntimeError("Checkpoint pool is not initialized")
 
-    # Shallow copy is sufficient — we only mutate the top-level ``owner``
-    # key, so any nested values shared with the caller's dict are safe to
-    # alias.  ``dict(None or {})`` also defends against a ``None`` argument
-    # without an explicit branch.
+    # Shallow copy: only top-level ``owner`` mutates; ``or {}`` defends None.
     metadata = dict(src_metadata or {})
     metadata["owner"] = user_identity
 
     async with db_manager.lg_pool.connection() as conn, conn.transaction():
-        # Pin the transaction snapshot so the three checkpoint INSERT...SELECT
-        # statements see a consistent view of the source thread, even if a
-        # concurrent run on that thread is committing checkpoints. Must be
-        # the first statement in the transaction for PostgreSQL to honour it.
+        # First statement in tx — required for Postgres to honour the level.
         await conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
         await conn.execute(
             'INSERT INTO "thread" ("thread_id", "status", "metadata_json", "user_id", '
@@ -160,10 +100,7 @@ async def copy_thread_atomically(
         )
         for table in _CHECKPOINT_TABLES:
             await _copy_checkpoint_table(conn, table, src_thread_id, new_thread_id)
-    # Audit log on success — ISO 27017/27018 expect data-duplication events
-    # to be traceable to caller, source, target, and timestamp. The failure
-    # path emits ``logger.exception`` from the API layer; this completes the
-    # pair so the operation is observable in both outcomes.
+    # Audit pair: API layer logs on failure via ``logger.exception``.
     logger.info(
         "thread.copy",
         src_thread_id=src_thread_id,

--- a/libs/aegra-api/src/aegra_api/services/thread_copy.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_copy.py
@@ -3,9 +3,9 @@
 One Postgres transaction on the checkpointer pool at REPEATABLE READ:
 no cross-pool coordination, no orphan rows on failure, snapshot pinned
 against concurrent writers. Column lists resolved via
-``pg_catalog.pg_attribute`` + ``to_regclass`` so introspection follows
-the same ``search_path`` as the unqualified DML (forward-compat with
-upstream column additions).
+``pg_catalog.pg_attribute`` + ``to_regclass`` so the copy tracks live
+schema changes instead of a hardcoded column list, following the same
+``search_path`` as the unqualified DML.
 """
 
 from typing import TYPE_CHECKING, Any
@@ -68,39 +68,93 @@ async def _copy_checkpoint_table(
     await conn.execute(stmt, (new_thread_id, src_thread_id))
 
 
+async def _copy_thread_row(
+    conn: "AsyncConnection",
+    *,
+    src_thread_id: str,
+    new_thread_id: str,
+    user_identity: str,
+    metadata_overrides: dict[str, Any],
+) -> None:
+    """Insert the copy's ``thread`` row via ``INSERT ... SELECT`` from source.
+
+    Columns are introspected so future additions are inherited verbatim.
+    Overridden: identity + timestamps regenerated; active ``status``
+    (busy/running) reset to idle since the copy has no ``runs`` row; and
+    ``metadata_json`` merged source ``||`` handler ``||`` ``owner`` (caller).
+    """
+    cols = await _table_columns(conn, "thread")
+    if "thread_id" not in cols:
+        raise RuntimeError("Table 'thread' has no 'thread_id' column; aborting copy to preserve atomicity")
+
+    merged_metadata = {**metadata_overrides, "owner": user_identity}
+    select_parts: list[pgsql.Composable] = []
+    params: list[Any] = []
+    for col in cols:
+        col_id = pgsql.Identifier(col)
+        if col == "thread_id":
+            select_parts.append(pgsql.Placeholder())
+            params.append(new_thread_id)
+        elif col == "user_id":
+            select_parts.append(pgsql.Placeholder())
+            params.append(user_identity)
+        elif col == "status":
+            select_parts.append(
+                pgsql.SQL("CASE WHEN {c} IN ('busy', 'running') THEN 'idle' ELSE {c} END").format(c=col_id)
+            )
+        elif col == "metadata_json":
+            select_parts.append(
+                pgsql.SQL("COALESCE({c}, '{{}}'::jsonb) || {ph}").format(c=col_id, ph=pgsql.Placeholder())
+            )
+            params.append(Jsonb(merged_metadata))
+        elif col in ("created_at", "updated_at"):
+            select_parts.append(pgsql.SQL("NOW()"))
+        else:
+            select_parts.append(col_id)
+    params.append(src_thread_id)
+
+    stmt = pgsql.SQL("INSERT INTO {t} ({cols}) SELECT {vals} FROM {t} WHERE {tid} = {ph}").format(
+        t=pgsql.Identifier("thread"),
+        cols=pgsql.SQL(", ").join(pgsql.Identifier(c) for c in cols),
+        vals=pgsql.SQL(", ").join(select_parts),
+        tid=pgsql.Identifier("thread_id"),
+        ph=pgsql.Placeholder(),
+    )
+    result = await conn.execute(stmt, params)
+    if result.rowcount == 0:
+        raise RuntimeError(f"Source thread {src_thread_id!r} disappeared before copy; rolling back")
+
+
 async def copy_thread_atomically(
     *,
     src_thread_id: str,
     new_thread_id: str,
-    src_status: str,
-    src_metadata: dict[str, Any],
     user_identity: str,
+    metadata_overrides: dict[str, Any] | None = None,
 ) -> None:
-    """Insert thread row + copy checkpoint history in one REPEATABLE READ tx.
+    """Copy thread row + checkpoint history in one REPEATABLE READ tx.
 
-    ``metadata["owner"]`` is rewritten to ``user_identity`` (mirrors
-    ``create_thread``), timestamps regenerated to copy time, status
-    inherited from source.
+    The ``thread`` row and all checkpoint tables are read within the same
+    pinned snapshot, so a concurrent writer cannot produce a partially
+    copied result. See ``_copy_thread_row`` for the per-column semantics.
     """
     if db_manager.lg_pool is None:
         raise RuntimeError("Checkpoint pool is not initialized")
 
-    # Shallow copy: only top-level ``owner`` mutates; ``or {}`` defends None.
-    metadata = dict(src_metadata or {})
-    metadata["owner"] = user_identity
-
     async with db_manager.lg_pool.connection() as conn, conn.transaction():
-        # First statement in tx — required for Postgres to honour the level.
+        # First statement in tx — Postgres honours the level only before any
+        # query runs. psycopg3 transaction() has no isolation_level kwarg and
+        # setting conn.isolation_level would leak across pooled borrowers.
         await conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
-        await conn.execute(
-            'INSERT INTO "thread" ("thread_id", "status", "metadata_json", "user_id", '
-            '"created_at", "updated_at") '
-            "VALUES (%s, %s, %s, %s, NOW(), NOW())",
-            (new_thread_id, src_status, Jsonb(metadata), user_identity),
+        await _copy_thread_row(
+            conn,
+            src_thread_id=src_thread_id,
+            new_thread_id=new_thread_id,
+            user_identity=user_identity,
+            metadata_overrides=metadata_overrides or {},
         )
         for table in _CHECKPOINT_TABLES:
             await _copy_checkpoint_table(conn, table, src_thread_id, new_thread_id)
-    # Audit pair: API layer logs on failure via ``logger.exception``.
     logger.info(
         "thread.copy",
         src_thread_id=src_thread_id,

--- a/libs/aegra-api/tests/e2e/test_threads/test_thread_copy.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_thread_copy.py
@@ -1,0 +1,111 @@
+import uuid
+
+import pytest
+
+from tests.e2e._utils import check_and_skip_if_geo_blocked, elog, get_e2e_client
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_thread_copy_returns_new_id_and_preserves_status() -> None:
+    """Copy of an empty thread returns a new ``thread_id`` and inherits status.
+
+    Empty-thread baseline: no checkpoint history, just the thread row, so the
+    test isolates the row-copy semantics from the checkpoint-chain semantics.
+    """
+    client = get_e2e_client()
+
+    src = await client.threads.create(metadata={"label": "copy-empty-source"})
+    src_id = src["thread_id"]
+    src_status = src["status"]
+    elog("Created source thread", {"thread_id": src_id, "status": src_status})
+
+    new_thread = await client.threads.copy(src_id)
+    elog("Copied thread", new_thread)
+
+    assert new_thread["thread_id"] != src_id, "copy must mint a fresh thread_id"
+    assert new_thread["status"] == src_status, "status inherited from source"
+
+    fetched = await client.threads.get(new_thread["thread_id"])
+    assert fetched["thread_id"] == new_thread["thread_id"]
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_thread_copy_preserves_checkpoint_chain() -> None:
+    """A run produces checkpoints; ``copy`` keeps the same ``checkpoint_id``.
+
+    Verifies the SQL-level INSERT...SELECT semantics end-to-end: after a run,
+    the source has a checkpoint chain; the copy must expose that chain under
+    its own ``thread_id`` with identical ``checkpoint_id`` values.
+    """
+    client = get_e2e_client()
+
+    src = await client.threads.create()
+    src_id = src["thread_id"]
+
+    await client.runs.wait(
+        thread_id=src_id,
+        assistant_id="agent",
+        input={"messages": [{"role": "human", "content": "Reply with the single word 'ok'."}]},
+    )
+    runs_list = await client.runs.list(src_id)
+    assert runs_list, "Expected source run to be recorded"
+    check_and_skip_if_geo_blocked(runs_list[0])
+    assert runs_list[0]["status"] in ("success", "interrupted"), (
+        f"source run failed unexpectedly: {runs_list[0]['status']}"
+    )
+
+    src_state = await client.threads.get_state(thread_id=src_id)
+    src_checkpoint_id = src_state["checkpoint"]["checkpoint_id"]
+    src_history = await client.threads.get_history(src_id)
+    elog(
+        "Source run + state",
+        {
+            "checkpoint_id": src_checkpoint_id,
+            "history_len": len(src_history),
+            "run_status": runs_list[0]["status"],
+        },
+    )
+    assert src_checkpoint_id is not None
+    assert src_history, "Expected non-empty checkpoint history on source"
+
+    new_thread = await client.threads.copy(src_id)
+    new_id = new_thread["thread_id"]
+
+    new_state = await client.threads.get_state(thread_id=new_id)
+    new_checkpoint_id = new_state["checkpoint"]["checkpoint_id"]
+    new_history = await client.threads.get_history(new_id)
+    elog(
+        "Copy state",
+        {
+            "thread_id": new_id,
+            "checkpoint_id": new_checkpoint_id,
+            "history_len": len(new_history),
+        },
+    )
+
+    assert new_checkpoint_id == src_checkpoint_id, "checkpoint_id must be identical between source and copy"
+    assert len(new_history) == len(src_history), "checkpoint history length must match between source and copy"
+    src_chain = [c["checkpoint"]["checkpoint_id"] for c in src_history]
+    new_chain = [c["checkpoint"]["checkpoint_id"] for c in new_history]
+    assert src_chain == new_chain, "checkpoint chain must be identical"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_thread_copy_404_for_missing_source() -> None:
+    """Copying a thread the caller does not own (or that doesn't exist) returns 404.
+
+    Uses a freshly-minted UUID as source; ownership check + non-existence
+    converge on the same 404 response.
+    """
+    client = get_e2e_client()
+    missing_id = str(uuid.uuid4())
+
+    with pytest.raises(Exception) as excinfo:
+        await client.threads.copy(missing_id)
+
+    msg = str(excinfo.value)
+    assert "404" in msg or "not found" in msg.lower(), f"expected 404 / not-found error, got: {msg}"
+    elog("Copy of missing thread surfaced expected error", {"error": msg})

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -451,18 +451,26 @@ class TestCopyThread:
         id keyed in the event payload — not just the source id.  The original
         PR passed ``{"thread_id": <source>}``, leaving the handler with stale
         data and no way to bind a resource to the row about to be created.
+
+        Also asserts that the id seen by the handler is the **same** id
+        passed to ``copy_thread_atomically`` — i.e. one ``uuid4()`` call
+        shared across both call sites.  Without this stricter check, a
+        regression that generated two distinct ids (one for the event,
+        one for the copy) would still satisfy the "non-source" assertion
+        above while breaking the handler's resource provisioning.
         """
         src = _thread_row("src-123")
         new = _thread_row("new-456")
 
         captured_payload: dict = {}
+        captured_copy_kwargs: dict = {}
 
         async def mock_handle_event(_ctx, value):
             captured_payload.update(value)
             return None
 
-        async def fake_copy(**_kwargs):
-            return None
+        async def fake_copy(**kwargs):
+            captured_copy_kwargs.update(kwargs)
 
         app = create_test_app(include_runs=False, include_threads=True)
         app.dependency_overrides[core_get_session] = override_get_session_dep(self._session_class(src, new))
@@ -487,6 +495,9 @@ class TestCopyThread:
         new_id_in_payload = captured_payload.get("thread_id")
         assert new_id_in_payload is not None
         assert new_id_in_payload != "src-123"
+        # Same id reaches ``copy_thread_atomically`` — one uuid4() call,
+        # shared across the handler payload and the persistence layer.
+        assert captured_copy_kwargs["new_thread_id"] == new_id_in_payload
 
 
 class TestSearchThreads:

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -382,6 +382,113 @@ class TestDeleteThread:
         assert resp.json()["status"] == "deleted"
 
 
+class TestCopyThread:
+    """Test POST /threads/{thread_id}/copy endpoint."""
+
+    def _session_class(self, src_thread, new_thread):
+        """Build a session class whose scalar() returns ``src`` first, then ``new``.
+
+        Mirrors the endpoint's call order: ownership lookup, then post-commit
+        reload of the freshly-inserted row.
+        """
+
+        class Session(DummySessionBase):
+            _calls = 0
+
+            async def scalar(self, _stmt):
+                Session._calls += 1
+                return src_thread if Session._calls == 1 else new_thread
+
+            async def commit(self):
+                return None
+
+        return Session
+
+    def test_copy_thread_applies_handler_metadata_mutations(self):
+        """A handler that returns ``{"metadata": {...}}`` from ``handle_event``
+        must have its mutations merged onto the copied thread's metadata.
+
+        Without this capture (the original PR discarded the return value),
+        the ``/copy`` endpoint would be a bypass path for handler-enforced
+        invariants — tenant_id, quota markers, billing tags — that
+        ``create_thread`` applies to every directly-created thread.
+        """
+        src = _thread_row("src-123", metadata={"graph_id": "agent"})
+        new = _thread_row("new-456", metadata={"graph_id": "agent", "tenant_id": "acme"})
+
+        captured_call: dict = {}
+
+        async def fake_copy(**kwargs):
+            captured_call.update(kwargs)
+
+        async def mock_handle_event(_ctx, _value):
+            return {"metadata": {"tenant_id": "acme"}}
+
+        app = create_test_app(include_runs=False, include_threads=True)
+        app.dependency_overrides[core_get_session] = override_get_session_dep(self._session_class(src, new))
+
+        with (
+            patch(
+                "aegra_api.api.threads.handle_event",
+                new=AsyncMock(side_effect=mock_handle_event),
+            ),
+            patch(
+                "aegra_api.api.threads.copy_thread_atomically",
+                new=AsyncMock(side_effect=fake_copy),
+            ),
+        ):
+            client = make_client(app)
+            resp = client.post("/threads/src-123/copy")
+
+        assert resp.status_code == 200
+        # Handler-injected key reaches the service call site.
+        assert captured_call["src_metadata"]["tenant_id"] == "acme"
+        # Source metadata is preserved on the same dict.
+        assert captured_call["src_metadata"]["graph_id"] == "agent"
+
+    def test_copy_thread_event_payload_includes_new_thread_id(self):
+        """Handlers that provision per-thread resources need the *new* thread
+        id keyed in the event payload — not just the source id.  The original
+        PR passed ``{"thread_id": <source>}``, leaving the handler with stale
+        data and no way to bind a resource to the row about to be created.
+        """
+        src = _thread_row("src-123")
+        new = _thread_row("new-456")
+
+        captured_payload: dict = {}
+
+        async def mock_handle_event(_ctx, value):
+            captured_payload.update(value)
+            return None
+
+        async def fake_copy(**_kwargs):
+            return None
+
+        app = create_test_app(include_runs=False, include_threads=True)
+        app.dependency_overrides[core_get_session] = override_get_session_dep(self._session_class(src, new))
+
+        with (
+            patch(
+                "aegra_api.api.threads.handle_event",
+                new=AsyncMock(side_effect=mock_handle_event),
+            ),
+            patch(
+                "aegra_api.api.threads.copy_thread_atomically",
+                new=AsyncMock(side_effect=fake_copy),
+            ),
+        ):
+            client = make_client(app)
+            resp = client.post("/threads/src-123/copy")
+
+        assert resp.status_code == 200
+        # Source thread id is still surfaced under a dedicated key for context.
+        assert captured_payload.get("src_thread_id") == "src-123"
+        # The ``thread_id`` key carries the NEW (server-generated) id.
+        new_id_in_payload = captured_payload.get("thread_id")
+        assert new_id_in_payload is not None
+        assert new_id_in_payload != "src-123"
+
+
 class TestSearchThreads:
     """Test POST /threads/search endpoint"""
 

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -441,10 +441,10 @@ class TestCopyThread:
             resp = client.post("/threads/src-123/copy")
 
         assert resp.status_code == 200
-        # Handler-injected key reaches the service call site.
-        assert captured_call["src_metadata"]["tenant_id"] == "acme"
-        # Source metadata is preserved on the same dict.
-        assert captured_call["src_metadata"]["graph_id"] == "agent"
+        # Handler-injected key reaches the service as a metadata override.
+        # Source metadata is inherited inside the copy transaction (SQL-side),
+        # so it is no longer re-passed through the endpoint call site.
+        assert captured_call["metadata_overrides"]["tenant_id"] == "acme"
 
     def test_copy_thread_event_payload_includes_new_thread_id(self):
         """Handlers that provision per-thread resources need the *new* thread

--- a/libs/aegra-api/tests/unit/test_services/test_thread_copy.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_copy.py
@@ -1,10 +1,10 @@
 """Unit tests for thread_copy service."""
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from psycopg import sql as pgsql
+from psycopg.types.json import Jsonb
 
 from aegra_api.services.thread_copy import (
     _CHECKPOINT_TABLES,
@@ -44,7 +44,14 @@ class TestTableColumns:
         # Query is parametrised on table name — no string interpolation.
         args, _ = conn.execute.call_args
         sql, params = args
-        assert "information_schema.columns" in sql
+        # Introspection runs through ``to_regclass`` against ``pg_attribute``
+        # so it follows the connection's ``search_path`` exactly the way an
+        # unqualified ``INSERT INTO checkpoints`` does. Filtering on
+        # ``current_schema()`` would only inspect the first schema in the
+        # search path and silently miss tables that live in a later schema.
+        assert "pg_catalog.pg_attribute" in sql
+        assert "to_regclass" in sql
+        assert "attisdropped" in sql  # tombstones excluded
         assert params == ("checkpoints",)
 
 
@@ -57,7 +64,7 @@ class TestCopyCheckpointTable:
 
         await _copy_checkpoint_table(conn, "checkpoints", "src-uuid", "new-uuid")
 
-        # Two execute calls: information_schema lookup + INSERT...SELECT
+        # Two execute calls: pg_attribute introspection + INSERT...SELECT
         assert conn.execute.await_count == 2
         insert_call = conn.execute.await_args_list[1]
         stmt, params = insert_call.args
@@ -102,6 +109,43 @@ class TestCopyCheckpointTable:
         assert sql_str.count('"checkpoint_id"') == 2  # in INSERT cols + SELECT cols
         assert sql_str.count('"thread_id"') == 1  # only in INSERT cols
 
+    @pytest.mark.asyncio()
+    async def test_preserves_checkpoint_chain_columns_verbatim(self) -> None:
+        """Both ``checkpoint_id`` and ``parent_checkpoint_id`` must appear in
+        the SELECT clause unchanged, so the new thread inherits the source's
+        chain identifiers byte-for-byte. This is the headline differentiator
+        vs ``checkpoint-fork`` (which regenerates checkpoint IDs); end-to-end
+        verification against a live Postgres lives in the integration suite
+        (see follow-up F3 in `infra/aegra/README.md`)."""
+        cols_cursor = _make_async_cursor(
+            [
+                "thread_id",
+                "checkpoint_ns",
+                "checkpoint_id",
+                "parent_checkpoint_id",
+                "type",
+                "checkpoint",
+                "metadata",
+            ]
+        )
+        insert_cursor = _make_async_cursor([])
+        conn = _make_async_connection([cols_cursor, insert_cursor])
+
+        await _copy_checkpoint_table(conn, "checkpoints", "src", "new")
+
+        stmt = conn.execute.await_args_list[1].args[0]
+        sql_str = stmt.as_string(None)
+        # checkpoint_id and parent_checkpoint_id appear in BOTH the INSERT
+        # column list and the SELECT projection — meaning the value is read
+        # from the source row and inserted verbatim under the new thread_id.
+        # No transformation, no nextval(), no CASE WHEN.
+        assert sql_str.count('"checkpoint_id"') == 2
+        assert sql_str.count('"parent_checkpoint_id"') == 2
+        # No id-regeneration artefacts in the SQL.
+        assert "nextval" not in sql_str.lower()
+        assert "uuid_generate" not in sql_str.lower()
+        assert "gen_random_uuid" not in sql_str.lower()
+
 
 def _make_atomic_pool_mocks() -> tuple[MagicMock, MagicMock]:
     """Build a (pool, conn) pair wired with the async context-manager protocol."""
@@ -124,7 +168,7 @@ def _make_atomic_pool_mocks() -> tuple[MagicMock, MagicMock]:
 class TestCopyThreadAtomically:
     @pytest.mark.asyncio()
     async def test_inserts_thread_row_then_copies_three_checkpoint_tables(self) -> None:
-        """The thread INSERT must precede the checkpoint INSERT...SELECT calls,
+        """SET TRANSACTION → thread INSERT → checkpoint INSERT...SELECT calls,
         all inside the same connection transaction."""
         mock_pool, mock_conn = _make_atomic_pool_mocks()
 
@@ -142,10 +186,10 @@ class TestCopyThreadAtomically:
                 user_identity="user-1",
             )
 
-        # Thread INSERT issued exactly once on the same conn used for the
-        # checkpoint copy (single transaction).
-        assert mock_conn.execute.await_count == 1
-        thread_sql, thread_params = mock_conn.execute.await_args_list[0].args
+        # Two execute calls on the connection: SET TRANSACTION first, then the
+        # thread INSERT. Checkpoint tables go through the patched helper.
+        assert mock_conn.execute.await_count == 2
+        thread_sql, thread_params = mock_conn.execute.await_args_list[1].args
         assert thread_sql.startswith('INSERT INTO "thread"')
         assert thread_params[0] == "new-uuid"
         assert thread_params[1] == "idle"
@@ -160,8 +204,69 @@ class TestCopyThreadAtomically:
             assert call.args[3] == "new-uuid"
 
     @pytest.mark.asyncio()
-    async def test_serializes_metadata_to_json(self) -> None:
-        """Metadata dict is JSON-serialized before being passed to the JSONB cast."""
+    async def test_sets_repeatable_read_isolation_before_dml(self) -> None:
+        """``SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`` must be the
+        first statement inside the ``conn.transaction()`` block. PostgreSQL
+        only honours the directive when no DML has run yet, so the order
+        matters; without REPEATABLE READ the three checkpoint INSERT...SELECT
+        statements can see different snapshots if a concurrent run on the
+        source thread commits between them."""
+        mock_pool, mock_conn = _make_atomic_pool_mocks()
+
+        with (
+            patch("aegra_api.services.thread_copy._copy_checkpoint_table", new=AsyncMock()),
+            patch("aegra_api.services.thread_copy.db_manager") as mock_db,
+        ):
+            mock_db.lg_pool = mock_pool
+
+            await copy_thread_atomically(
+                src_thread_id="src",
+                new_thread_id="new",
+                src_status="idle",
+                src_metadata={},
+                user_identity="u",
+            )
+
+        first_sql = mock_conn.execute.await_args_list[0].args[0]
+        assert "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ" in first_sql
+
+    @pytest.mark.asyncio()
+    async def test_serializes_metadata_via_jsonb_adapter(self) -> None:
+        """Metadata is bound through psycopg's ``Jsonb`` adapter rather than
+        a string + ``::jsonb`` cast. The adapter goes through psycopg's
+        adapter chain, so non-JSON-serializable values (e.g. datetime, UUID)
+        raise at adapt-time with a clear error rather than blowing up
+        ``json.dumps`` mid-transaction."""
+        mock_pool, mock_conn = _make_atomic_pool_mocks()
+
+        with (
+            patch("aegra_api.services.thread_copy._copy_checkpoint_table", new=AsyncMock()),
+            patch("aegra_api.services.thread_copy.db_manager") as mock_db,
+        ):
+            mock_db.lg_pool = mock_pool
+
+            await copy_thread_atomically(
+                src_thread_id="src",
+                new_thread_id="new",
+                src_status="idle",
+                src_metadata={"graph_id": "agent"},
+                user_identity="alice",
+            )
+
+        thread_sql, thread_params = mock_conn.execute.await_args_list[1].args
+        # No ``::jsonb`` cast in the SQL — psycopg infers the column type.
+        assert "::jsonb" not in thread_sql
+        # Third positional argument is the bound value: a Jsonb wrapper, not a
+        # string, so psycopg adapts it natively.
+        assert isinstance(thread_params[2], Jsonb)
+
+    @pytest.mark.asyncio()
+    async def test_metadata_owner_rewritten_to_caller(self) -> None:
+        """``metadata.owner`` is overwritten with the caller identity. Without
+        this rewrite the new thread inherits the source owner field, which
+        misattributes the row for any code reading ``metadata.owner`` instead
+        of the canonical ``thread.user_id`` column. ``create_thread`` enforces
+        the same invariant for fresh threads."""
         mock_pool, mock_conn = _make_atomic_pool_mocks()
 
         with (
@@ -175,12 +280,38 @@ class TestCopyThreadAtomically:
                 new_thread_id="new",
                 src_status="idle",
                 src_metadata={"owner": "alice", "graph_id": "agent"},
-                user_identity="alice",
+                user_identity="bob",
             )
 
-        thread_params = mock_conn.execute.await_args_list[0].args[1]
-        # metadata_json is the third positional after (new_id, status, json, ...)
-        assert json.loads(thread_params[2]) == {"owner": "alice", "graph_id": "agent"}
+        thread_params = mock_conn.execute.await_args_list[1].args[1]
+        bound_metadata = thread_params[2].obj  # Jsonb stores the dict on `.obj`
+        assert bound_metadata["owner"] == "bob"
+        # Other keys are preserved verbatim.
+        assert bound_metadata["graph_id"] == "agent"
+
+    @pytest.mark.asyncio()
+    async def test_does_not_mutate_caller_metadata_dict(self) -> None:
+        """Owner rewrite must operate on a copy, otherwise the caller's
+        ``ThreadORM.metadata_json`` dict (a SQLAlchemy mutable JSONB) would
+        see ``owner`` change in place — a subtle ORM-state corruption."""
+        mock_pool, _ = _make_atomic_pool_mocks()
+        original = {"owner": "alice", "graph_id": "agent"}
+
+        with (
+            patch("aegra_api.services.thread_copy._copy_checkpoint_table", new=AsyncMock()),
+            patch("aegra_api.services.thread_copy.db_manager") as mock_db,
+        ):
+            mock_db.lg_pool = mock_pool
+
+            await copy_thread_atomically(
+                src_thread_id="src",
+                new_thread_id="new",
+                src_status="idle",
+                src_metadata=original,
+                user_identity="bob",
+            )
+
+        assert original == {"owner": "alice", "graph_id": "agent"}
 
     @pytest.mark.asyncio()
     async def test_raises_when_pool_not_initialized(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_thread_copy.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_copy.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from psycopg import sql as pgsql
 
 from aegra_api.services.thread_copy import (
     _CHECKPOINT_TABLES,
@@ -59,25 +60,31 @@ class TestCopyCheckpointTable:
         # Two execute calls: information_schema lookup + INSERT...SELECT
         assert conn.execute.await_count == 2
         insert_call = conn.execute.await_args_list[1]
-        sql, params = insert_call.args
-        assert sql.startswith('INSERT INTO "checkpoints"')
-        assert '"thread_id"' in sql
-        assert '"checkpoint_ns"' in sql
-        assert '"checkpoint_id"' in sql
-        assert '"metadata"' in sql
-        assert "WHERE thread_id = %s" in sql
+        stmt, params = insert_call.args
+        # The statement is composed via psycopg.sql.Identifier rather than
+        # an f-string, so render it once for content assertions.
+        assert isinstance(stmt, pgsql.Composed)
+        sql_str = stmt.as_string(None)
+        assert sql_str.startswith('INSERT INTO "checkpoints"')
+        assert '"thread_id"' in sql_str
+        assert '"checkpoint_ns"' in sql_str
+        assert '"checkpoint_id"' in sql_str
+        assert '"metadata"' in sql_str
+        assert "WHERE thread_id = %s" in sql_str
         # First param is the new thread_id, second is the source — order matters
         assert params == ("new-uuid", "src-uuid")
 
     @pytest.mark.asyncio()
-    async def test_skips_when_thread_id_column_missing(self) -> None:
-        """Defensive: unexpected schema → skip table without raising."""
+    async def test_raises_when_thread_id_column_missing(self) -> None:
+        """Unexpected schema (no ``thread_id`` col) raises so the surrounding
+        transaction rolls back rather than committing a partial copy."""
         cols_cursor = _make_async_cursor(["checkpoint_id"])
         conn = _make_async_connection([cols_cursor])
 
-        await _copy_checkpoint_table(conn, "checkpoints", "src", "new")
+        with pytest.raises(RuntimeError, match="thread_id"):
+            await _copy_checkpoint_table(conn, "checkpoints", "src", "new")
 
-        # Only the introspection call — no INSERT issued.
+        # Only the introspection call — no INSERT issued before the raise.
         assert conn.execute.await_count == 1
 
     @pytest.mark.asyncio()
@@ -89,10 +96,11 @@ class TestCopyCheckpointTable:
 
         await _copy_checkpoint_table(conn, "checkpoints", "src", "new")
 
-        sql = conn.execute.await_args_list[1].args[0]
+        stmt = conn.execute.await_args_list[1].args[0]
+        sql_str = stmt.as_string(None)
         # Non-thread_id column listed once after explicit thread_id literal.
-        assert sql.count('"checkpoint_id"') == 2  # in INSERT cols + SELECT cols
-        assert sql.count('"thread_id"') == 1  # only in INSERT cols
+        assert sql_str.count('"checkpoint_id"') == 2  # in INSERT cols + SELECT cols
+        assert sql_str.count('"thread_id"') == 1  # only in INSERT cols
 
 
 def _make_atomic_pool_mocks() -> tuple[MagicMock, MagicMock]:

--- a/libs/aegra-api/tests/unit/test_services/test_thread_copy.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_copy.py
@@ -1,0 +1,188 @@
+"""Unit tests for thread_copy service."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aegra_api.services.thread_copy import (
+    _CHECKPOINT_TABLES,
+    _copy_checkpoint_table,
+    _table_columns,
+    copy_thread_atomically,
+)
+
+
+def _make_async_cursor(column_names: list[str]) -> AsyncMock:
+    """Build an awaitable cursor whose ``fetchall`` returns ``dict_row``-style rows.
+
+    Mirrors the pool's ``row_factory=dict_row`` configuration (see
+    ``core/database.py``): each row is a dict keyed by column name.
+    """
+    cur = AsyncMock()
+    cur.fetchall = AsyncMock(return_value=[{"column_name": name} for name in column_names])
+    return cur
+
+
+def _make_async_connection(cursors: list[AsyncMock]) -> AsyncMock:
+    """Build an async connection whose ``execute`` yields ``cursors`` in order."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=cursors)
+    return conn
+
+
+class TestTableColumns:
+    @pytest.mark.asyncio()
+    async def test_returns_columns_in_declaration_order(self) -> None:
+        cursor = _make_async_cursor(["thread_id", "checkpoint_id", "metadata"])
+        conn = _make_async_connection([cursor])
+
+        result = await _table_columns(conn, "checkpoints")
+
+        assert result == ["thread_id", "checkpoint_id", "metadata"]
+        # Query is parametrised on table name — no string interpolation.
+        args, _ = conn.execute.call_args
+        sql, params = args
+        assert "information_schema.columns" in sql
+        assert params == ("checkpoints",)
+
+
+class TestCopyCheckpointTable:
+    @pytest.mark.asyncio()
+    async def test_builds_insert_select_with_thread_id_substitution(self) -> None:
+        cols_cursor = _make_async_cursor(["thread_id", "checkpoint_ns", "checkpoint_id", "metadata"])
+        insert_cursor = _make_async_cursor([])
+        conn = _make_async_connection([cols_cursor, insert_cursor])
+
+        await _copy_checkpoint_table(conn, "checkpoints", "src-uuid", "new-uuid")
+
+        # Two execute calls: information_schema lookup + INSERT...SELECT
+        assert conn.execute.await_count == 2
+        insert_call = conn.execute.await_args_list[1]
+        sql, params = insert_call.args
+        assert sql.startswith('INSERT INTO "checkpoints"')
+        assert '"thread_id"' in sql
+        assert '"checkpoint_ns"' in sql
+        assert '"checkpoint_id"' in sql
+        assert '"metadata"' in sql
+        assert "WHERE thread_id = %s" in sql
+        # First param is the new thread_id, second is the source — order matters
+        assert params == ("new-uuid", "src-uuid")
+
+    @pytest.mark.asyncio()
+    async def test_skips_when_thread_id_column_missing(self) -> None:
+        """Defensive: unexpected schema → skip table without raising."""
+        cols_cursor = _make_async_cursor(["checkpoint_id"])
+        conn = _make_async_connection([cols_cursor])
+
+        await _copy_checkpoint_table(conn, "checkpoints", "src", "new")
+
+        # Only the introspection call — no INSERT issued.
+        assert conn.execute.await_count == 1
+
+    @pytest.mark.asyncio()
+    async def test_does_not_select_thread_id_twice(self) -> None:
+        """thread_id must appear once in column list — first param of INSERT."""
+        cols_cursor = _make_async_cursor(["thread_id", "checkpoint_id"])
+        insert_cursor = _make_async_cursor([])
+        conn = _make_async_connection([cols_cursor, insert_cursor])
+
+        await _copy_checkpoint_table(conn, "checkpoints", "src", "new")
+
+        sql = conn.execute.await_args_list[1].args[0]
+        # Non-thread_id column listed once after explicit thread_id literal.
+        assert sql.count('"checkpoint_id"') == 2  # in INSERT cols + SELECT cols
+        assert sql.count('"thread_id"') == 1  # only in INSERT cols
+
+
+def _make_atomic_pool_mocks() -> tuple[MagicMock, MagicMock]:
+    """Build a (pool, conn) pair wired with the async context-manager protocol."""
+    mock_conn = MagicMock()
+    mock_conn.execute = AsyncMock()
+
+    transaction_ctx = MagicMock()
+    transaction_ctx.__aenter__ = AsyncMock(return_value=None)
+    transaction_ctx.__aexit__ = AsyncMock(return_value=None)
+    mock_conn.transaction = MagicMock(return_value=transaction_ctx)
+
+    connection_ctx = MagicMock()
+    connection_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    connection_ctx.__aexit__ = AsyncMock(return_value=None)
+    mock_pool = MagicMock()
+    mock_pool.connection = MagicMock(return_value=connection_ctx)
+    return mock_pool, mock_conn
+
+
+class TestCopyThreadAtomically:
+    @pytest.mark.asyncio()
+    async def test_inserts_thread_row_then_copies_three_checkpoint_tables(self) -> None:
+        """The thread INSERT must precede the checkpoint INSERT...SELECT calls,
+        all inside the same connection transaction."""
+        mock_pool, mock_conn = _make_atomic_pool_mocks()
+
+        with (
+            patch("aegra_api.services.thread_copy._copy_checkpoint_table", new=AsyncMock()) as mock_copy,
+            patch("aegra_api.services.thread_copy.db_manager") as mock_db,
+        ):
+            mock_db.lg_pool = mock_pool
+
+            await copy_thread_atomically(
+                src_thread_id="src-uuid",
+                new_thread_id="new-uuid",
+                src_status="idle",
+                src_metadata={"k": "v"},
+                user_identity="user-1",
+            )
+
+        # Thread INSERT issued exactly once on the same conn used for the
+        # checkpoint copy (single transaction).
+        assert mock_conn.execute.await_count == 1
+        thread_sql, thread_params = mock_conn.execute.await_args_list[0].args
+        assert thread_sql.startswith('INSERT INTO "thread"')
+        assert thread_params[0] == "new-uuid"
+        assert thread_params[1] == "idle"
+        assert thread_params[3] == "user-1"
+        # The checkpoint copy was invoked once per checkpoint table, in order.
+        tables_copied = [call.args[1] for call in mock_copy.await_args_list]
+        assert tables_copied == list(_CHECKPOINT_TABLES)
+        for call in mock_copy.await_args_list:
+            # Same connection ref ⇒ same Postgres tx as the thread INSERT.
+            assert call.args[0] is mock_conn
+            assert call.args[2] == "src-uuid"
+            assert call.args[3] == "new-uuid"
+
+    @pytest.mark.asyncio()
+    async def test_serializes_metadata_to_json(self) -> None:
+        """Metadata dict is JSON-serialized before being passed to the JSONB cast."""
+        mock_pool, mock_conn = _make_atomic_pool_mocks()
+
+        with (
+            patch("aegra_api.services.thread_copy._copy_checkpoint_table", new=AsyncMock()),
+            patch("aegra_api.services.thread_copy.db_manager") as mock_db,
+        ):
+            mock_db.lg_pool = mock_pool
+
+            await copy_thread_atomically(
+                src_thread_id="src",
+                new_thread_id="new",
+                src_status="idle",
+                src_metadata={"owner": "alice", "graph_id": "agent"},
+                user_identity="alice",
+            )
+
+        thread_params = mock_conn.execute.await_args_list[0].args[1]
+        # metadata_json is the third positional after (new_id, status, json, ...)
+        assert json.loads(thread_params[2]) == {"owner": "alice", "graph_id": "agent"}
+
+    @pytest.mark.asyncio()
+    async def test_raises_when_pool_not_initialized(self) -> None:
+        with patch("aegra_api.services.thread_copy.db_manager") as mock_db:
+            mock_db.lg_pool = None
+            with pytest.raises(RuntimeError, match="not initialized"):
+                await copy_thread_atomically(
+                    src_thread_id="src",
+                    new_thread_id="new",
+                    src_status="idle",
+                    src_metadata={},
+                    user_identity="u",
+                )

--- a/libs/aegra-api/tests/unit/test_services/test_thread_copy.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_copy.py
@@ -9,19 +9,24 @@ from psycopg.types.json import Jsonb
 from aegra_api.services.thread_copy import (
     _CHECKPOINT_TABLES,
     _copy_checkpoint_table,
+    _copy_thread_row,
     _table_columns,
     copy_thread_atomically,
 )
 
+_THREAD_COLS: list[str] = ["thread_id", "status", "metadata_json", "user_id", "created_at", "updated_at"]
 
-def _make_async_cursor(column_names: list[str]) -> AsyncMock:
+
+def _make_async_cursor(column_names: list[str], rowcount: int = 1) -> AsyncMock:
     """Build an awaitable cursor whose ``fetchall`` returns ``dict_row``-style rows.
 
     Mirrors the pool's ``row_factory=dict_row`` configuration (see
     ``core/database.py``): each row is a dict keyed by column name.
+    ``rowcount`` backs the affected-row check after an ``INSERT``.
     """
     cur = AsyncMock()
     cur.fetchall = AsyncMock(return_value=[{"column_name": name} for name in column_names])
+    cur.rowcount = rowcount
     return cur
 
 
@@ -115,8 +120,7 @@ class TestCopyCheckpointTable:
         the SELECT clause unchanged, so the new thread inherits the source's
         chain identifiers byte-for-byte. This is the headline differentiator
         vs ``checkpoint-fork`` (which regenerates checkpoint IDs); end-to-end
-        verification against a live Postgres lives in the integration suite
-        (see follow-up F3 in `infra/aegra/README.md`)."""
+        verification against a live Postgres lives in the e2e suite."""
         cols_cursor = _make_async_cursor(
             [
                 "thread_id",
@@ -147,6 +151,121 @@ class TestCopyCheckpointTable:
         assert "gen_random_uuid" not in sql_str.lower()
 
 
+class TestCopyThreadRow:
+    @pytest.mark.asyncio()
+    async def test_builds_insert_select_from_source_thread(self) -> None:
+        cols_cursor = _make_async_cursor(_THREAD_COLS)
+        insert_cursor = _make_async_cursor([], rowcount=1)
+        conn = _make_async_connection([cols_cursor, insert_cursor])
+
+        await _copy_thread_row(conn, src_thread_id="src", new_thread_id="new", user_identity="u", metadata_overrides={})
+
+        assert conn.execute.await_count == 2  # introspection + INSERT...SELECT
+        stmt = conn.execute.await_args_list[1].args[0]
+        sql_str = stmt.as_string(None)
+        assert sql_str.startswith('INSERT INTO "thread"')
+        assert 'FROM "thread" WHERE "thread_id" = %s' in sql_str
+        assert "NOW()" in sql_str  # timestamps regenerated, not inherited
+
+    @pytest.mark.asyncio()
+    async def test_active_status_resets_to_idle(self) -> None:
+        """Regression: a ``busy``/``running`` source must not copy into a
+        permanently-stuck thread. The copy has no ``runs`` row to advance an
+        active status, so the SQL normalises it to ``idle`` while leaving
+        terminal states untouched."""
+        cols_cursor = _make_async_cursor(_THREAD_COLS)
+        insert_cursor = _make_async_cursor([], rowcount=1)
+        conn = _make_async_connection([cols_cursor, insert_cursor])
+
+        await _copy_thread_row(conn, src_thread_id="src", new_thread_id="new", user_identity="u", metadata_overrides={})
+
+        sql_str = conn.execute.await_args_list[1].args[0].as_string(None)
+        assert "CASE WHEN \"status\" IN ('busy', 'running') THEN 'idle' ELSE \"status\" END" in sql_str
+
+    @pytest.mark.asyncio()
+    async def test_metadata_merges_source_then_handler_then_owner(self) -> None:
+        """Merge order is source ``||`` handler overrides ``||`` ``owner``.
+        The owner rewrite wins even over a handler-supplied ``owner`` key —
+        it is the security invariant that attributes the copy to the caller."""
+        cols_cursor = _make_async_cursor(_THREAD_COLS)
+        insert_cursor = _make_async_cursor([], rowcount=1)
+        conn = _make_async_connection([cols_cursor, insert_cursor])
+
+        await _copy_thread_row(
+            conn,
+            src_thread_id="src",
+            new_thread_id="new",
+            user_identity="bob",
+            metadata_overrides={"team": "x", "owner": "alice"},
+        )
+
+        stmt, params = conn.execute.await_args_list[1].args
+        sql_str = stmt.as_string(None)
+        # Source metadata inherited via jsonb concat, handler/owner layered on top.
+        assert "COALESCE(\"metadata_json\", '{}'::jsonb) ||" in sql_str
+        jsonb_param = next(p for p in params if isinstance(p, Jsonb))
+        assert jsonb_param.obj == {"team": "x", "owner": "bob"}
+
+    @pytest.mark.asyncio()
+    async def test_binds_identity_columns_as_params_in_column_order(self) -> None:
+        cols_cursor = _make_async_cursor(_THREAD_COLS)
+        insert_cursor = _make_async_cursor([], rowcount=1)
+        conn = _make_async_connection([cols_cursor, insert_cursor])
+
+        await _copy_thread_row(
+            conn, src_thread_id="src-uuid", new_thread_id="new-uuid", user_identity="user-1", metadata_overrides={}
+        )
+
+        params = conn.execute.await_args_list[1].args[1]
+        # SELECT-list order (thread_id, metadata_json, user_id) then WHERE src.
+        assert params[0] == "new-uuid"
+        assert isinstance(params[1], Jsonb)
+        assert params[2] == "user-1"
+        assert params[-1] == "src-uuid"
+
+    @pytest.mark.asyncio()
+    async def test_inherits_unknown_future_column_verbatim(self) -> None:
+        """Regression: a column outside the override set is copied as-is, so a
+        NOT NULL column added upstream is inherited from the source rather than
+        silently dropped from the INSERT."""
+        cols = [*_THREAD_COLS, "tenant_id"]
+        cols_cursor = _make_async_cursor(cols)
+        insert_cursor = _make_async_cursor([], rowcount=1)
+        conn = _make_async_connection([cols_cursor, insert_cursor])
+
+        await _copy_thread_row(conn, src_thread_id="src", new_thread_id="new", user_identity="u", metadata_overrides={})
+
+        sql_str = conn.execute.await_args_list[1].args[0].as_string(None)
+        # tenant_id in both the INSERT column list and the SELECT projection.
+        assert sql_str.count('"tenant_id"') == 2
+
+    @pytest.mark.asyncio()
+    async def test_raises_when_thread_id_column_missing(self) -> None:
+        cols_cursor = _make_async_cursor(["status", "user_id"])
+        conn = _make_async_connection([cols_cursor])
+
+        with pytest.raises(RuntimeError, match="thread_id"):
+            await _copy_thread_row(
+                conn, src_thread_id="src", new_thread_id="new", user_identity="u", metadata_overrides={}
+            )
+
+        assert conn.execute.await_count == 1  # introspection only, no INSERT
+
+    @pytest.mark.asyncio()
+    async def test_raises_when_source_row_vanished(self) -> None:
+        """TOCTOU: the source may be deleted between the ownership check and
+        the copy. Zero affected rows raises so the transaction rolls back
+        instead of leaving a thread with no checkpoint history."""
+        cols_cursor = _make_async_cursor(_THREAD_COLS)
+        insert_cursor = _make_async_cursor([], rowcount=0)
+        conn = _make_async_connection([cols_cursor, insert_cursor])
+
+        with pytest.raises(RuntimeError, match="disappeared"):
+            await _copy_thread_row(
+                conn, src_thread_id="gone", new_thread_id="new", user_identity="u", metadata_overrides={}
+            )
+
+
 def _make_atomic_pool_mocks() -> tuple[MagicMock, MagicMock]:
     """Build a (pool, conn) pair wired with the async context-manager protocol."""
     mock_conn = MagicMock()
@@ -167,12 +286,14 @@ def _make_atomic_pool_mocks() -> tuple[MagicMock, MagicMock]:
 
 class TestCopyThreadAtomically:
     @pytest.mark.asyncio()
-    async def test_inserts_thread_row_then_copies_three_checkpoint_tables(self) -> None:
-        """SET TRANSACTION → thread INSERT → checkpoint INSERT...SELECT calls,
-        all inside the same connection transaction."""
+    async def test_sets_repeatable_read_then_copies_thread_then_checkpoints(self) -> None:
+        """SET TRANSACTION is the first statement, then the thread row, then
+        each checkpoint table in order — all on the same connection so they
+        share one Postgres transaction."""
         mock_pool, mock_conn = _make_atomic_pool_mocks()
 
         with (
+            patch("aegra_api.services.thread_copy._copy_thread_row", new=AsyncMock()) as mock_thread,
             patch("aegra_api.services.thread_copy._copy_checkpoint_table", new=AsyncMock()) as mock_copy,
             patch("aegra_api.services.thread_copy.db_manager") as mock_db,
         ):
@@ -181,147 +302,43 @@ class TestCopyThreadAtomically:
             await copy_thread_atomically(
                 src_thread_id="src-uuid",
                 new_thread_id="new-uuid",
-                src_status="idle",
-                src_metadata={"k": "v"},
                 user_identity="user-1",
+                metadata_overrides={"k": "v"},
             )
 
-        # Two execute calls on the connection: SET TRANSACTION first, then the
-        # thread INSERT. Checkpoint tables go through the patched helper.
-        assert mock_conn.execute.await_count == 2
-        thread_sql, thread_params = mock_conn.execute.await_args_list[1].args
-        assert thread_sql.startswith('INSERT INTO "thread"')
-        assert thread_params[0] == "new-uuid"
-        assert thread_params[1] == "idle"
-        assert thread_params[3] == "user-1"
-        # The checkpoint copy was invoked once per checkpoint table, in order.
+        # Only SET TRANSACTION runs directly on the connection; the row and
+        # checkpoint copies go through the patched helpers.
+        assert mock_conn.execute.await_count == 1
+        assert "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ" in mock_conn.execute.await_args_list[0].args[0]
+
+        mock_thread.assert_awaited_once()
+        assert mock_thread.await_args.args[0] is mock_conn
+        assert mock_thread.await_args.kwargs["src_thread_id"] == "src-uuid"
+        assert mock_thread.await_args.kwargs["metadata_overrides"] == {"k": "v"}
+
         tables_copied = [call.args[1] for call in mock_copy.await_args_list]
         assert tables_copied == list(_CHECKPOINT_TABLES)
         for call in mock_copy.await_args_list:
-            # Same connection ref ⇒ same Postgres tx as the thread INSERT.
-            assert call.args[0] is mock_conn
-            assert call.args[2] == "src-uuid"
-            assert call.args[3] == "new-uuid"
+            assert call.args[0] is mock_conn  # same connection ⇒ same tx
 
     @pytest.mark.asyncio()
-    async def test_sets_repeatable_read_isolation_before_dml(self) -> None:
-        """``SET TRANSACTION ISOLATION LEVEL REPEATABLE READ`` must be the
-        first statement inside the ``conn.transaction()`` block. PostgreSQL
-        only honours the directive when no DML has run yet, so the order
-        matters; without REPEATABLE READ the three checkpoint INSERT...SELECT
-        statements can see different snapshots if a concurrent run on the
-        source thread commits between them."""
-        mock_pool, mock_conn = _make_atomic_pool_mocks()
-
-        with (
-            patch("aegra_api.services.thread_copy._copy_checkpoint_table", new=AsyncMock()),
-            patch("aegra_api.services.thread_copy.db_manager") as mock_db,
-        ):
-            mock_db.lg_pool = mock_pool
-
-            await copy_thread_atomically(
-                src_thread_id="src",
-                new_thread_id="new",
-                src_status="idle",
-                src_metadata={},
-                user_identity="u",
-            )
-
-        first_sql = mock_conn.execute.await_args_list[0].args[0]
-        assert "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ" in first_sql
-
-    @pytest.mark.asyncio()
-    async def test_serializes_metadata_via_jsonb_adapter(self) -> None:
-        """Metadata is bound through psycopg's ``Jsonb`` adapter rather than
-        a string + ``::jsonb`` cast. The adapter goes through psycopg's
-        adapter chain, so non-JSON-serializable values (e.g. datetime, UUID)
-        raise at adapt-time with a clear error rather than blowing up
-        ``json.dumps`` mid-transaction."""
-        mock_pool, mock_conn = _make_atomic_pool_mocks()
-
-        with (
-            patch("aegra_api.services.thread_copy._copy_checkpoint_table", new=AsyncMock()),
-            patch("aegra_api.services.thread_copy.db_manager") as mock_db,
-        ):
-            mock_db.lg_pool = mock_pool
-
-            await copy_thread_atomically(
-                src_thread_id="src",
-                new_thread_id="new",
-                src_status="idle",
-                src_metadata={"graph_id": "agent"},
-                user_identity="alice",
-            )
-
-        thread_sql, thread_params = mock_conn.execute.await_args_list[1].args
-        # No ``::jsonb`` cast in the SQL — psycopg infers the column type.
-        assert "::jsonb" not in thread_sql
-        # Third positional argument is the bound value: a Jsonb wrapper, not a
-        # string, so psycopg adapts it natively.
-        assert isinstance(thread_params[2], Jsonb)
-
-    @pytest.mark.asyncio()
-    async def test_metadata_owner_rewritten_to_caller(self) -> None:
-        """``metadata.owner`` is overwritten with the caller identity. Without
-        this rewrite the new thread inherits the source owner field, which
-        misattributes the row for any code reading ``metadata.owner`` instead
-        of the canonical ``thread.user_id`` column. ``create_thread`` enforces
-        the same invariant for fresh threads."""
-        mock_pool, mock_conn = _make_atomic_pool_mocks()
-
-        with (
-            patch("aegra_api.services.thread_copy._copy_checkpoint_table", new=AsyncMock()),
-            patch("aegra_api.services.thread_copy.db_manager") as mock_db,
-        ):
-            mock_db.lg_pool = mock_pool
-
-            await copy_thread_atomically(
-                src_thread_id="src",
-                new_thread_id="new",
-                src_status="idle",
-                src_metadata={"owner": "alice", "graph_id": "agent"},
-                user_identity="bob",
-            )
-
-        thread_params = mock_conn.execute.await_args_list[1].args[1]
-        bound_metadata = thread_params[2].obj  # Jsonb stores the dict on `.obj`
-        assert bound_metadata["owner"] == "bob"
-        # Other keys are preserved verbatim.
-        assert bound_metadata["graph_id"] == "agent"
-
-    @pytest.mark.asyncio()
-    async def test_does_not_mutate_caller_metadata_dict(self) -> None:
-        """Owner rewrite must operate on a copy, otherwise the caller's
-        ``ThreadORM.metadata_json`` dict (a SQLAlchemy mutable JSONB) would
-        see ``owner`` change in place — a subtle ORM-state corruption."""
+    async def test_defaults_metadata_overrides_to_empty(self) -> None:
         mock_pool, _ = _make_atomic_pool_mocks()
-        original = {"owner": "alice", "graph_id": "agent"}
 
         with (
+            patch("aegra_api.services.thread_copy._copy_thread_row", new=AsyncMock()) as mock_thread,
             patch("aegra_api.services.thread_copy._copy_checkpoint_table", new=AsyncMock()),
             patch("aegra_api.services.thread_copy.db_manager") as mock_db,
         ):
             mock_db.lg_pool = mock_pool
 
-            await copy_thread_atomically(
-                src_thread_id="src",
-                new_thread_id="new",
-                src_status="idle",
-                src_metadata=original,
-                user_identity="bob",
-            )
+            await copy_thread_atomically(src_thread_id="src", new_thread_id="new", user_identity="u")
 
-        assert original == {"owner": "alice", "graph_id": "agent"}
+        assert mock_thread.await_args.kwargs["metadata_overrides"] == {}
 
     @pytest.mark.asyncio()
     async def test_raises_when_pool_not_initialized(self) -> None:
         with patch("aegra_api.services.thread_copy.db_manager") as mock_db:
             mock_db.lg_pool = None
             with pytest.raises(RuntimeError, match="not initialized"):
-                await copy_thread_atomically(
-                    src_thread_id="src",
-                    new_thread_id="new",
-                    src_status="idle",
-                    src_metadata={},
-                    user_identity="u",
-                )
+                await copy_thread_atomically(src_thread_id="src", new_thread_id="new", user_identity="u")


### PR DESCRIPTION
We're running aegra as the runtime for an enterprise agent platform we're building, and we hit this while migrating from LangSmith Deployments. The official LangGraph SDK exposes `client.threads.copy(thread_id)` which calls `POST /threads/{id}/copy`, and our codebase already uses it to fork conversation state for branching/replay flows. Aegra `0.9.11` doesn't implement that endpoint, so the SDK call returns a 404 even though every other thread method works.

Before writing anything we ran the call against a live LangSmith Deployments instance to capture the real contract — neither the SDK nor the public docs spell it out fully. The request is `POST /threads/{id}/copy` with body `null`, and the response is HTTP 200 carrying the **full new Thread JSON** (the SDK type hint says `-> None`, but the server actually returns a populated object — we believe the SDK just discards it). The new thread gets a server-generated UUID, deep-copies `metadata`, `config.configurable`, `status`, `error`, and `values` from the source, regenerates `state_updated_at` to the time of the copy, and — crucially — its checkpoint history shares the **same `checkpoint_id` and `parent_checkpoint_id` graph** as the source. We verified this by listing `/threads/{src}/history` and `/threads/{tgt}/history` for the same source-target pair and observing identical `(checkpoint_id, parent_checkpoint_id)` tuples. That last point told us LangSmith implements this as a SQL-level copy of the checkpoint tables rather than as an `aupdate_state` replay (which would regenerate IDs).

This PR ports the same semantics to aegra. The endpoint lives in `api/threads.py:copy_thread` and the heavy lifting is in a new `services/thread_copy.py:copy_thread_atomically` helper. The helper opens a single connection on the existing `langgraph-checkpoint-postgres` pool, starts one Postgres transaction, INSERTs the new thread row, and then runs `INSERT INTO ... SELECT ... WHERE thread_id = %s` against `checkpoints`, `checkpoint_writes`, and `checkpoint_blobs` — substituting only the `thread_id` and preserving every other column verbatim. Going through one pool/one transaction makes the copy atomic: either the new thread row and its full checkpoint history land together, or nothing does. Doing the thread-row INSERT through the same pool (rather than through the SQLAlchemy session) was a deliberate choice — we tried the cross-pool variant first and ended up with a window where the checkpointer pool had committed checkpoint rows while the SQLAlchemy session had not yet committed the thread row, which would leave orphaned checkpoint rows on a partial failure.

Column lists for the three checkpoint tables are introspected at runtime via `information_schema.columns` rather than hard-coded. We did this specifically because `langgraph-checkpoint-postgres` has been adding columns over time (`task_path` was added in a recent migration), and pinning to a static column list would silently drop any future additions on copy. The introspection uses dict-style row access (`r["column_name"]`) because the aegra pool is configured with `row_factory=dict_row` in `core/database.py:50` — getting that right matters because `r[0]` raises `KeyError(0)` against a `dict_row` cursor, and we only caught it through end-to-end testing on a real Postgres rather than through the unit tests, which had been mocking the cursor.

Authorization reuses the `threads:create` event because copy is a creation operation from the caller's point of view. Source-thread ownership is verified before the copy — the helper only fires after `session.scalar(select(ThreadORM).where(... user_id == user.identity))` confirms the source belongs to the caller, so a caller cannot copy someone else's thread.

We're aware of the recently-merged checkpoint-fork work in #321 / #346 / #347. That work is complementary, not overlapping: those PRs let you fork-resume **the same thread** at a chosen checkpoint via `POST /runs` with a `checkpoint` payload, while this endpoint creates a **new thread** with the full source history attached. Both code paths can coexist; nothing here changes the input/state-update flow they fixed.

### Type of change

- [x] `feat`: new feature

### Related issues / PRs

None open at the time of writing. Complementary to merged #321 / #346 / #347 (checkpoint-based fork-resume).

### Changes made

- `api/threads.py`: new `POST /threads/{thread_id}/copy` endpoint. 404 when the source thread is missing or owned by another user; 200 + full Thread JSON otherwise.
- `services/thread_copy.py` (new): `copy_thread_atomically` helper plus internal `_copy_checkpoint_table` and `_table_columns` used by it. Single transaction on the langgraph-checkpoint-postgres pool covers the thread row INSERT and the three checkpoint table copies.
- `tests/unit/test_services/test_thread_copy.py` (new): 7 unit tests covering column introspection (dict-row access matching the pool factory), INSERT...SELECT shape, defensive skip when `thread_id` column is missing from the schema, atomic helper sequencing (thread row before checkpoint copy, all on the same connection), JSON serialization of metadata, and error handling when the pool is uninitialized.

### Testing

- [x] Unit tests added/updated — 7 new tests, full unit suite green at 956 passed locally
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed — see "Validation in our staging environment" below

### Validation in our staging environment

We deployed this branch to our staging Cloud Run instance (built from a wheel of this branch) and verified the endpoint end-to-end against a real Postgres backend.

We created a source thread via `POST /threads`, ran a small graph against it via `POST /runs/wait` to populate two checkpoints (`step=-1 source=input`, `step=0 source=loop`), then issued `POST /threads/{src}/copy`. The response came back HTTP 200 with the full new Thread JSON; the new thread inherited `metadata`, `status`, and the populated `values` from the source as expected. We then listed `/threads/{tgt}/history` and compared `(checkpoint_id, parent_checkpoint_id)` tuples against the source — both threads had identical pairs, confirming the SQL-level copy preserves the checkpoint graph (whereas an `aupdate_state` replay would have regenerated the IDs). We also ran the same probe with a deliberately failing graph to confirm the source's `error`-status is copied through, mirroring the LangSmith reference behaviour.

### Backward compatibility

Additive endpoint — no existing routes touched. No schema changes; the helper uses the existing `thread` table and the langgraph-checkpoint-postgres tables that aegra already provisions. Threads created before this PR can be passed as the source; rows missing optional columns deserialize fine because the column list is introspected per-call.

### Additional notes

The behaviour around `status=src.status` is intentional: if the source has `status='running'` or `status='error'`, the new thread inherits that without an actual run attached. This matches what we observed on LangSmith Deployments when the source had a failed run, and we kept it this way for drop-in compatibility — flagging it explicitly because it is mildly surprising at first glance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "duplicate thread" endpoint to atomically copy a user-owned thread into a new thread_id, preserving conversation history, checkpoints, status, and metadata (owner updated), and returning the new thread.

* **Bug Fixes / Reliability**
  * Ensures atomic, repeatable-copy behavior and emits structured audit logging; returns 404 if source missing and 500 on unexpected failures.

* **Tests**
  * Added unit and integration tests for copy semantics, SQL safety, metadata handling, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements `POST /threads/{thread_id}/copy`, a new endpoint that atomically deep-copies a thread and its full checkpoint history to a new `thread_id`, matching `client.threads.copy()` semantics from LangSmith Deployments. The heavy lifting is in `services/thread_copy.py`, which opens a single REPEATABLE READ transaction on the `lg_pool` and uses `INSERT … SELECT` with `psycopg.sql.Identifier`-composed identifiers and `pg_catalog.pg_attribute`+`to_regclass` for live column introspection.

- `api/threads.py`: adds `copy_thread` endpoint; auth-handler metadata mutations are captured and forwarded, and `threads:create` fires with both the new and source thread IDs in the payload.
- `services/thread_copy.py`: new `copy_thread_atomically` helper with `_copy_thread_row` (overrides `thread_id`, `user_id`, timestamps, and active-status reset) and `_copy_checkpoint_table` (verbatim copy of all three checkpoint tables, preserving the `checkpoint_id` chain).
- Tests cover unit, integration, and E2E levels; docs are updated with a new \"Copying threads\" section.

<h3>Confidence Score: 5/5</h3>

Additive endpoint with no changes to existing routes; atomic cross-pool copy is well-tested at unit, integration, and E2E levels.

All previously flagged issues (silent skip, SQL identifier injection, schema-path mismatch, discarded handler return, wrong auth-event payload) are correctly addressed in this revision. The remaining notes are style and hygiene items that do not affect correctness.

The `session.commit()` + reload block in `api/threads.py` sits outside the try/except after a cross-pool commit — worth a second look to confirm the duplicate-copy scenario is acceptable for the deployment's retry posture.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/threads.py | Adds POST /threads/{thread_id}/copy endpoint. Auth-handler metadata capture and new-thread-id payload are correct. The post-commit reload sits outside the try/except, creating a narrow window where a durable copy can return HTTP 500. |
| libs/aegra-api/src/aegra_api/services/thread_copy.py | New service. Single REPEATABLE READ transaction on lg_pool, column introspection via pg_attribute+to_regclass, psycopg.sql.Identifier throughout — all previously flagged issues resolved. |
| libs/aegra-api/tests/unit/test_services/test_thread_copy.py | 7 unit tests covering dict-row access, INSERT…SELECT shape, missing-column raise, REPEATABLE READ sequencing, metadata merge order, and pool-not-initialized guard. |
| libs/aegra-api/tests/integration/test_api/test_threads_crud.py | Adds two integration tests for handler metadata propagation and consistent thread_id across the auth event and persistence call. |
| libs/aegra-api/tests/e2e/test_threads/test_thread_copy.py | Three E2E tests: empty-thread copy, checkpoint-chain preservation, and 404 on missing source. |
| docs/guides/threads-and-state.mdx | Documentation accurately describes copy semantics, atomicity guarantee, and authorization model. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant E as copy_thread endpoint
    participant A as handle_event (auth)
    participant S as SQLAlchemy session
    participant P as lg_pool (psycopg)
    participant DB as Postgres

    C->>E: "POST /threads/{id}/copy"
    E->>A: "threads:create event {thread_id: new_id, src_thread_id}"
    A-->>E: filters (metadata overrides)
    E->>S: "SELECT thread WHERE id=src AND user_id=caller"
    S->>DB: query
    DB-->>S: src row (or 404)
    S-->>E: src ORM object

    Note over E,P: copy_thread_atomically — single REPEATABLE READ tx
    E->>P: connection()
    P->>DB: BEGIN / SET TRANSACTION ISOLATION LEVEL REPEATABLE READ
    P->>DB: pg_attribute introspection (thread + 3 checkpoint tables)
    P->>DB: "INSERT INTO thread ... SELECT ... WHERE id=src"
    P->>DB: "INSERT INTO checkpoints ... SELECT ... WHERE thread_id=src"
    P->>DB: "INSERT INTO checkpoint_writes ... SELECT ... WHERE thread_id=src"
    P->>DB: "INSERT INTO checkpoint_blobs ... SELECT ... WHERE thread_id=src"
    P->>DB: COMMIT
    DB-->>P: committed

    E->>S: session.commit() (refresh snapshot)
    E->>S: "SELECT thread WHERE id=new_id"
    S->>DB: query
    DB-->>S: new thread row
    S-->>E: new ORM object
    E-->>C: 200 Thread JSON
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant E as copy_thread endpoint
    participant A as handle_event (auth)
    participant S as SQLAlchemy session
    participant P as lg_pool (psycopg)
    participant DB as Postgres

    C->>E: "POST /threads/{id}/copy"
    E->>A: "threads:create event {thread_id: new_id, src_thread_id}"
    A-->>E: filters (metadata overrides)
    E->>S: "SELECT thread WHERE id=src AND user_id=caller"
    S->>DB: query
    DB-->>S: src row (or 404)
    S-->>E: src ORM object

    Note over E,P: copy_thread_atomically — single REPEATABLE READ tx
    E->>P: connection()
    P->>DB: BEGIN / SET TRANSACTION ISOLATION LEVEL REPEATABLE READ
    P->>DB: pg_attribute introspection (thread + 3 checkpoint tables)
    P->>DB: "INSERT INTO thread ... SELECT ... WHERE id=src"
    P->>DB: "INSERT INTO checkpoints ... SELECT ... WHERE thread_id=src"
    P->>DB: "INSERT INTO checkpoint_writes ... SELECT ... WHERE thread_id=src"
    P->>DB: "INSERT INTO checkpoint_blobs ... SELECT ... WHERE thread_id=src"
    P->>DB: COMMIT
    DB-->>P: committed

    E->>S: session.commit() (refresh snapshot)
    E->>S: "SELECT thread WHERE id=new_id"
    S->>DB: query
    DB-->>S: new thread row
    S-->>E: new ORM object
    E-->>C: 200 Thread JSON
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `libs/aegra-api/src/aegra_api/api/threads.py`, line 43-56 ([link](https://github.com/aegra/aegra/blob/9a7ca7bce7af529041a54f061140abb65eddcfb0/libs/aegra-api/src/aegra_api/api/threads.py#L43-L56)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`handle_event` fires before the source ownership check**

   `handle_event` is called at line 44–47 before the `select(ThreadORM).where(... user_id == user.identity)` guard at line 49–54. If the source thread doesn't exist or belongs to another user the endpoint raises 404 — but the handler has already run. Any handler that increments a quota counter, creates a billing record, or provisions a tenant slot on the new `thread_id` will leave those side-effects in place even though no thread ever lands in the database.

   The fix is straightforward: move the ownership check to the top (before `new_id = str(uuid4())`), or at minimum before the `handle_event` call. `new_id` can be generated after the guard passes.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fthreads.py%0ALine%3A%2043-56%0A%0AComment%3A%0A**%60handle_event%60%20fires%20before%20the%20source%20ownership%20check**%0A%0A%60handle_event%60%20is%20called%20at%20line%2044%E2%80%9347%20before%20the%20%60select%28ThreadORM%29.where%28...%20user_id%20%3D%3D%20user.identity%29%60%20guard%20at%20line%2049%E2%80%9354.%20If%20the%20source%20thread%20doesn't%20exist%20or%20belongs%20to%20another%20user%20the%20endpoint%20raises%20404%20%E2%80%94%20but%20the%20handler%20has%20already%20run.%20Any%20handler%20that%20increments%20a%20quota%20counter%2C%20creates%20a%20billing%20record%2C%20or%20provisions%20a%20tenant%20slot%20on%20the%20new%20%60thread_id%60%20will%20leave%20those%20side-effects%20in%20place%20even%20though%20no%20thread%20ever%20lands%20in%20the%20database.%0A%0AThe%20fix%20is%20straightforward%3A%20move%20the%20ownership%20check%20to%20the%20top%20%28before%20%60new_id%20%3D%20str%28uuid4%28%29%29%60%29%2C%20or%20at%20minimum%20before%20the%20%60handle_event%60%20call.%20%60new_id%60%20can%20be%20generated%20after%20the%20guard%20passes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fthreads.py%0ALine%3A%2043-56%0A%0AComment%3A%0A**%60handle_event%60%20fires%20before%20the%20source%20ownership%20check**%0A%0A%60handle_event%60%20is%20called%20at%20line%2044%E2%80%9347%20before%20the%20%60select%28ThreadORM%29.where%28...%20user_id%20%3D%3D%20user.identity%29%60%20guard%20at%20line%2049%E2%80%9354.%20If%20the%20source%20thread%20doesn't%20exist%20or%20belongs%20to%20another%20user%20the%20endpoint%20raises%20404%20%E2%80%94%20but%20the%20handler%20has%20already%20run.%20Any%20handler%20that%20increments%20a%20quota%20counter%2C%20creates%20a%20billing%20record%2C%20or%20provisions%20a%20tenant%20slot%20on%20the%20new%20%60thread_id%60%20will%20leave%20those%20side-effects%20in%20place%20even%20though%20no%20thread%20ever%20lands%20in%20the%20database.%0A%0AThe%20fix%20is%20straightforward%3A%20move%20the%20ownership%20check%20to%20the%20top%20%28before%20%60new_id%20%3D%20str%28uuid4%28%29%29%60%29%2C%20or%20at%20minimum%20before%20the%20%60handle_event%60%20call.%20%60new_id%60%20can%20be%20generated%20after%20the%20guard%20passes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fthread-copy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fthread-copy%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fthreads.py%0ALine%3A%2043-56%0A%0AComment%3A%0A**%60handle_event%60%20fires%20before%20the%20source%20ownership%20check**%0A%0A%60handle_event%60%20is%20called%20at%20line%2044%E2%80%9347%20before%20the%20%60select%28ThreadORM%29.where%28...%20user_id%20%3D%3D%20user.identity%29%60%20guard%20at%20line%2049%E2%80%9354.%20If%20the%20source%20thread%20doesn't%20exist%20or%20belongs%20to%20another%20user%20the%20endpoint%20raises%20404%20%E2%80%94%20but%20the%20handler%20has%20already%20run.%20Any%20handler%20that%20increments%20a%20quota%20counter%2C%20creates%20a%20billing%20record%2C%20or%20provisions%20a%20tenant%20slot%20on%20the%20new%20%60thread_id%60%20will%20leave%20those%20side-effects%20in%20place%20even%20though%20no%20thread%20ever%20lands%20in%20the%20database.%0A%0AThe%20fix%20is%20straightforward%3A%20move%20the%20ownership%20check%20to%20the%20top%20%28before%20%60new_id%20%3D%20str%28uuid4%28%29%29%60%29%2C%20or%20at%20minimum%20before%20the%20%60handle_event%60%20call.%20%60new_id%60%20can%20be%20generated%20after%20the%20guard%20passes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (9): Last reviewed commit: ["fix(api): harden thread copy per review ..."](https://github.com/aegra/aegra/commit/8cad03857241919b91725850fffff9dc23f7c83b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30812020)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=1640ab19-5310-4fc5-aaf6-3760087c66e8))

<!-- /greptile_comment -->