### PR TITLE
feat(observability): seed OTEL trace_id from run_id for deterministic trace linking

### DIFF
--- a/libs/aegra-api/src/aegra_api/api/store.py
+++ b/libs/aegra-api/src/aegra_api/api/store.py
@@ -82,7 +82,7 @@ async def get_store_item(
     if isinstance(namespace, str):
         ns_list = [part for part in namespace.split(".") if part]
     elif isinstance(namespace, list):
-        ns_list = namespace
+        ns_list = [part for part in namespace if part]
     else:
         ns_list = []
 

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -21,9 +21,14 @@ Usage::
 """
 
 import contextvars
+import random
+import uuid as _uuid
 
+from opentelemetry import context as otel_context
+from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 
 # Per-request context variable holding span attributes to inject.
 # None means no trace context is set; on_start() is a no-op in that case.
@@ -118,6 +123,23 @@ def set_trace_context(
     _trace_attrs.set(attrs or None)
 
 
+def seed_otel_trace_id(run_id: str) -> None:
+    """Set a remote-parent span context whose trace_id is derived from *run_id*.
+
+    The ``run_id`` UUID (128-bit) is reused verbatim as the OTEL trace_id so
+    that downstream instrumentors (LangChainInstrumentor) inherit it.  No real
+    span is created or exported — ``NonRecordingSpan`` is the standard OTEL
+    mechanism for W3C ``traceparent`` propagation.
+    """
+    span_ctx = SpanContext(
+        trace_id=_uuid.UUID(run_id).int,
+        span_id=random.getrandbits(64),
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    otel_context.attach(trace.set_span_in_context(NonRecordingSpan(span_ctx)))
+
+
 def make_run_trace_context(
     run_id: str,
     thread_id: str,
@@ -131,6 +153,7 @@ def make_run_trace_context(
     context=ctx)`` so the background task starts with the correct trace data.
     """
     ctx = contextvars.copy_context()
+    ctx.run(seed_otel_trace_id, run_id)
     ctx.run(
         set_trace_context,
         user_id=user_identity,

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -55,12 +55,16 @@ class SpanEnrichmentProcessor(SpanProcessor):
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         if span.parent is not None and span.parent.is_valid and not span.parent.is_remote:
-            # Skip local child spans only — spans whose parent arrived via
-            # a remote traceparent header are still local roots and must be enriched.
             return
         attrs = _trace_attrs.get()
         if not attrs:
             return
+        # Strip the injected remote parent (from seed_otel_trace_id) so the
+        # span exports as a true root.  The trace_id is already correct
+        # (inherited during construction).  Without this, Langfuse cannot
+        # identify a root span and trace-level input/output stay undefined.
+        if span.parent is not None and span.parent.is_remote:
+            span._parent = None  # noqa: SLF001
         for key, value in attrs.items():
             span.set_attribute(key, value)
 

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -680,14 +680,10 @@ def inject_user_context(user: Any | None, base_config: dict[str, Any] | None = N
         config["configurable"].setdefault("user_id", user.identity)
         config["configurable"].setdefault("user_display_name", getattr(user, "display_name", None) or user.identity)
 
-        # Full auth payload for graph nodes - includes ALL fields from auth handler
+        # Pass user object directly so langgraph's _build_server_info() can
+        # detect it via hasattr(obj, "identity") and populate Runtime.server_info.
         if "langgraph_auth_user" not in config["configurable"]:
-            try:
-                # user.to_dict() returns all fields including extras from auth handlers
-                config["configurable"]["langgraph_auth_user"] = user.to_dict()
-            except Exception:
-                # Fallback: minimal dict if to_dict unavailable or fails
-                config["configurable"]["langgraph_auth_user"] = {"identity": user.identity}
+            config["configurable"]["langgraph_auth_user"] = user
 
     return config
 

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -26,7 +26,7 @@ from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import _get_session_maker
 from aegra_api.core.redis_manager import redis_manager
 from aegra_api.models.run_job import RunJob
-from aegra_api.observability.span_enrichment import set_trace_context
+from aegra_api.observability.span_enrichment import seed_otel_trace_id, set_trace_context
 from aegra_api.services.base_executor import BaseExecutor
 from aegra_api.services.run_executor import _lease_loss_cancellations, execute_run
 from aegra_api.services.run_status import finalize_run, update_run_status
@@ -474,6 +474,7 @@ def _restore_trace_context(run_id: str, job: RunJob, trace: dict[str, str]) -> N
     if original_request_id:
         correlation_id.set(original_request_id)
 
+    seed_otel_trace_id(run_id)
     set_trace_context(
         user_id=job.user.identity,
         session_id=job.identity.thread_id,

--- a/libs/aegra-api/tests/integration/test_api/test_store_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_store_crud.py
@@ -211,6 +211,22 @@ class TestGetStoreItem:
         data = resp.json()
         assert data["key"] == "test-key"
 
+    def test_get_item_with_empty_namespace_query_param(self, client, mock_store):
+        """Test empty namespace query param is treated as no namespace"""
+        mock_item = DummyStoreItem(
+            key="test-key",
+            value={"data": "test"},
+            namespace=("users", "test-user"),
+        )
+        mock_store.aget.return_value = mock_item
+
+        resp = client.get("/store/items?namespace=&key=test-key")
+
+        assert resp.status_code == 200
+        call_args = mock_store.aget.call_args
+        namespace = call_args[0][0]
+        assert namespace == ("users", "test-user")
+
 
 class TestDeleteStoreItem:
     """Test DELETE /store/items"""

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -204,29 +204,43 @@ class TestMakeRunTraceContext:
         """Reset context var before each test."""
         _trace_attrs.set(None)
 
+    _RUN_ID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+
     def test_returned_context_contains_expected_attributes(self) -> None:
         """Returned context has all trace attributes pre-set."""
-        ctx = make_run_trace_context("run-1", "thread-1", "my_graph", "user-1")
+        ctx = make_run_trace_context(self._RUN_ID, "thread-1", "my_graph", "user-1")
 
         attrs = ctx.run(_trace_attrs.get)
         assert attrs["langfuse.user.id"] == "user-1"
         assert attrs["langfuse.session.id"] == "thread-1"
         assert attrs["langfuse.trace.name"] == "my_graph"
-        assert attrs["langfuse.trace.metadata.run_id"] == "run-1"
+        assert attrs["langfuse.trace.metadata.run_id"] == self._RUN_ID
         assert attrs["langfuse.trace.metadata.thread_id"] == "thread-1"
         assert attrs["langfuse.trace.metadata.graph_id"] == "my_graph"
 
     def test_does_not_pollute_caller_context(self) -> None:
         """Calling make_run_trace_context() does not mutate the caller's context."""
-        make_run_trace_context("run-1", "thread-1", "my_graph", "user-1")
+        make_run_trace_context(self._RUN_ID, "thread-1", "my_graph", "user-1")
 
         assert _trace_attrs.get() is None
 
     def test_anonymous_user_omits_user_attributes(self) -> None:
         """Passing user_identity=None omits user.id keys from the context."""
-        ctx = make_run_trace_context("run-1", "thread-1", "my_graph", None)
+        ctx = make_run_trace_context(self._RUN_ID, "thread-1", "my_graph", None)
 
         attrs = ctx.run(_trace_attrs.get)
         assert "langfuse.user.id" not in attrs
         assert "user.id" not in attrs
         assert attrs["langfuse.trace.name"] == "my_graph"
+
+    def test_seeds_otel_trace_id_from_run_id(self) -> None:
+        """The returned context has an OTEL trace_id derived from run_id."""
+        import uuid
+
+        from opentelemetry import trace
+
+        ctx = make_run_trace_context(self._RUN_ID, "thread-1", "my_graph", "user-1")
+
+        span = ctx.run(trace.get_current_span)
+        trace_id = span.get_span_context().trace_id
+        assert trace_id == uuid.UUID(self._RUN_ID).int

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -545,10 +545,7 @@ class TestLangGraphServiceContext:
         assert result["existing"] == "value"
         assert result["configurable"]["user_id"] == "user-123"
         assert result["configurable"]["user_display_name"] == "Test User"
-        assert result["configurable"]["langgraph_auth_user"] == {
-            "identity": "user-123",
-            "name": "Test User",
-        }
+        assert result["configurable"]["langgraph_auth_user"] is mock_user
 
     def test_inject_user_context_without_user(self):
         """Test injecting context without user object"""
@@ -572,18 +569,17 @@ class TestLangGraphServiceContext:
         assert result["configurable"]["user_id"] == "user-123"
         assert result["configurable"]["user_display_name"] == "Test User"
 
-    def test_inject_user_context_user_to_dict_failure(self):
-        """Test fallback when user.to_dict() fails"""
+    def test_inject_user_context_user_object_passed_directly(self):
+        """Test that the user object is passed directly (not serialized)."""
         mock_user = Mock()
         mock_user.identity = "user-123"
         mock_user.display_name = "Test User"
-        mock_user.to_dict.side_effect = Exception("to_dict failed")
 
         result = inject_user_context(mock_user, {})
 
         assert result["configurable"]["user_id"] == "user-123"
         assert result["configurable"]["user_display_name"] == "Test User"
-        assert result["configurable"]["langgraph_auth_user"] == {"identity": "user-123"}
+        assert result["configurable"]["langgraph_auth_user"] is mock_user
 
     def test_inject_user_context_existing_configurable(self):
         """Test preserving existing configurable values"""


### PR DESCRIPTION
## Summary

- Seed the OpenTelemetry `trace_id` from the run's UUID instead of generating a random one. This makes Langfuse traces deterministically linkable to LangGraph runs by ID, simplifying feedback endpoints and trace correlation.

## Test plan

- [x] Unit tests for `trace_id` seeding logic added
- [x] Existing unit/integration tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved namespace parameter handling to properly filter empty segments in store queries.
  * Enhanced OpenTelemetry trace identity initialization during context restoration.

* **New Features**
  * Added trace ID seeding capability to enable proper trace inheritance across downstream services.

* **Tests**
  * Added integration test for empty namespace query parameters.
  * Updated unit tests for trace context and user context handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/371)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR seeds the OpenTelemetry `trace_id` from the LangGraph `run_id` UUID so that Langfuse traces are deterministically linkable to runs without extra lookup. It also fixes empty-string filtering for list-typed store namespace parameters and switches `langgraph_auth_user` from a serialised dict to a live object reference.

- **`seed_otel_trace_id()`** (`span_enrichment.py`): creates a `NonRecordingSpan` carrying the `run_id` as trace_id and attaches it as a remote parent; `SpanEnrichmentProcessor.on_start()` strips that remote parent so the first real span exports as a true root with the correct trace_id.
- **`_restore_trace_context()`** (`worker_executor.py`): calls `seed_otel_trace_id()` directly in the worker's live context so re-queued runs inherit the same trace_id on recovery.
- **`store.py` / `langgraph_service.py`**: small bug-fixes and a behaviour change to pass the user object directly into LangGraph configurable.

<h3>Confidence Score: 3/5</h3>

The core seeding logic works for the described use case, but on_start() strips all remote parents indiscriminately, which would silently break distributed trace links if any upstream service injects a W3C traceparent header.

The on_start() modification strips the parent from every span with a remote parent, not only those whose remote parent came from seed_otel_trace_id(). Any real upstream traceparent would be erased, severing the distributed trace without error. The worker_executor path also discards the OTEL detach token, leaving the live thread context in a state that cannot be restored.

libs/aegra-api/src/aegra_api/observability/span_enrichment.py (remote-parent stripping logic in on_start() and missing detach token in seed_otel_trace_id()); libs/aegra-api/src/aegra_api/services/worker_executor.py (direct seed_otel_trace_id() call in _restore_trace_context()).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/observability/span_enrichment.py | Adds seed_otel_trace_id() to deterministically bind trace_id to run_id; modifies on_start() to strip all remote parents (not just the seeded one), which risks severing legitimate distributed traces; uses private SDK attribute _parent = None that could break on SDK upgrades. |
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Calls seed_otel_trace_id() directly in _restore_trace_context() against the live worker context without capturing the detach token; functionally correct for sequential jobs but misses the OTEL cleanup contract. |
| libs/aegra-api/src/aegra_api/services/langgraph_service.py | Passes the raw user object into configurable["langgraph_auth_user"] instead of serialising via to_dict(); intentional change to let LangGraph's _build_server_info() detect identity via hasattr checks. |
| libs/aegra-api/src/aegra_api/api/store.py | Filters empty strings from list-typed namespace parameters, matching existing behaviour for string namespaces; correct and safe change. |
| libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py | Adds a unit test verifying OTEL trace_id is seeded from run_id UUID; updates existing tests to use a valid UUID run_id. |
| libs/aegra-api/tests/unit/test_services/test_langgraph_service.py | Updates tests to assert user object is passed by reference; removes the to_dict() failure-fallback test that no longer applies. |
| libs/aegra-api/tests/integration/test_api/test_store_crud.py | Adds regression test for empty string namespace query parameter; covers the string case but not the list-with-empty-elements case that was patched in store.py. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller / API
    participant MR as make_run_trace_context()
    participant SI as seed_otel_trace_id()
    participant OC as OTEL Context (copy)
    participant T as asyncio Task
    participant SEP as SpanEnrichmentProcessor
    participant LF as Langfuse

    C->>MR: run_id, thread_id, graph_id, user_id
    MR->>OC: copy_context()
    MR->>SI: ctx.run(seed_otel_trace_id, run_id)
    SI->>OC: "attach(NonRecordingSpan(trace_id=UUID(run_id).int, is_remote=True))"
    MR->>OC: ctx.run(set_trace_context, attrs)
    MR-->>C: ctx (copy with seeded trace_id)
    C->>T: "asyncio.create_task(context=ctx)"
    T->>SEP: on_start(first_span, remote_parent)
    SEP->>SEP: "span._parent = None"
    SEP->>SEP: "set_attribute(langfuse.* attrs)"
    T->>LF: "export root span (trace_id == run_id, no parent)"
    LF-->>T: trace linked by run_id
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A66-67%0A**Remote-parent%20stripping%20too%20broad%20%E2%80%94%20breaks%20legitimate%20distributed%20tracing**%0A%0A%60on_start%28%29%60%20now%20strips%20the%20parent%20from%20ANY%20span%20whose%20%60parent.is_remote%60%20is%20%60True%60%2C%20including%20parents%20that%20arrived%20via%20a%20genuine%20upstream%20W3C%20%60traceparent%60%20header%20%28e.g.%2C%20from%20an%20API%20gateway%20or%20a%20calling%20service%29.%20The%20seeded%20%60NonRecordingSpan%60%20and%20a%20real%20upstream%20parent%20are%20indistinguishable%20here%3A%20both%20appear%20as%20remote%20parents%20on%20the%20first%20LangChainInstrumentor%20span.%20Any%20deployment%20that%20propagates%20%60traceparent%60%20into%20these%20runs%20would%20silently%20sever%20the%20distributed%20trace%20link%20on%20every%20request.%0A%0A%23%23%23%20Issue%202%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A130-144%0A**%60otel_context.attach%28%29%60%20token%20is%20discarded%20%E2%80%94%20detach%20is%20never%20possible**%0A%0A%60otel_context.attach%28%29%60%20returns%20a%20%60Token%60%20that%20must%20be%20passed%20to%20%60otel_context.detach%28token%29%60%20to%20restore%20the%20previous%20context.%20Discarding%20the%20return%20value%20here%20means%20the%20call%20path%20in%20%60_restore_trace_context%60%20%28%60worker_executor.py%60%29%20permanently%20modifies%20the%20worker%20thread's%20live%20OTEL%20context%20without%20any%20way%20to%20undo%20it.%20If%20the%20worker%20ever%20needs%20to%20run%20a%20span%20outside%20of%20a%20job%20context%20%28e.g.%2C%20health%20checks%2C%20metrics%20emission%29%2C%20it%20will%20inherit%20a%20stale%20%60trace_id%60%20from%20the%20last%20processed%20job.%20The%20%60make_run_trace_context%60%20path%20is%20safe%20because%20%60ctx.run%28%29%60%20isolates%20modifications%20to%20the%20copy%2C%20but%20the%20%60_restore_trace_context%60%20call%20site%20is%20not%20isolated.%0A%0A%23%23%23%20Issue%203%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A66-67%0APrivate%20attribute%20mutation%20on%20the%20OTEL%20%60Span%60%20object%20bypasses%20the%20public%20API.%20%60span._parent%60%20is%20not%20part%20of%20the%20documented%2Fstable%20SDK%20surface%20and%20could%20be%20renamed%20or%20removed%20in%20a%20future%20release.%20Consider%20returning%20the%20token%20from%20%60otel_context.attach%28%29%60%20to%20callers%20so%20%60detach%28%29%60%20can%20be%20called%20after%20spans%20are%20finished%2C%20or%20explore%20the%20public%20%60use_span%60%2F%60Context%60%20propagation%20path%20to%20achieve%20the%20same%20parentless%20root%20without%20touching%20SDK%20internals.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20span.parent%20is%20not%20None%20and%20span.parent.is_remote%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20span._parent%20%3D%20None%20%20%23%20noqa%3A%20SLF001%20%20%23%20TODO%3A%20replace%20with%20public%20API%20when%20available%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=371&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A66-67%0A**Remote-parent%20stripping%20too%20broad%20%E2%80%94%20breaks%20legitimate%20distributed%20tracing**%0A%0A%60on_start%28%29%60%20now%20strips%20the%20parent%20from%20ANY%20span%20whose%20%60parent.is_remote%60%20is%20%60True%60%2C%20including%20parents%20that%20arrived%20via%20a%20genuine%20upstream%20W3C%20%60traceparent%60%20header%20%28e.g.%2C%20from%20an%20API%20gateway%20or%20a%20calling%20service%29.%20The%20seeded%20%60NonRecordingSpan%60%20and%20a%20real%20upstream%20parent%20are%20indistinguishable%20here%3A%20both%20appear%20as%20remote%20parents%20on%20the%20first%20LangChainInstrumentor%20span.%20Any%20deployment%20that%20propagates%20%60traceparent%60%20into%20these%20runs%20would%20silently%20sever%20the%20distributed%20trace%20link%20on%20every%20request.%0A%0A%23%23%23%20Issue%202%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A130-144%0A**%60otel_context.attach%28%29%60%20token%20is%20discarded%20%E2%80%94%20detach%20is%20never%20possible**%0A%0A%60otel_context.attach%28%29%60%20returns%20a%20%60Token%60%20that%20must%20be%20passed%20to%20%60otel_context.detach%28token%29%60%20to%20restore%20the%20previous%20context.%20Discarding%20the%20return%20value%20here%20means%20the%20call%20path%20in%20%60_restore_trace_context%60%20%28%60worker_executor.py%60%29%20permanently%20modifies%20the%20worker%20thread's%20live%20OTEL%20context%20without%20any%20way%20to%20undo%20it.%20If%20the%20worker%20ever%20needs%20to%20run%20a%20span%20outside%20of%20a%20job%20context%20%28e.g.%2C%20health%20checks%2C%20metrics%20emission%29%2C%20it%20will%20inherit%20a%20stale%20%60trace_id%60%20from%20the%20last%20processed%20job.%20The%20%60make_run_trace_context%60%20path%20is%20safe%20because%20%60ctx.run%28%29%60%20isolates%20modifications%20to%20the%20copy%2C%20but%20the%20%60_restore_trace_context%60%20call%20site%20is%20not%20isolated.%0A%0A%23%23%23%20Issue%203%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A66-67%0APrivate%20attribute%20mutation%20on%20the%20OTEL%20%60Span%60%20object%20bypasses%20the%20public%20API.%20%60span._parent%60%20is%20not%20part%20of%20the%20documented%2Fstable%20SDK%20surface%20and%20could%20be%20renamed%20or%20removed%20in%20a%20future%20release.%20Consider%20returning%20the%20token%20from%20%60otel_context.attach%28%29%60%20to%20callers%20so%20%60detach%28%29%60%20can%20be%20called%20after%20spans%20are%20finished%2C%20or%20explore%20the%20public%20%60use_span%60%2F%60Context%60%20propagation%20path%20to%20achieve%20the%20same%20parentless%20root%20without%20touching%20SDK%20internals.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20span.parent%20is%20not%20None%20and%20span.parent.is_remote%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20span._parent%20%3D%20None%20%20%23%20noqa%3A%20SLF001%20%20%23%20TODO%3A%20replace%20with%20public%20API%20when%20available%0A%60%60%60%0A%0A&pr=371&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fseed-otel-trace-id-from-run-id%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fseed-otel-trace-id-from-run-id%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A66-67%0A**Remote-parent%20stripping%20too%20broad%20%E2%80%94%20breaks%20legitimate%20distributed%20tracing**%0A%0A%60on_start%28%29%60%20now%20strips%20the%20parent%20from%20ANY%20span%20whose%20%60parent.is_remote%60%20is%20%60True%60%2C%20including%20parents%20that%20arrived%20via%20a%20genuine%20upstream%20W3C%20%60traceparent%60%20header%20%28e.g.%2C%20from%20an%20API%20gateway%20or%20a%20calling%20service%29.%20The%20seeded%20%60NonRecordingSpan%60%20and%20a%20real%20upstream%20parent%20are%20indistinguishable%20here%3A%20both%20appear%20as%20remote%20parents%20on%20the%20first%20LangChainInstrumentor%20span.%20Any%20deployment%20that%20propagates%20%60traceparent%60%20into%20these%20runs%20would%20silently%20sever%20the%20distributed%20trace%20link%20on%20every%20request.%0A%0A%23%23%23%20Issue%202%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A130-144%0A**%60otel_context.attach%28%29%60%20token%20is%20discarded%20%E2%80%94%20detach%20is%20never%20possible**%0A%0A%60otel_context.attach%28%29%60%20returns%20a%20%60Token%60%20that%20must%20be%20passed%20to%20%60otel_context.detach%28token%29%60%20to%20restore%20the%20previous%20context.%20Discarding%20the%20return%20value%20here%20means%20the%20call%20path%20in%20%60_restore_trace_context%60%20%28%60worker_executor.py%60%29%20permanently%20modifies%20the%20worker%20thread's%20live%20OTEL%20context%20without%20any%20way%20to%20undo%20it.%20If%20the%20worker%20ever%20needs%20to%20run%20a%20span%20outside%20of%20a%20job%20context%20%28e.g.%2C%20health%20checks%2C%20metrics%20emission%29%2C%20it%20will%20inherit%20a%20stale%20%60trace_id%60%20from%20the%20last%20processed%20job.%20The%20%60make_run_trace_context%60%20path%20is%20safe%20because%20%60ctx.run%28%29%60%20isolates%20modifications%20to%20the%20copy%2C%20but%20the%20%60_restore_trace_context%60%20call%20site%20is%20not%20isolated.%0A%0A%23%23%23%20Issue%203%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A66-67%0APrivate%20attribute%20mutation%20on%20the%20OTEL%20%60Span%60%20object%20bypasses%20the%20public%20API.%20%60span._parent%60%20is%20not%20part%20of%20the%20documented%2Fstable%20SDK%20surface%20and%20could%20be%20renamed%20or%20removed%20in%20a%20future%20release.%20Consider%20returning%20the%20token%20from%20%60otel_context.attach%28%29%60%20to%20callers%20so%20%60detach%28%29%60%20can%20be%20called%20after%20spans%20are%20finished%2C%20or%20explore%20the%20public%20%60use_span%60%2F%60Context%60%20propagation%20path%20to%20achieve%20the%20same%20parentless%20root%20without%20touching%20SDK%20internals.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20span.parent%20is%20not%20None%20and%20span.parent.is_remote%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20span._parent%20%3D%20None%20%20%23%20noqa%3A%20SLF001%20%20%23%20TODO%3A%20replace%20with%20public%20API%20when%20available%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat: seed OTEL trace\_id from run\_id for..."](https://github.com/aegra/aegra/commit/975e88cd1350cb21d95bdc35a19b84e9fcefca6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31562308)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->