### PR TITLE
chore: bump version to 0.9.13

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.12"
+    "version": "0.9.13"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.12"
+version = "0.9.13"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.12"
+version = "0.9.13"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.12"
+version = "0.9.13"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -96,7 +96,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.12"
+version = "0.9.13"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
Patch bump rolling up the changes from #348, which was merged without a version bump.

## Summary

- aegra-api: 0.9.12 -> 0.9.13
- aegra-cli: 0.9.12 -> 0.9.13
- docs/openapi.json: 0.9.12 -> 0.9.13
- uv.lock synced

## Changes since 0.9.12

- #348 fix(api): honor sort params and auth-handler filters in /assistants/search

Patch bump since the changes are additive (new sort_by / sort_order on AssistantSearchRequest, new GIN index on assistant.metadata, /assistants/count and GET /assistants no longer 500 under @auth.on handlers) with no breaking changes.

## Test plan

- [ ] CI green
- [ ] Tag v0.9.13 + publish to PyPI after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version incremented to 0.9.13 across API, CLI, and documentation components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/364)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Patch version bump from 0.9.12 to 0.9.13, rolling up the `/assistants/search` sort and auth-handler fixes from #348. All four artifacts (`aegra-api`, `aegra-cli`, `docs/openapi.json`, `uv.lock`) are updated consistently.

- Both `pyproject.toml` files and `uv.lock` are in sync at 0.9.13, satisfying the repo's requirement that `aegra-api` and `aegra-cli` always share the same version.
- The `aegra-api~=0.9.0` compatible-release constraint in `aegra-cli` is correctly left unchanged, as patch bumps within `0.9.*` are already covered.
- `docs/openapi.json` version field matches the package versions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four artifacts are updated consistently and no logic changes are introduced.

This is a purely mechanical version bump with no code logic changes. Both package versions are in lockstep at 0.9.13, the aegra-api~=0.9.0 compatible-release pin in aegra-cli correctly covers the new patch version without modification, and uv.lock is synced. Nothing here can regress runtime behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/pyproject.toml | Version bumped from 0.9.12 to 0.9.13; no other changes. |
| libs/aegra-cli/pyproject.toml | Version bumped from 0.9.12 to 0.9.13; aegra-api~=0.9.0 constraint correctly unchanged for a patch bump. |
| docs/openapi.json | OpenAPI spec version field updated from 0.9.12 to 0.9.13 to match package versions. |
| uv.lock | Lock file updated to reflect the new 0.9.13 versions for both aegra-api and aegra-cli workspace members. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PR #348 merged\n(sort params + auth-handler fixes)"] --> B["Version bump PR #364"]
    B --> C["libs/aegra-api/pyproject.toml\n0.9.12 → 0.9.13"]
    B --> D["libs/aegra-cli/pyproject.toml\n0.9.12 → 0.9.13"]
    B --> E["docs/openapi.json\n0.9.12 → 0.9.13"]
    B --> F["uv.lock\naegra-api + aegra-cli → 0.9.13"]
    C & D & E & F --> G["Tag v0.9.13\n+ Publish to PyPI"]
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump version to 0.9.13"](https://github.com/aegra/aegra/commit/292eea1a267deaac004d46b72aa8fa349a9011f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31440863)</sub>

<!-- /greptile_comment -->