### PR TITLE
chore: bump version to 0.9.14

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.13"
+    "version": "0.9.14"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.13"
+version = "0.9.14"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.13"
+version = "0.9.14"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.13"
+version = "0.9.14"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -96,7 +96,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.13"
+version = "0.9.14"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
Patch bump rolling up #335.

## Summary

- aegra-api: 0.9.13 -> 0.9.14
- aegra-cli: 0.9.13 -> 0.9.14
- docs/openapi.json: 0.9.13 -> 0.9.14
- uv.lock synced

## Changes since 0.9.13

- #335 feat(observability): propagate user-supplied run metadata to OTEL trace context

Patch bump since the changes are additive: `RunCreate.metadata` now flows through the run pipeline and surfaces as filterable OTEL attributes (`langfuse.trace.metadata.<key>`) on Langfuse / Phoenix targets. Previously the field was accepted but silently dropped.

DoS surface closed at the API boundary via key/count/length validation on `RunCreate.metadata`. No breaking changes for existing callers.

## Test plan

- [ ] CI green
- [ ] Tag v0.9.14 + publish to PyPI after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.9.14 across packages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/366)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps `aegra-api` and `aegra-cli` from 0.9.13 to 0.9.14, rolling up the additive `RunCreate.metadata` → OTEL propagation change from #335. All four touched files (`pyproject.toml` × 2, `uv.lock`, `docs/openapi.json`) are consistent on the new version.

- `libs/aegra-api/pyproject.toml` and `libs/aegra-cli/pyproject.toml`: version field set to 0.9.14.
- `uv.lock`: both package entries re-pinned to 0.9.14, keeping the lock in sync.
- `docs/openapi.json`: OpenAPI `info.version` updated to match.

<h3>Confidence Score: 5/5</h3>

Pure version-string bump with no logic changes; all four files are mutually consistent on 0.9.14.

Every changed line is a version string, and the four files agree on the new value. There is nothing here that can introduce a regression.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/openapi.json | Version string bumped from 0.9.13 to 0.9.14 to match package versions. |
| libs/aegra-api/pyproject.toml | Package version bumped from 0.9.13 to 0.9.14. |
| libs/aegra-cli/pyproject.toml | Package version bumped from 0.9.13 to 0.9.14. |
| uv.lock | Lock file updated to reflect 0.9.14 versions for both aegra-api and aegra-cli. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PyPI as PyPI Registry
    participant Users as Downstream Users

    Dev->>Dev: Bump aegra-api + aegra-cli to 0.9.14
    Dev->>Dev: Sync uv.lock
    Dev->>Dev: Update docs/openapi.json version
    Dev->>PyPI: "Publish aegra-api==0.9.14"
    Dev->>PyPI: "Publish aegra-cli==0.9.14"
    PyPI-->>Users: aegra-api 0.9.14 available (RunCreate.metadata → OTEL)
    PyPI-->>Users: aegra-cli 0.9.14 available
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump version to 0.9.14"](https://github.com/aegra/aegra/commit/5a6d28f1c895e04586f83f0bbb3a57071a0eb557) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31488161)</sub>

<!-- /greptile_comment -->