### PR TITLE
feat(scripts): add LangGraph checkpoint and runs cleanup script

### DIFF
--- a/scripts/checkpoint_cleanup.py
+++ b/scripts/checkpoint_cleanup.py
@@ -1,0 +1,801 @@
+#!/usr/bin/env python3
+"""
+LangGraph cleanup job (schema-aware).
+
+This script enforces two retention policies in one pass.
+
+Checkpoint retention:
+  - Threads with thread.status='busy' or any in-flight run -> SKIPPED.
+  - Threads idle/error AND thread.updated_at >= now() - 7 days -> keep all.
+  - Threads idle/error AND thread.updated_at < now() - 7 days  -> keep only the
+    latest checkpoint per (thread_id, checkpoint_ns), and only the blob
+    versions referenced by that kept checkpoint's channel_versions map.
+  - Thread rows themselves are NEVER deleted by this script.
+
+Runs retention:
+  - Runs in terminal statuses older than 30 days -> DELETE.
+  - Runs with active leases (lease_expires_at >= now()) -> SKIPPED.
+  - Runs in in-flight statuses -> SKIPPED.
+
+Safe to run repeatedly. Idempotent. Batched. Logs everything.
+
+Usage:
+    python checkpoint_cleanup.py --dry-run
+    python checkpoint_cleanup.py
+    python checkpoint_cleanup.py --skip-runs
+    python checkpoint_cleanup.py --skip-checkpoints
+    python checkpoint_cleanup.py --skip-estimate            # skip slow count queries
+    python checkpoint_cleanup.py --thread-id <id> --dry-run
+    python checkpoint_cleanup.py --retention-days 14 --runs-retention-days 60
+
+Requires:
+    pip install psycopg[binary]>=3.1
+
+Environment:
+    DATABASE_URL  postgres://user:pass@host:port/db
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from contextlib import suppress
+from typing import Any
+
+import psycopg  # type: ignore[import-not-found]
+from psycopg import sql  # type: ignore[import-not-found]
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+log = logging.getLogger("checkpoint_cleanup")
+
+
+def require_row(row: Any, *, context: str) -> tuple[Any, ...]:
+    if row is None:
+        raise RuntimeError(f"Expected a row for {context}, but query returned none")
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Status semantics (locked in based on your data)
+# ---------------------------------------------------------------------------
+THREAD_BUSY_STATUSES = ("busy",)
+RUN_IN_FLIGHT_STATUSES = ("pending", "running")
+RUN_TERMINAL_STATUSES = ("success", "error", "interrupted", "timeout", "cancelled")
+
+
+# ---------------------------------------------------------------------------
+# Cleanup steps - checkpoints
+# ---------------------------------------------------------------------------
+def build_checkpoint_working_sets(
+    conn: psycopg.Connection,
+    retention_days: int,
+    thread_id: str | None = None,
+    force_thread: bool = False,
+) -> tuple[int, int]:
+    """Populate temp tables identifying checkpoint cleanup work.
+
+    Joins against `thread` and `runs` to enforce safety gates:
+      - Skip thread.status='busy'
+      - Skip threads with any in-flight run
+
+    Returns (threads_to_trim_count, blobs_to_keep_count).
+    """
+    where_clauses: list[sql.SQL] = [
+        sql.SQL("t.status <> ALL(%s)"),
+        sql.SQL("NOT EXISTS (SELECT 1 FROM runs r WHERE r.thread_id = t.thread_id AND r.status = ANY(%s))"),
+    ]
+    params: list = [list(THREAD_BUSY_STATUSES), list(RUN_IN_FLIGHT_STATUSES)]
+
+    if not force_thread:
+        where_clauses.append(sql.SQL("t.updated_at < now() - make_interval(days => %s)"))
+        params.append(retention_days)
+
+    if thread_id:
+        where_clauses.append(sql.SQL("t.thread_id = %s"))
+        params.append(thread_id)
+
+    where_sql = sql.SQL("WHERE ") + sql.SQL(" AND ").join(where_clauses)
+    threads_to_trim_sql = sql.SQL(
+        """
+        CREATE TEMP TABLE threads_to_trim AS
+        SELECT c.thread_id, c.checkpoint_ns, MAX(c.checkpoint_id) AS latest_id
+        FROM checkpoints c
+        JOIN thread t ON t.thread_id = c.thread_id
+        {}
+        GROUP BY c.thread_id, c.checkpoint_ns
+        """
+    ).format(where_sql)
+
+    with conn.cursor() as cur:
+        log.info("Building threads_to_trim%s", f" (scoped to thread_id={thread_id})" if thread_id else "")
+        if force_thread:
+            log.warning("  --force-thread is ON: ignoring age cutoff for this thread")
+
+        cur.execute("DROP TABLE IF EXISTS threads_to_trim")
+        cur.execute(threads_to_trim_sql, params)
+        cur.execute("CREATE INDEX ON threads_to_trim (thread_id, checkpoint_ns)")
+        cur.execute("ANALYZE threads_to_trim")
+        cur.execute("SELECT count(*) FROM threads_to_trim")
+        threads_count = int(require_row(cur.fetchone(), context="threads_to_trim count")[0])
+        log.info("  threads_to_trim: %s rows", f"{threads_count:,}")
+
+        if threads_count == 0:
+            return 0, 0
+
+        log.info("Building blobs_to_keep")
+        cur.execute("DROP TABLE IF EXISTS blobs_to_keep")
+        cur.execute("""
+            CREATE TEMP TABLE blobs_to_keep AS
+            SELECT
+                c.thread_id,
+                c.checkpoint_ns,
+                kv.key             AS channel,
+                kv.value #>> '{}'  AS version
+            FROM checkpoints c
+            JOIN threads_to_trim t
+              ON t.thread_id = c.thread_id
+             AND t.checkpoint_ns = c.checkpoint_ns
+             AND t.latest_id = c.checkpoint_id
+            CROSS JOIN LATERAL jsonb_each(
+                COALESCE(c.checkpoint -> 'channel_versions', '{}'::jsonb)
+            ) kv
+        """)
+        cur.execute("CREATE INDEX ON blobs_to_keep (thread_id, checkpoint_ns, channel, version)")
+        cur.execute("ANALYZE blobs_to_keep")
+        cur.execute("SELECT count(*) FROM blobs_to_keep")
+        blobs_count = int(require_row(cur.fetchone(), context="blobs_to_keep count")[0])
+        log.info("  blobs_to_keep: %s rows", f"{blobs_count:,}")
+
+        return threads_count, blobs_count
+
+
+def estimate_checkpoint_deletes(
+    conn: psycopg.Connection,
+    retention_days: int,
+    force_thread: bool,
+) -> dict[str, int]:
+    """Count rows that would be deleted, applying the same per-batch
+    revalidation gates as the DELETE statements. So the dry-run estimate
+    matches actual deletion behavior including the safety re-checks."""
+    age_clause_sql: sql.SQL | sql.Composed
+    if force_thread:
+        age_clause_sql = sql.SQL("TRUE")
+    else:
+        age_clause_sql = sql.SQL("th.updated_at < now() - make_interval(days => {})").format(
+            sql.Literal(int(retention_days))
+        )
+
+    common_gates = sql.SQL(
+        """
+        AND th.status <> ALL(ARRAY['busy']::text[])
+        AND ({age_clause})
+        AND NOT EXISTS (
+            SELECT 1 FROM runs r
+            WHERE r.thread_id = th.thread_id
+              AND r.status = ANY(ARRAY['pending','running']::text[])
+        )
+        """
+    ).format(age_clause=age_clause_sql)
+
+    counts = {}
+    with conn.cursor() as cur:
+        log.info("Estimating checkpoint deletion counts...")
+
+        cur.execute(
+            sql.SQL(
+                """
+            SELECT count(*) FROM checkpoint_writes cw
+            JOIN threads_to_trim t USING (thread_id, checkpoint_ns)
+            JOIN thread th ON th.thread_id = cw.thread_id
+            WHERE cw.checkpoint_id <> t.latest_id
+            {common_gates}
+                """
+            ).format(common_gates=common_gates)
+        )
+        counts["checkpoint_writes"] = int(require_row(cur.fetchone(), context="checkpoint_writes estimate")[0])
+        log.info("  checkpoint_writes to delete: %s", f"{counts['checkpoint_writes']:,}")
+
+        cur.execute(
+            sql.SQL(
+                """
+            SELECT count(*) FROM checkpoint_blobs cb
+            JOIN threads_to_trim t USING (thread_id, checkpoint_ns)
+            JOIN thread th ON th.thread_id = cb.thread_id
+            WHERE NOT EXISTS (
+                SELECT 1 FROM blobs_to_keep k
+                WHERE k.thread_id = cb.thread_id
+                  AND k.checkpoint_ns = cb.checkpoint_ns
+                  AND k.channel = cb.channel
+                  AND k.version = cb.version
+            )
+            {common_gates}
+                """
+            ).format(common_gates=common_gates)
+        )
+        counts["checkpoint_blobs"] = int(require_row(cur.fetchone(), context="checkpoint_blobs estimate")[0])
+        log.info("  checkpoint_blobs to delete: %s", f"{counts['checkpoint_blobs']:,}")
+
+        cur.execute(
+            sql.SQL(
+                """
+            SELECT count(*) FROM checkpoints c
+            JOIN threads_to_trim t USING (thread_id, checkpoint_ns)
+            JOIN thread th ON th.thread_id = c.thread_id
+            WHERE c.checkpoint_id <> t.latest_id
+            {common_gates}
+                """
+            ).format(common_gates=common_gates)
+        )
+        counts["checkpoints"] = int(require_row(cur.fetchone(), context="checkpoints estimate")[0])
+        log.info("  checkpoints to delete: %s", f"{counts['checkpoints']:,}")
+
+    return counts
+
+
+# Batched DELETE statements with per-batch revalidation against thread/runs.
+
+DELETE_WRITES_SQL_TEMPLATE = """
+WITH victims AS (
+    SELECT cw.thread_id, cw.checkpoint_ns, cw.checkpoint_id, cw.task_id, cw.idx
+    FROM checkpoint_writes cw
+    JOIN threads_to_trim t USING (thread_id, checkpoint_ns)
+    JOIN thread th ON th.thread_id = cw.thread_id
+    WHERE cw.checkpoint_id <> t.latest_id
+      AND th.status <> ALL(ARRAY['busy']::text[])
+      AND ({age_clause})
+      AND NOT EXISTS (
+          SELECT 1 FROM runs r
+          WHERE r.thread_id = cw.thread_id
+            AND r.status = ANY(ARRAY['pending','running']::text[])
+      )
+    LIMIT %s
+)
+DELETE FROM checkpoint_writes cw
+USING victims v
+WHERE cw.thread_id     = v.thread_id
+  AND cw.checkpoint_ns = v.checkpoint_ns
+  AND cw.checkpoint_id = v.checkpoint_id
+  AND cw.task_id       = v.task_id
+  AND cw.idx           = v.idx
+"""
+
+DELETE_BLOBS_SQL_TEMPLATE = """
+WITH victims AS (
+    SELECT cb.thread_id, cb.checkpoint_ns, cb.channel, cb.version
+    FROM checkpoint_blobs cb
+    JOIN threads_to_trim t USING (thread_id, checkpoint_ns)
+    JOIN thread th ON th.thread_id = cb.thread_id
+    WHERE NOT EXISTS (
+        SELECT 1 FROM blobs_to_keep k
+        WHERE k.thread_id     = cb.thread_id
+          AND k.checkpoint_ns = cb.checkpoint_ns
+          AND k.channel       = cb.channel
+          AND k.version       = cb.version
+    )
+      AND th.status <> ALL(ARRAY['busy']::text[])
+      AND ({age_clause})
+      AND NOT EXISTS (
+          SELECT 1 FROM runs r
+          WHERE r.thread_id = cb.thread_id
+            AND r.status = ANY(ARRAY['pending','running']::text[])
+      )
+    LIMIT %s
+)
+DELETE FROM checkpoint_blobs cb
+USING victims v
+WHERE cb.thread_id     = v.thread_id
+  AND cb.checkpoint_ns = v.checkpoint_ns
+  AND cb.channel       = v.channel
+  AND cb.version       = v.version
+"""
+
+DELETE_CHECKPOINTS_SQL_TEMPLATE = """
+WITH victims AS (
+    SELECT c.thread_id, c.checkpoint_ns, c.checkpoint_id
+    FROM checkpoints c
+    JOIN threads_to_trim t USING (thread_id, checkpoint_ns)
+    JOIN thread th ON th.thread_id = c.thread_id
+    WHERE c.checkpoint_id <> t.latest_id
+      AND th.status <> ALL(ARRAY['busy']::text[])
+      AND ({age_clause})
+      AND NOT EXISTS (
+          SELECT 1 FROM runs r
+          WHERE r.thread_id = c.thread_id
+            AND r.status = ANY(ARRAY['pending','running']::text[])
+      )
+    LIMIT %s
+)
+DELETE FROM checkpoints c
+USING victims v
+WHERE c.thread_id     = v.thread_id
+  AND c.checkpoint_ns = v.checkpoint_ns
+  AND c.checkpoint_id = v.checkpoint_id
+"""
+
+
+def build_delete_statements(
+    retention_days: int,
+    force_thread: bool,
+) -> tuple[sql.SQL | sql.Composed, sql.SQL | sql.Composed, sql.SQL | sql.Composed]:
+    """Render the three DELETE templates with the proper age clause."""
+    age_clause: sql.SQL | sql.Composed
+    if force_thread:
+        age_clause = sql.SQL("TRUE")
+    else:
+        age_clause = sql.SQL("th.updated_at < now() - make_interval(days => {})").format(
+            sql.Literal(int(retention_days))
+        )
+
+    return (
+        sql.SQL(DELETE_WRITES_SQL_TEMPLATE).format(age_clause=age_clause),
+        sql.SQL(DELETE_BLOBS_SQL_TEMPLATE).format(age_clause=age_clause),
+        sql.SQL(DELETE_CHECKPOINTS_SQL_TEMPLATE).format(age_clause=age_clause),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cleanup steps - runs
+# ---------------------------------------------------------------------------
+def estimate_runs_deletes(
+    conn: psycopg.Connection,
+    retention_days: int,
+    thread_id: str | None = None,
+) -> int:
+    """Count runs eligible for deletion."""
+    where_clauses: list[sql.SQL] = [
+        sql.SQL("status = ANY(%s)"),
+        sql.SQL("updated_at < now() - make_interval(days => %s)"),
+        sql.SQL("(lease_expires_at IS NULL OR lease_expires_at < now())"),
+    ]
+    params: list = [list(RUN_TERMINAL_STATUSES), retention_days]
+
+    if thread_id:
+        where_clauses.append(sql.SQL("thread_id = %s"))
+        params.append(thread_id)
+
+    where_sql = sql.SQL(" AND ").join(where_clauses)
+    sql_q = sql.SQL("SELECT count(*) FROM runs WHERE {}").format(where_sql)
+    with conn.cursor() as cur:
+        log.info("Estimating runs deletion count...")
+        cur.execute(sql_q, params)
+        count = int(require_row(cur.fetchone(), context="runs estimate")[0])
+        log.info("  runs to delete: %s", f"{count:,}")
+    return count
+
+
+def delete_runs_in_batches(
+    conn: psycopg.Connection,
+    retention_days: int,
+    batch_size: int,
+    pause_seconds: float,
+    thread_id: str | None = None,
+    max_iterations: int = 100_000,
+) -> int:
+    """Batched deletion of terminal runs older than retention window."""
+    where_clauses: list[sql.SQL] = [
+        sql.SQL("status = ANY(%s)"),
+        sql.SQL("updated_at < now() - make_interval(days => %s)"),
+        sql.SQL("(lease_expires_at IS NULL OR lease_expires_at < now())"),
+    ]
+    params_template: list = [list(RUN_TERMINAL_STATUSES), retention_days]
+
+    if thread_id:
+        where_clauses.append(sql.SQL("thread_id = %s"))
+        params_template.append(thread_id)
+
+    where_sql = sql.SQL(" AND ").join(where_clauses)
+    delete_sql = sql.SQL(
+        """
+        WITH victims AS (
+            SELECT run_id FROM runs
+            WHERE {}
+            LIMIT %s
+        )
+        DELETE FROM runs r USING victims v WHERE r.run_id = v.run_id
+        """
+    ).format(where_sql)
+
+    log.info("Deleting from runs in batches of %s", f"{batch_size:,}")
+    total = 0
+    iterations = 0
+    started = time.monotonic()
+
+    while iterations < max_iterations:
+        iterations += 1
+        with conn.cursor() as cur:
+            cur.execute(delete_sql, [*params_template, batch_size])
+            affected = cur.rowcount
+        conn.commit()
+
+        total += affected
+        if iterations % 10 == 0 or affected < batch_size:
+            elapsed = time.monotonic() - started
+            rate = total / elapsed if elapsed > 0 else 0
+            log.info("  runs: deleted %s so far (%.0f rows/sec, batch=%s)", f"{total:,}", rate, affected)
+
+        if affected == 0:
+            break
+        if pause_seconds > 0:
+            time.sleep(pause_seconds)
+
+    if iterations >= max_iterations:
+        log.warning("runs: hit max_iterations safety limit")
+
+    elapsed = time.monotonic() - started
+    log.info("  runs: done. Total deleted: %s in %.1fs", f"{total:,}", elapsed)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Generic batched delete
+# ---------------------------------------------------------------------------
+def delete_in_batches(
+    conn: psycopg.Connection,
+    label: str,
+    delete_sql: sql.SQL | sql.Composed,
+    batch_size: int,
+    pause_seconds: float,
+    max_iterations: int = 100_000,
+) -> int:
+    log.info("Deleting from %s in batches of %s", label, f"{batch_size:,}")
+    total = 0
+    iterations = 0
+    started = time.monotonic()
+
+    while iterations < max_iterations:
+        iterations += 1
+        with conn.cursor() as cur:
+            cur.execute(delete_sql, (batch_size,))
+            affected = cur.rowcount
+        conn.commit()
+
+        total += affected
+        if iterations % 10 == 0 or affected < batch_size:
+            elapsed = time.monotonic() - started
+            rate = total / elapsed if elapsed > 0 else 0
+            log.info("  %s: deleted %s so far (%.0f rows/sec, batch=%s)", label, f"{total:,}", rate, affected)
+
+        if affected == 0:
+            break
+        if pause_seconds > 0:
+            time.sleep(pause_seconds)
+
+    if iterations >= max_iterations:
+        log.warning("%s: hit max_iterations safety limit", label)
+
+    elapsed = time.monotonic() - started
+    log.info("  %s: done. Total deleted: %s in %.1fs", label, f"{total:,}", elapsed)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Snapshots for thread-scoped testing
+# ---------------------------------------------------------------------------
+def snapshot_thread(conn: psycopg.Connection, thread_id: str, label: str) -> None:
+    """Log a per-table summary for a single thread."""
+    with conn.cursor() as cur:
+        log.info("--- Thread snapshot: %s (thread_id=%s) ---", label, thread_id)
+
+        cur.execute("SELECT status, updated_at FROM thread WHERE thread_id = %s", (thread_id,))
+        row = cur.fetchone()
+        if row:
+            log.info("  thread:            status=%s updated_at=%s", row[0], row[1])
+        else:
+            log.info("  thread:            (not found)")
+
+        cur.execute(
+            """
+            SELECT status, count(*)
+            FROM runs WHERE thread_id = %s
+            GROUP BY status ORDER BY count(*) DESC
+            """,
+            (thread_id,),
+        )
+        rs = cur.fetchall()
+        if rs:
+            for st, cnt in rs:
+                log.info("  runs[%s]: %s", st, f"{cnt:,}")
+        else:
+            log.info("  runs:              (none)")
+
+        cur.execute(
+            """
+            SELECT checkpoint_ns, count(*)
+            FROM checkpoints WHERE thread_id = %s
+            GROUP BY checkpoint_ns ORDER BY checkpoint_ns
+            """,
+            (thread_id,),
+        )
+        for ns, cnt in cur.fetchall():
+            log.info("  checkpoints[ns=%r]: %s rows", ns, f"{cnt:,}")
+
+        cur.execute(
+            """
+            SELECT count(*),
+                   pg_size_pretty(COALESCE(sum(pg_column_size(blob)),0)::bigint)
+            FROM checkpoint_writes WHERE thread_id = %s
+            """,
+            (thread_id,),
+        )
+        wcount, wsize = require_row(cur.fetchone(), context="checkpoint_writes snapshot")
+        log.info("  checkpoint_writes: %s rows, ~%s on disk", f"{wcount:,}", wsize)
+
+        cur.execute(
+            """
+            SELECT count(*),
+                   pg_size_pretty(COALESCE(sum(pg_column_size(blob)),0)::bigint)
+            FROM checkpoint_blobs WHERE thread_id = %s
+            """,
+            (thread_id,),
+        )
+        bcount, bsize = require_row(cur.fetchone(), context="checkpoint_blobs snapshot")
+        log.info("  checkpoint_blobs:  %s rows, ~%s on disk", f"{bcount:,}", bsize)
+
+
+def show_kept_checkpoint(conn: psycopg.Connection, thread_id: str) -> None:
+    """Show which checkpoint will be retained for a single-thread test."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT checkpoint_ns, MAX(checkpoint_id)
+            FROM checkpoints WHERE thread_id = %s
+            GROUP BY checkpoint_ns ORDER BY checkpoint_ns
+            """,
+            (thread_id,),
+        )
+        for ns, latest_id in cur.fetchall():
+            log.info("  KEEP latest checkpoint: ns=%r id=%s", ns, latest_id)
+            cur.execute(
+                """
+                SELECT checkpoint -> 'channel_versions'
+                FROM checkpoints
+                WHERE thread_id = %s AND checkpoint_ns = %s AND checkpoint_id = %s
+                """,
+                (thread_id, ns, latest_id),
+            )
+            row = cur.fetchone()
+            if row and row[0] and isinstance(row[0], dict):
+                cv = row[0]
+                log.info("    channel_versions has %d entries", len(cv))
+                for ch, ver in list(cv.items())[:10]:
+                    log.info("      %s -> %s", ch, ver)
+                if len(cv) > 10:
+                    log.info("      ... and %d more", len(cv) - 10)
+            else:
+                log.warning(
+                    "    NO channel_versions in this checkpoint - "
+                    "ALL blobs for this thread will be deleted. "
+                    "Verify before running live."
+                )
+
+
+# ---------------------------------------------------------------------------
+# Advisory lock
+# ---------------------------------------------------------------------------
+ADVISORY_LOCK_KEY = 0x6C67636B6E7570
+
+
+def acquire_lock(conn: psycopg.Connection) -> bool:
+    with conn.cursor() as cur:
+        cur.execute("SELECT pg_try_advisory_lock(%s)", (ADVISORY_LOCK_KEY,))
+        return bool(require_row(cur.fetchone(), context="advisory lock")[0])
+
+
+def release_lock(conn: psycopg.Connection) -> None:
+    with suppress(Exception):
+        conn.rollback()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT pg_advisory_unlock(%s)", (ADVISORY_LOCK_KEY,))
+        conn.commit()
+    except Exception as e:
+        log.warning("Could not release advisory lock cleanly: %s (it will be released on connection close)", e)
+
+
+# ---------------------------------------------------------------------------
+# Pass orchestration
+# ---------------------------------------------------------------------------
+def run_checkpoint_pass(
+    conn: psycopg.Connection,
+    args: argparse.Namespace,
+    pause_seconds: float,
+) -> None:
+    log.info("=" * 72)
+    log.info("CHECKPOINT CLEANUP PASS")
+    log.info("=" * 72)
+
+    if args.thread_id:
+        snapshot_thread(conn, args.thread_id, "BEFORE (checkpoints)")
+
+    threads_count, _ = build_checkpoint_working_sets(
+        conn,
+        retention_days=args.retention_days,
+        thread_id=args.thread_id,
+        force_thread=args.force_thread,
+    )
+
+    if threads_count == 0:
+        if args.thread_id and not args.force_thread:
+            log.info(
+                "Thread %s does not qualify for trimming. Use --force-thread to trim regardless of age.", args.thread_id
+            )
+        else:
+            log.info("No threads need trimming.")
+        return
+
+    if args.thread_id:
+        show_kept_checkpoint(conn, args.thread_id)
+
+    if args.skip_estimate and not args.dry_run:
+        log.info("Skipping deletion estimate (--skip-estimate). Proceeding directly to deletes.")
+    else:
+        counts = estimate_checkpoint_deletes(
+            conn,
+            retention_days=args.retention_days,
+            force_thread=args.force_thread,
+        )
+        total = sum(counts.values())
+        log.info("Estimated checkpoint deletions: %s rows", f"{total:,}")
+
+        if args.dry_run:
+            log.info("DRY RUN: no changes made.")
+            return
+
+    delete_writes_sql, delete_blobs_sql, delete_checkpoints_sql = build_delete_statements(
+        args.retention_days, args.force_thread
+    )
+
+    delete_in_batches(conn, "checkpoint_writes", delete_writes_sql, args.batch_size, pause_seconds)
+    delete_in_batches(conn, "checkpoint_blobs", delete_blobs_sql, args.batch_size, pause_seconds)
+    delete_in_batches(conn, "checkpoints", delete_checkpoints_sql, args.batch_size, pause_seconds)
+
+    if args.thread_id:
+        snapshot_thread(conn, args.thread_id, "AFTER (checkpoints)")
+
+
+def run_runs_pass(
+    conn: psycopg.Connection,
+    args: argparse.Namespace,
+    pause_seconds: float,
+) -> None:
+    log.info("=" * 72)
+    log.info("RUNS CLEANUP PASS")
+    log.info("=" * 72)
+
+    if args.skip_estimate and not args.dry_run:
+        log.info("Skipping runs deletion estimate (--skip-estimate).")
+    else:
+        count = estimate_runs_deletes(
+            conn,
+            retention_days=args.runs_retention_days,
+            thread_id=args.thread_id,
+        )
+
+        if count == 0:
+            log.info("No runs need cleanup.")
+            return
+
+        if args.dry_run:
+            log.info("DRY RUN: no changes made.")
+            return
+
+    delete_runs_in_batches(
+        conn,
+        retention_days=args.runs_retention_days,
+        batch_size=args.batch_size,
+        pause_seconds=pause_seconds,
+        thread_id=args.thread_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Report only, no deletes")
+    parser.add_argument(
+        "--retention-days",
+        type=int,
+        default=7,
+        help="Checkpoint retention: trim threads inactive longer than this (default: 7)",
+    )
+    parser.add_argument(
+        "--runs-retention-days",
+        type=int,
+        default=30,
+        help="Runs retention: delete terminal runs older than this (default: 30)",
+    )
+    parser.add_argument("--batch-size", type=int, default=10_000, help="Rows per DELETE batch (default: 10000)")
+    parser.add_argument("--pause-ms", type=int, default=100, help="Pause between batches in ms (default: 100)")
+    parser.add_argument(
+        "--statement-timeout-ms", type=int, default=300_000, help="Per-statement timeout in ms (default: 300000)"
+    )
+    parser.add_argument("--thread-id", type=str, default=None, help="Scope cleanup to a single thread_id (for testing)")
+    parser.add_argument(
+        "--force-thread", action="store_true", help="With --thread-id, ignore age cutoff. Testing only."
+    )
+    parser.add_argument("--skip-checkpoints", action="store_true", help="Skip the checkpoint cleanup pass")
+    parser.add_argument("--skip-runs", action="store_true", help="Skip the runs cleanup pass")
+    parser.add_argument(
+        "--skip-estimate",
+        action="store_true",
+        help="Skip the deletion-count estimate before running. "
+        "Useful on large databases where the count query is "
+        "slow. The actual deletes still run; you just don't "
+        "get a preview of how many rows will be affected. "
+        "Ignored when --dry-run is set (dry-run needs the "
+        "estimate to do anything useful).",
+    )
+    args = parser.parse_args()
+
+    if args.force_thread and not args.thread_id:
+        log.error("--force-thread requires --thread-id")
+        return 2
+    if args.skip_checkpoints and args.skip_runs:
+        log.error("--skip-checkpoints and --skip-runs together = nothing to do")
+        return 2
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        log.error("DATABASE_URL environment variable not set")
+        return 2
+
+    log.info("=" * 72)
+    log.info("LangGraph cleanup")
+    log.info("  checkpoint retention: %s days", args.retention_days)
+    log.info("  runs retention:       %s days", args.runs_retention_days)
+    log.info("  batch:                %s rows, %sms pause", f"{args.batch_size:,}", args.pause_ms)
+    log.info("  mode:                 %s", "DRY RUN" if args.dry_run else "EXECUTE")
+    if args.thread_id:
+        log.info("  scope:                thread_id=%s%s", args.thread_id, " (force)" if args.force_thread else "")
+    if args.skip_checkpoints:
+        log.info("  skipping checkpoint pass")
+    if args.skip_runs:
+        log.info("  skipping runs pass")
+    if args.skip_estimate:
+        log.info("  skipping deletion estimate (--skip-estimate)")
+    log.info("=" * 72)
+
+    started = time.monotonic()
+    pause_seconds = args.pause_ms / 1000.0
+
+    with psycopg.connect(dsn, autocommit=False) as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql.SQL("SET statement_timeout = {}").format(sql.Literal(args.statement_timeout_ms)))
+            cur.execute("SET lock_timeout = '5s'")
+            cur.execute("SET idle_in_transaction_session_timeout = '60s'")
+        conn.commit()
+
+        if not acquire_lock(conn):
+            log.error("Another cleanup job is already running. Exiting.")
+            return 3
+
+        try:
+            if not args.skip_checkpoints:
+                run_checkpoint_pass(conn, args, pause_seconds)
+            if not args.skip_runs:
+                run_runs_pass(conn, args, pause_seconds)
+        finally:
+            release_lock(conn)
+
+    elapsed = time.monotonic() - started
+    log.info("Cleanup complete in %.1fs", elapsed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Adds `scripts/checkpoint_cleanup.py`, a schema-aware retention job for the LangGraph checkpoint tables (`checkpoints`, `checkpoint_writes`, `checkpoint_blobs`) and the `runs` table.

Without retention, these tables grow unbounded. On databases with high write volume this can reach hundreds of GB within weeks. This script provides a safe, batched cleanup that can run on cron.

**How it works:**

For checkpoints — threads inactive longer than N days (default 7) keep only their latest checkpoint per `(thread_id, checkpoint_ns)` plus the blob versions that checkpoint references via its `channel_versions` map. Threads with `status='busy'` or any in-flight run are always skipped. Thread rows themselves are never deleted.

For runs — terminal-status runs older than M days (default 30) are deleted. Runs with active leases are skipped.

**Safety properties:**

- Per-batch revalidation against `thread`/`runs` so threads that resume mid-cleanup are skipped rather than corrupted
- Postgres advisory lock prevents overlapping cron runs
- Commit-per-batch — safe to interrupt; resumable; bounded locks (`lock_timeout=5s`, `idle_in_transaction_session_timeout=60s`)
- `--dry-run` for safe estimation
- `--thread-id` / `--force-thread` for single-thread testing
- `--skip-estimate` for production-scale databases where the count query is slow

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues

<!-- Replace with the actual issue number if there's an open retention/cleanup issue,
     or remove this section if there isn't one -->
N/A

## Changes Made

- Added `scripts/checkpoint_cleanup.py` implementing the dual-pass retention job (checkpoints + runs)
- Status semantics encoded as module-level constants: `THREAD_BUSY_STATUSES`, `RUN_IN_FLIGHT_STATUSES`, `RUN_TERMINAL_STATUSES`
- Per-batch revalidation in all DELETE statements to handle concurrent thread resumes safely
- Postgres advisory lock for single-instance enforcement
- CLI flags: `--dry-run`, `--retention-days`, `--runs-retention-days`, `--batch-size`, `--pause-ms`, `--statement-timeout-ms`, `--thread-id`, `--force-thread`, `--skip-checkpoints`, `--skip-runs`, `--skip-estimate`
- Module-level docstring covering retention policies, safety properties, usage, and operational notes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

**Manual testing:**

- Verified end-to-end against PostgreSQL 18 with ~3.8M checkpoint rows / 224 GB total
- First-pass cleanup deleted ~25% of rows at 7-day retention; ~67% at 2-day retention
- Resume verified through `PostgresSaver.get_tuple()` and live graph invocation on multiple trimmed threads of varying ages and namespaces
- Concurrent-write race condition exercised by running cleanup while application traffic continued; per-batch revalidation correctly skipped threads whose `updated_at` advanced mid-cleanup
- Validated single-thread test mode (`--thread-id` + `--force-thread`) before broader run
- Confirmed advisory lock prevents overlapping invocations

Note on automated tests — the script's behavior is hard to unit-test without a real Postgres database with the Aegra schema and representative data. Open to adding an integration test fixture if maintainers prefer; happy to follow up in a separate PR.

## Checklist

- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [ ] All tests pass (`make test`) <!-- check this if you ran make test and it passed -->
- [x] Documentation updated (module docstring covers usage; happy to add a separate docs page if preferred)
- [x] Commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Screenshots (if applicable)

N/A

## Additional Notes

A few open questions for maintainers:

1. **Location.** I placed the script under `scripts/`. If you'd prefer `libs/aegra-api/scripts/` or somewhere else, happy to move it.
2. **CLI integration.** Should this also be exposed as an `aegra` CLI subcommand (e.g., `aegra cleanup`)? Functionality stays in the script; the CLI would just be a wrapper.
3. **Tests.** As noted above, this is hard to unit-test. Let me know if you'd like an integration test added — I'd want guidance on how the project prefers to structure DB-backed tests.
4. **Bandit suppressions.** The dynamic SQL composition triggers B608 warnings. All interpolated values are either script-controlled constants (status arrays) or `int()`-cast integers (retention days); user data is exclusively passed via `%s` parameter binding. I've handled this via `<chosen approach>` — happy to refactor to `psycopg.sql.SQL` composition if you'd prefer that pattern.

The script has been running successfully on a 224 GB production database for cleanup operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database cleanup utility for managing checkpoint and run retention
  * Supports dry-run and estimation modes to preview deletions before execution
  * Configurable retention windows and batch processing parameters for controlled cleanup
  * Built-in safety mechanisms to prevent data loss during deletion operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `scripts/checkpoint_cleanup.py`, a standalone PostgreSQL retention job that trims stale LangGraph checkpoint rows (`checkpoints`, `checkpoint_writes`, `checkpoint_blobs`) and old terminal `runs` records using batched DELETEs with per-batch safety revalidation and a Postgres advisory lock to prevent overlapping cron runs.

- **Status-constant divergence:** `THREAD_BUSY_STATUSES` and `RUN_IN_FLIGHT_STATUSES` are only used in the temp-table build step; the three DELETE SQL templates and `estimate_checkpoint_deletes` hardcode the status values literally, so updating the Python constants would silently leave the actual DELETE gates unchanged.
- **Exception handling:** `release_lock` wraps `conn.rollback()` in `suppress(Exception)`, swallowing errors without logging.
- **Keyword-only args:** `delete_in_batches` and `delete_runs_in_batches` both have 6 parameters without a `*` separator.

<h3>Confidence Score: 3/5</h3>

The script should not be run in production until the status-value divergence between the module constants and the DELETE SQL templates is resolved — as written, adding a new busy/in-flight status to the Python constants would leave the actual destructive DELETE gates unchanged.

The per-batch revalidation logic that guards against deleting checkpoints for resuming threads relies on status checks embedded directly in the SQL template strings rather than the module-level constants. A future maintainer updating THREAD_BUSY_STATUSES would reasonably expect all safety gates to change, but the DELETE CTEs would continue using stale hardcoded values and could delete data from threads that should be protected. This is the primary concern alongside the silent exception suppression in the lock-release path.

scripts/checkpoint_cleanup.py — specifically the three DELETE SQL templates and estimate_checkpoint_deletes, which hardcode status values instead of referencing the module constants.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/checkpoint_cleanup.py | New batched retention script for LangGraph checkpoint and runs tables; well-structured with per-batch revalidation and advisory locking, but the module-level status constants are not referenced in the DELETE SQL templates or estimate queries — those hardcode the values — creating a divergence that could cause safety-gate bypass if constants are ever updated. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([main]) --> B[Set session timeouts]
    B --> C{acquire advisory lock}
    C -- locked --> D([exit 3])
    C -- acquired --> E{skip_checkpoints?}
    E -- no --> F[build_checkpoint_working_sets]
    F --> G{threads_count == 0?}
    G -- yes --> H([return])
    G -- no --> I{skip_estimate?}
    I -- no --> J[estimate_checkpoint_deletes]
    J --> K{dry_run?}
    K -- yes --> L([return])
    K -- no --> M[build_delete_statements]
    I -- yes --> M
    M --> N[delete checkpoint_writes in batches]
    N --> O[delete checkpoint_blobs in batches]
    O --> P[delete checkpoints in batches]
    P --> Q{skip_runs?}
    E -- yes --> Q
    Q -- no --> R{skip_estimate?}
    R -- no --> S[estimate_runs_deletes]
    S --> T{count == 0 or dry_run?}
    T -- yes --> U([return])
    T -- no --> V[delete_runs_in_batches]
    R -- yes --> V
    V --> W[release_lock]
    W --> X([exit 0])
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Ascripts%2Fcheckpoint_cleanup.py%3A247-270%0AStatus%20constants%20not%20used%20in%20DELETE%20SQL%20templates%20%E2%80%94%20safety%20gates%20diverge%20from%20module-level%20source%20of%20truth.%20The%20constants%20%60THREAD_BUSY_STATUSES%60%20and%20%60RUN_IN_FLIGHT_STATUSES%60%20are%20only%20consumed%20in%20%60build_checkpoint_working_sets%60%20and%20the%20runs%20helpers%3B%20the%20three%20%60DELETE_*_SQL_TEMPLATE%60%20strings%20and%20%60estimate_checkpoint_deletes%60%20all%20hardcode%20%60ARRAY%5B'busy'%5D%3A%3Atext%5B%5D%60%20%2F%20%60ARRAY%5B'pending'%2C'running'%5D%3A%3Atext%5B%5D%60.%20If%20someone%20adds%20%60%22streaming%22%60%20to%20%60THREAD_BUSY_STATUSES%60%2C%20the%20temp-table%20build%20would%20correctly%20exclude%20those%20threads%2C%20but%20the%20per-batch%20revalidation%20in%20the%20DELETE%20CTEs%20would%20still%20delete%20their%20checkpoints%20%E2%80%94%20silently%20corrupting%20live%20threads.%20Replace%20the%20hardcoded%20literals%20with%20%60psycopg.sql%60%20interpolation%20already%20used%20elsewhere%20in%20this%20file.%0A%0A%60%60%60suggestion%0ADELETE_WRITES_SQL_TEMPLATE%20%3D%20%22%22%22%0AWITH%20victims%20AS%20%28%0A%20%20%20%20SELECT%20cw.thread_id%2C%20cw.checkpoint_ns%2C%20cw.checkpoint_id%2C%20cw.task_id%2C%20cw.idx%0A%20%20%20%20FROM%20checkpoint_writes%20cw%0A%20%20%20%20JOIN%20threads_to_trim%20t%20USING%20%28thread_id%2C%20checkpoint_ns%29%0A%20%20%20%20JOIN%20thread%20th%20ON%20th.thread_id%20%3D%20cw.thread_id%0A%20%20%20%20WHERE%20cw.checkpoint_id%20%3C%3E%20t.latest_id%0A%20%20%20%20%20%20AND%20th.status%20%3C%3E%20ALL%28%7Bbusy_statuses%7D%29%0A%20%20%20%20%20%20AND%20%28%7Bage_clause%7D%29%0A%20%20%20%20%20%20AND%20NOT%20EXISTS%20%28%0A%20%20%20%20%20%20%20%20%20%20SELECT%201%20FROM%20runs%20r%0A%20%20%20%20%20%20%20%20%20%20WHERE%20r.thread_id%20%3D%20cw.thread_id%0A%20%20%20%20%20%20%20%20%20%20%20%20AND%20r.status%20%3D%20ANY%28%7Bin_flight_statuses%7D%29%0A%20%20%20%20%20%20%29%0A%20%20%20%20LIMIT%20%25s%0A%29%0ADELETE%20FROM%20checkpoint_writes%20cw%0AUSING%20victims%20v%0AWHERE%20cw.thread_id%20%20%20%20%20%3D%20v.thread_id%0A%20%20AND%20cw.checkpoint_ns%20%3D%20v.checkpoint_ns%0A%20%20AND%20cw.checkpoint_id%20%3D%20v.checkpoint_id%0A%20%20AND%20cw.task_id%20%20%20%20%20%20%20%3D%20v.task_id%0A%20%20AND%20cw.idx%20%20%20%20%20%20%20%20%20%20%20%3D%20v.idx%0A%22%22%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Ascripts%2Fcheckpoint_cleanup.py%3A594-602%0A%60suppress%28Exception%29%60%20silently%20swallows%20all%20errors%20on%20rollback%20%E2%80%94%20same%20effect%20as%20%60except%20Exception%3A%20pass%60.%20Per%20project%20rules%2C%20exceptions%20must%20never%20be%20swallowed%20silently%3B%20if%20the%20rollback%20fails%20%28e.g.%2C%20broken%20connection%2C%20SSL%20error%29%2C%20the%20failure%20disappears%20without%20any%20log%20entry.%20The%20best%20fix%20is%20to%20log%20the%20failure%2C%20consistent%20with%20how%20the%20outer%20%60try%60%20block%20already%20handles%20%60pg_advisory_unlock%60%20errors.%0A%0A%60%60%60suggestion%0Adef%20release_lock%28conn%3A%20psycopg.Connection%29%20-%3E%20None%3A%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20conn.rollback%28%29%0A%20%20%20%20except%20Exception%20as%20e%3A%0A%20%20%20%20%20%20%20%20log.warning%28%22rollback%20before%20advisory%20unlock%20failed%3A%20%25s%22%2C%20e%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20with%20conn.cursor%28%29%20as%20cur%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20cur.execute%28%22SELECT%20pg_advisory_unlock%28%25s%29%22%2C%20%28ADVISORY_LOCK_KEY%2C%29%29%0A%20%20%20%20%20%20%20%20conn.commit%28%29%0A%20%20%20%20except%20Exception%20as%20e%3A%0A%20%20%20%20%20%20%20%20log.warning%28%22Could%20not%20release%20advisory%20lock%20cleanly%3A%20%25s%20%28it%20will%20be%20released%20on%20connection%20close%29%22%2C%20e%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Ascripts%2Fcheckpoint_cleanup.py%3A442-449%0A%60delete_in_batches%60%20has%206%20parameters%20but%20no%20keyword-only%20separator.%20Per%20project%20style%2C%20functions%20with%205%2B%20parameters%20must%20use%20a%20%60*%60%20separator%20so%20callers%20cannot%20accidentally%20pass%20arguments%20in%20the%20wrong%20positional%20order.%0A%0A%60%60%60suggestion%0Adef%20delete_in_batches%28%0A%20%20%20%20conn%3A%20psycopg.Connection%2C%0A%20%20%20%20label%3A%20str%2C%0A%20%20%20%20delete_sql%3A%20sql.SQL%20%7C%20sql.Composed%2C%0A%20%20%20%20*%2C%0A%20%20%20%20batch_size%3A%20int%2C%0A%20%20%20%20pause_seconds%3A%20float%2C%0A%20%20%20%20max_iterations%3A%20int%20%3D%20100_000%2C%0A%29%20-%3E%20int%3A%0A%60%60%60%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=aegra%2Faegra&pr=355&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Ascripts%2Fcheckpoint_cleanup.py%3A247-270%0AStatus%20constants%20not%20used%20in%20DELETE%20SQL%20templates%20%E2%80%94%20safety%20gates%20diverge%20from%20module-level%20source%20of%20truth.%20The%20constants%20%60THREAD_BUSY_STATUSES%60%20and%20%60RUN_IN_FLIGHT_STATUSES%60%20are%20only%20consumed%20in%20%60build_checkpoint_working_sets%60%20and%20the%20runs%20helpers%3B%20the%20three%20%60DELETE_*_SQL_TEMPLATE%60%20strings%20and%20%60estimate_checkpoint_deletes%60%20all%20hardcode%20%60ARRAY%5B'busy'%5D%3A%3Atext%5B%5D%60%20%2F%20%60ARRAY%5B'pending'%2C'running'%5D%3A%3Atext%5B%5D%60.%20If%20someone%20adds%20%60%22streaming%22%60%20to%20%60THREAD_BUSY_STATUSES%60%2C%20the%20temp-table%20build%20would%20correctly%20exclude%20those%20threads%2C%20but%20the%20per-batch%20revalidation%20in%20the%20DELETE%20CTEs%20would%20still%20delete%20their%20checkpoints%20%E2%80%94%20silently%20corrupting%20live%20threads.%20Replace%20the%20hardcoded%20literals%20with%20%60psycopg.sql%60%20interpolation%20already%20used%20elsewhere%20in%20this%20file.%0A%0A%60%60%60suggestion%0ADELETE_WRITES_SQL_TEMPLATE%20%3D%20%22%22%22%0AWITH%20victims%20AS%20%28%0A%20%20%20%20SELECT%20cw.thread_id%2C%20cw.checkpoint_ns%2C%20cw.checkpoint_id%2C%20cw.task_id%2C%20cw.idx%0A%20%20%20%20FROM%20checkpoint_writes%20cw%0A%20%20%20%20JOIN%20threads_to_trim%20t%20USING%20%28thread_id%2C%20checkpoint_ns%29%0A%20%20%20%20JOIN%20thread%20th%20ON%20th.thread_id%20%3D%20cw.thread_id%0A%20%20%20%20WHERE%20cw.checkpoint_id%20%3C%3E%20t.latest_id%0A%20%20%20%20%20%20AND%20th.status%20%3C%3E%20ALL%28%7Bbusy_statuses%7D%29%0A%20%20%20%20%20%20AND%20%28%7Bage_clause%7D%29%0A%20%20%20%20%20%20AND%20NOT%20EXISTS%20%28%0A%20%20%20%20%20%20%20%20%20%20SELECT%201%20FROM%20runs%20r%0A%20%20%20%20%20%20%20%20%20%20WHERE%20r.thread_id%20%3D%20cw.thread_id%0A%20%20%20%20%20%20%20%20%20%20%20%20AND%20r.status%20%3D%20ANY%28%7Bin_flight_statuses%7D%29%0A%20%20%20%20%20%20%29%0A%20%20%20%20LIMIT%20%25s%0A%29%0ADELETE%20FROM%20checkpoint_writes%20cw%0AUSING%20victims%20v%0AWHERE%20cw.thread_id%20%20%20%20%20%3D%20v.thread_id%0A%20%20AND%20cw.checkpoint_ns%20%3D%20v.checkpoint_ns%0A%20%20AND%20cw.checkpoint_id%20%3D%20v.checkpoint_id%0A%20%20AND%20cw.task_id%20%20%20%20%20%20%20%3D%20v.task_id%0A%20%20AND%20cw.idx%20%20%20%20%20%20%20%20%20%20%20%3D%20v.idx%0A%22%22%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Ascripts%2Fcheckpoint_cleanup.py%3A594-602%0A%60suppress%28Exception%29%60%20silently%20swallows%20all%20errors%20on%20rollback%20%E2%80%94%20same%20effect%20as%20%60except%20Exception%3A%20pass%60.%20Per%20project%20rules%2C%20exceptions%20must%20never%20be%20swallowed%20silently%3B%20if%20the%20rollback%20fails%20%28e.g.%2C%20broken%20connection%2C%20SSL%20error%29%2C%20the%20failure%20disappears%20without%20any%20log%20entry.%20The%20best%20fix%20is%20to%20log%20the%20failure%2C%20consistent%20with%20how%20the%20outer%20%60try%60%20block%20already%20handles%20%60pg_advisory_unlock%60%20errors.%0A%0A%60%60%60suggestion%0Adef%20release_lock%28conn%3A%20psycopg.Connection%29%20-%3E%20None%3A%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20conn.rollback%28%29%0A%20%20%20%20except%20Exception%20as%20e%3A%0A%20%20%20%20%20%20%20%20log.warning%28%22rollback%20before%20advisory%20unlock%20failed%3A%20%25s%22%2C%20e%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20with%20conn.cursor%28%29%20as%20cur%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20cur.execute%28%22SELECT%20pg_advisory_unlock%28%25s%29%22%2C%20%28ADVISORY_LOCK_KEY%2C%29%29%0A%20%20%20%20%20%20%20%20conn.commit%28%29%0A%20%20%20%20except%20Exception%20as%20e%3A%0A%20%20%20%20%20%20%20%20log.warning%28%22Could%20not%20release%20advisory%20lock%20cleanly%3A%20%25s%20%28it%20will%20be%20released%20on%20connection%20close%29%22%2C%20e%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Ascripts%2Fcheckpoint_cleanup.py%3A442-449%0A%60delete_in_batches%60%20has%206%20parameters%20but%20no%20keyword-only%20separator.%20Per%20project%20style%2C%20functions%20with%205%2B%20parameters%20must%20use%20a%20%60*%60%20separator%20so%20callers%20cannot%20accidentally%20pass%20arguments%20in%20the%20wrong%20positional%20order.%0A%0A%60%60%60suggestion%0Adef%20delete_in_batches%28%0A%20%20%20%20conn%3A%20psycopg.Connection%2C%0A%20%20%20%20label%3A%20str%2C%0A%20%20%20%20delete_sql%3A%20sql.SQL%20%7C%20sql.Composed%2C%0A%20%20%20%20*%2C%0A%20%20%20%20batch_size%3A%20int%2C%0A%20%20%20%20pause_seconds%3A%20float%2C%0A%20%20%20%20max_iterations%3A%20int%20%3D%20100_000%2C%0A%29%20-%3E%20int%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Ascripts%2Fcheckpoint_cleanup.py%3A376-383%0A%60delete_runs_in_batches%60%20also%20has%206%20parameters%20with%20no%20keyword-only%20separator%2C%20same%20issue%20as%20%60delete_in_batches%60.%0A%0A%60%60%60suggestion%0Adef%20delete_runs_in_batches%28%0A%20%20%20%20conn%3A%20psycopg.Connection%2C%0A%20%20%20%20retention_days%3A%20int%2C%0A%20%20%20%20*%2C%0A%20%20%20%20batch_size%3A%20int%2C%0A%20%20%20%20pause_seconds%3A%20float%2C%0A%20%20%20%20thread_id%3A%20str%20%7C%20None%20%3D%20None%2C%0A%20%20%20%20max_iterations%3A%20int%20%3D%20100_000%2C%0A%29%20-%3E%20int%3A%0A%60%60%60%0A%0A&pr=355&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fcheckpoint-cleanup-script%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fcheckpoint-cleanup-script%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Ascripts%2Fcheckpoint_cleanup.py%3A247-270%0AStatus%20constants%20not%20used%20in%20DELETE%20SQL%20templates%20%E2%80%94%20safety%20gates%20diverge%20from%20module-level%20source%20of%20truth.%20The%20constants%20%60THREAD_BUSY_STATUSES%60%20and%20%60RUN_IN_FLIGHT_STATUSES%60%20are%20only%20consumed%20in%20%60build_checkpoint_working_sets%60%20and%20the%20runs%20helpers%3B%20the%20three%20%60DELETE_*_SQL_TEMPLATE%60%20strings%20and%20%60estimate_checkpoint_deletes%60%20all%20hardcode%20%60ARRAY%5B'busy'%5D%3A%3Atext%5B%5D%60%20%2F%20%60ARRAY%5B'pending'%2C'running'%5D%3A%3Atext%5B%5D%60.%20If%20someone%20adds%20%60%22streaming%22%60%20to%20%60THREAD_BUSY_STATUSES%60%2C%20the%20temp-table%20build%20would%20correctly%20exclude%20those%20threads%2C%20but%20the%20per-batch%20revalidation%20in%20the%20DELETE%20CTEs%20would%20still%20delete%20their%20checkpoints%20%E2%80%94%20silently%20corrupting%20live%20threads.%20Replace%20the%20hardcoded%20literals%20with%20%60psycopg.sql%60%20interpolation%20already%20used%20elsewhere%20in%20this%20file.%0A%0A%60%60%60suggestion%0ADELETE_WRITES_SQL_TEMPLATE%20%3D%20%22%22%22%0AWITH%20victims%20AS%20%28%0A%20%20%20%20SELECT%20cw.thread_id%2C%20cw.checkpoint_ns%2C%20cw.checkpoint_id%2C%20cw.task_id%2C%20cw.idx%0A%20%20%20%20FROM%20checkpoint_writes%20cw%0A%20%20%20%20JOIN%20threads_to_trim%20t%20USING%20%28thread_id%2C%20checkpoint_ns%29%0A%20%20%20%20JOIN%20thread%20th%20ON%20th.thread_id%20%3D%20cw.thread_id%0A%20%20%20%20WHERE%20cw.checkpoint_id%20%3C%3E%20t.latest_id%0A%20%20%20%20%20%20AND%20th.status%20%3C%3E%20ALL%28%7Bbusy_statuses%7D%29%0A%20%20%20%20%20%20AND%20%28%7Bage_clause%7D%29%0A%20%20%20%20%20%20AND%20NOT%20EXISTS%20%28%0A%20%20%20%20%20%20%20%20%20%20SELECT%201%20FROM%20runs%20r%0A%20%20%20%20%20%20%20%20%20%20WHERE%20r.thread_id%20%3D%20cw.thread_id%0A%20%20%20%20%20%20%20%20%20%20%20%20AND%20r.status%20%3D%20ANY%28%7Bin_flight_statuses%7D%29%0A%20%20%20%20%20%20%29%0A%20%20%20%20LIMIT%20%25s%0A%29%0ADELETE%20FROM%20checkpoint_writes%20cw%0AUSING%20victims%20v%0AWHERE%20cw.thread_id%20%20%20%20%20%3D%20v.thread_id%0A%20%20AND%20cw.checkpoint_ns%20%3D%20v.checkpoint_ns%0A%20%20AND%20cw.checkpoint_id%20%3D%20v.checkpoint_id%0A%20%20AND%20cw.task_id%20%20%20%20%20%20%20%3D%20v.task_id%0A%20%20AND%20cw.idx%20%20%20%20%20%20%20%20%20%20%20%3D%20v.idx%0A%22%22%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Ascripts%2Fcheckpoint_cleanup.py%3A594-602%0A%60suppress%28Exception%29%60%20silently%20swallows%20all%20errors%20on%20rollback%20%E2%80%94%20same%20effect%20as%20%60except%20Exception%3A%20pass%60.%20Per%20project%20rules%2C%20exceptions%20must%20never%20be%20swallowed%20silently%3B%20if%20the%20rollback%20fails%20%28e.g.%2C%20broken%20connection%2C%20SSL%20error%29%2C%20the%20failure%20disappears%20without%20any%20log%20entry.%20The%20best%20fix%20is%20to%20log%20the%20failure%2C%20consistent%20with%20how%20the%20outer%20%60try%60%20block%20already%20handles%20%60pg_advisory_unlock%60%20errors.%0A%0A%60%60%60suggestion%0Adef%20release_lock%28conn%3A%20psycopg.Connection%29%20-%3E%20None%3A%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20conn.rollback%28%29%0A%20%20%20%20except%20Exception%20as%20e%3A%0A%20%20%20%20%20%20%20%20log.warning%28%22rollback%20before%20advisory%20unlock%20failed%3A%20%25s%22%2C%20e%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20with%20conn.cursor%28%29%20as%20cur%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20cur.execute%28%22SELECT%20pg_advisory_unlock%28%25s%29%22%2C%20%28ADVISORY_LOCK_KEY%2C%29%29%0A%20%20%20%20%20%20%20%20conn.commit%28%29%0A%20%20%20%20except%20Exception%20as%20e%3A%0A%20%20%20%20%20%20%20%20log.warning%28%22Could%20not%20release%20advisory%20lock%20cleanly%3A%20%25s%20%28it%20will%20be%20released%20on%20connection%20close%29%22%2C%20e%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Ascripts%2Fcheckpoint_cleanup.py%3A442-449%0A%60delete_in_batches%60%20has%206%20parameters%20but%20no%20keyword-only%20separator.%20Per%20project%20style%2C%20functions%20with%205%2B%20parameters%20must%20use%20a%20%60*%60%20separator%20so%20callers%20cannot%20accidentally%20pass%20arguments%20in%20the%20wrong%20positional%20order.%0A%0A%60%60%60suggestion%0Adef%20delete_in_batches%28%0A%20%20%20%20conn%3A%20psycopg.Connection%2C%0A%20%20%20%20label%3A%20str%2C%0A%20%20%20%20delete_sql%3A%20sql.SQL%20%7C%20sql.Composed%2C%0A%20%20%20%20*%2C%0A%20%20%20%20batch_size%3A%20int%2C%0A%20%20%20%20pause_seconds%3A%20float%2C%0A%20%20%20%20max_iterations%3A%20int%20%3D%20100_000%2C%0A%29%20-%3E%20int%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Ascripts%2Fcheckpoint_cleanup.py%3A376-383%0A%60delete_runs_in_batches%60%20also%20has%206%20parameters%20with%20no%20keyword-only%20separator%2C%20same%20issue%20as%20%60delete_in_batches%60.%0A%0A%60%60%60suggestion%0Adef%20delete_runs_in_batches%28%0A%20%20%20%20conn%3A%20psycopg.Connection%2C%0A%20%20%20%20retention_days%3A%20int%2C%0A%20%20%20%20*%2C%0A%20%20%20%20batch_size%3A%20int%2C%0A%20%20%20%20pause_seconds%3A%20float%2C%0A%20%20%20%20thread_id%3A%20str%20%7C%20None%20%3D%20None%2C%0A%20%20%20%20max_iterations%3A%20int%20%3D%20100_000%2C%0A%29%20-%3E%20int%3A%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(scripts): add LangGraph checkpoint ..."](https://github.com/aegra/aegra/commit/819bf220e5af32bd70083a82e934db4f4ea6974c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31189075)</sub>

> Greptile also left **4 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=1640ab19-5310-4fc5-aaf6-3760087c66e8))

<!-- /greptile_comment -->