### PR TITLE
feat(observability): seed OTEL trace_id from run_id for deterministic trace linking

### DIFF
--- a/docs/guides/observability.mdx
+++ b/docs/guides/observability.mdx
@@ -139,6 +139,27 @@ Aegra injects a small number of runtime keys into the same metadata stream so th
 
 If the request `metadata` contains a key already populated by the runtime, the system value wins, the user value is dropped, and a warning is logged from `aegra_api.observability.span_enrichment`. This makes the OTEL view a reliable join key with logs and the runs table; user audit fidelity is preserved by keeping the original payload in `execution_params.run_metadata`.
 
+## Trace identification
+
+Each run's OTEL `trace_id` is derived deterministically from its `run_id` — the UUID integer maps directly to the 128-bit trace identifier. This means you can look up a trace in Langfuse (or any OTLP backend) knowing only the run ID:
+
+```python
+# Submit feedback to Langfuse using just the run_id
+langfuse.score(
+    trace_id=run_id.replace("-", ""),
+    name="thumbs_up",
+    value=1.0,
+)
+```
+
+No extra API call to Aegra is needed to discover the trace.
+
+### Upstream W3C `traceparent`
+
+Each run starts its own trace — Aegra does **not** continue an incoming W3C `traceparent` from an API gateway or proxy. The deterministic `trace_id` always takes precedence.
+
+If you need to correlate Aegra traces with an upstream distributed trace (e.g. from Envoy, Istio, or AWS ALB), use the `original_request_id` key in [run metadata](#system-key-collisions) instead of relying on OTEL `trace_id` stitching.
+
 ## Key environment variables
 
 The main variables you'll need:

--- a/libs/aegra-api/src/aegra_api/observability/otel.py
+++ b/libs/aegra-api/src/aegra_api/observability/otel.py
@@ -13,7 +13,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 
 from aegra_api.observability.base import ObservabilityProvider
-from aegra_api.observability.span_enrichment import SpanEnrichmentProcessor
+from aegra_api.observability.span_enrichment import RunIdAwareIdGenerator, SpanEnrichmentProcessor
 from aegra_api.observability.targets import (
     BaseOtelTarget,
     GenericOtelTarget,
@@ -97,7 +97,7 @@ class OpenTelemetryProvider(ObservabilityProvider):
             }
         )
 
-        self._tracer_provider = TracerProvider(resource=resource)
+        self._tracer_provider = TracerProvider(resource=resource, id_generator=RunIdAwareIdGenerator())
         self._tracer_provider.add_span_processor(SpanEnrichmentProcessor())
         processors_count = 0
 

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -22,7 +22,7 @@ Usage::
 
 import contextvars
 import logging
-import random
+import secrets
 import uuid as _uuid
 from typing import Any
 
@@ -190,7 +190,7 @@ def seed_otel_trace_id(run_id: str) -> None:
     """
     span_ctx = SpanContext(
         trace_id=_uuid.UUID(run_id).int,
-        span_id=random.getrandbits(64),
+        span_id=secrets.randbits(64),
         is_remote=True,
         trace_flags=TraceFlags(TraceFlags.SAMPLED),
     )

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -187,6 +187,10 @@ def seed_otel_trace_id(run_id: str) -> None:
     that downstream instrumentors (LangChainInstrumentor) inherit it.  No real
     span is created or exported — ``NonRecordingSpan`` is the standard OTEL
     mechanism for W3C ``traceparent`` propagation.
+
+    The ``attach()`` token is intentionally not detached: this function must
+    only be called from a short-lived, task-scoped context (``ctx.run(...)``
+    or a per-job asyncio task) where the context is discarded on completion.
     """
     span_ctx = SpanContext(
         trace_id=_uuid.UUID(run_id).int,

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -22,10 +22,15 @@ Usage::
 
 import contextvars
 import logging
+import random
+import uuid as _uuid
 from typing import Any
 
+from opentelemetry import context as otel_context
+from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 
 logger = logging.getLogger(__name__)
 
@@ -60,12 +65,16 @@ class SpanEnrichmentProcessor(SpanProcessor):
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         if span.parent is not None and span.parent.is_valid and not span.parent.is_remote:
-            # Skip local child spans only — spans whose parent arrived via
-            # a remote traceparent header are still local roots and must be enriched.
             return
         attrs = _trace_attrs.get()
         if not attrs:
             return
+        # Strip the injected remote parent (from seed_otel_trace_id) so the
+        # span exports as a true root.  The trace_id is already correct
+        # (inherited during construction).  Without this, Langfuse cannot
+        # identify a root span and trace-level input/output stay undefined.
+        if span.parent is not None and span.parent.is_remote:
+            span._parent = None  # noqa: SLF001
         for key, value in attrs.items():
             span.set_attribute(key, value)
 
@@ -171,6 +180,23 @@ def merge_run_metadata(
     return merged
 
 
+def seed_otel_trace_id(run_id: str) -> None:
+    """Set a remote-parent span context whose trace_id is derived from *run_id*.
+
+    The ``run_id`` UUID (128-bit) is reused verbatim as the OTEL trace_id so
+    that downstream instrumentors (LangChainInstrumentor) inherit it.  No real
+    span is created or exported — ``NonRecordingSpan`` is the standard OTEL
+    mechanism for W3C ``traceparent`` propagation.
+    """
+    span_ctx = SpanContext(
+        trace_id=_uuid.UUID(run_id).int,
+        span_id=random.getrandbits(64),
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    otel_context.attach(trace.set_span_in_context(NonRecordingSpan(span_ctx)))
+
+
 def make_run_trace_context(
     run_id: str,
     thread_id: str,
@@ -196,6 +222,7 @@ def make_run_trace_context(
     }
     metadata = merge_run_metadata(extra_metadata, system_metadata)
     ctx = contextvars.copy_context()
+    ctx.run(seed_otel_trace_id, run_id)
     ctx.run(
         set_trace_context,
         user_id=user_identity,

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -26,6 +26,7 @@ import random
 import uuid as _uuid
 from typing import Any
 
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
@@ -245,6 +246,7 @@ def make_run_trace_context(
     }
     metadata = merge_run_metadata(extra_metadata, system_metadata)
     ctx = contextvars.copy_context()
+    ctx.run(otel_context.attach, trace.set_span_in_context(trace.INVALID_SPAN))
     ctx.run(seed_otel_trace_id, run_id)
     ctx.run(
         set_trace_context,

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -22,15 +22,14 @@ Usage::
 
 import contextvars
 import logging
-import secrets
+import random
 import uuid as _uuid
 from typing import Any
 
-from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
-from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+from opentelemetry.sdk.trace.id_generator import IdGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +45,10 @@ _trace_attrs: contextvars.ContextVar[dict[str, str | int | float | bool] | None]
     "aegra_otel_trace_attrs", default=None
 )
 
+# Per-request context variable: when set, the IdGenerator uses this
+# UUID's int as the trace_id instead of generating a random one.
+_run_trace_id: contextvars.ContextVar[int | None] = contextvars.ContextVar("aegra_run_trace_id", default=None)
+
 
 class SpanEnrichmentProcessor(SpanProcessor):
     """Injects per-request trace attributes onto the root span of each trace.
@@ -54,8 +57,9 @@ class SpanEnrichmentProcessor(SpanProcessor):
     each key/value pair as a span attribute on the **root span** only.
     A span is considered a root if it has no parent OR if its parent is a
     remote span (i.e. arrived via W3C ``traceparent`` from an upstream
-    service).  Langfuse reads trace-level properties (userId, sessionId,
-    name) exclusively from the root span, so enriching local child spans
+    service).  Remote-parent spans are the local root of a distributed
+    trace and must carry Langfuse metadata so trace-level properties
+    (userId, sessionId, name) are surfaced.  Enriching local child spans
     is unnecessary and produces noise in per-observation metadata.
 
     Call :func:`set_trace_context` inside the asyncio Task that runs
@@ -69,12 +73,6 @@ class SpanEnrichmentProcessor(SpanProcessor):
         attrs = _trace_attrs.get()
         if not attrs:
             return
-        # Strip the injected remote parent (from seed_otel_trace_id) so the
-        # span exports as a true root.  The trace_id is already correct
-        # (inherited during construction).  Without this, Langfuse cannot
-        # identify a root span and trace-level input/output stay undefined.
-        if span.parent is not None and span.parent.is_remote:
-            span._parent = None  # noqa: SLF001
         for key, value in attrs.items():
             span.set_attribute(key, value)
 
@@ -181,24 +179,45 @@ def merge_run_metadata(
 
 
 def seed_otel_trace_id(run_id: str) -> None:
-    """Set a remote-parent span context whose trace_id is derived from *run_id*.
+    """Request that the next root span uses ``run_id`` as its OTEL trace_id.
 
-    The ``run_id`` UUID (128-bit) is reused verbatim as the OTEL trace_id so
-    that downstream instrumentors (LangChainInstrumentor) inherit it.  No real
-    span is created or exported — ``NonRecordingSpan`` is the standard OTEL
-    mechanism for W3C ``traceparent`` propagation.
+    Sets the ``_run_trace_id`` context variable so that
+    :class:`RunIdAwareIdGenerator` returns ``UUID(run_id).int`` from
+    ``generate_trace_id()`` instead of a random value.  The root span is
+    then constructed with ``parent=None`` naturally — no ``NonRecordingSpan``
+    or private-attribute mutation needed.
 
-    The ``attach()`` token is intentionally not detached: this function must
-    only be called from a short-lived, task-scoped context (``ctx.run(...)``
-    or a per-job asyncio task) where the context is discarded on completion.
+    Must be called inside a task-scoped context (``ctx.run(...)`` or a
+    per-job asyncio task) before any spans are created.
     """
-    span_ctx = SpanContext(
-        trace_id=_uuid.UUID(run_id).int,
-        span_id=secrets.randbits(64),
-        is_remote=True,
-        trace_flags=TraceFlags(TraceFlags.SAMPLED),
-    )
-    otel_context.attach(trace.set_span_in_context(NonRecordingSpan(span_ctx)))
+    _run_trace_id.set(_uuid.UUID(run_id).int)
+
+
+class RunIdAwareIdGenerator(IdGenerator):
+    """IdGenerator that derives trace_id from run_id when available.
+
+    When ``_run_trace_id`` is set (via :func:`seed_otel_trace_id`), returns
+    that value as the trace_id — giving deterministic Langfuse trace linking.
+    Falls back to random generation otherwise (e.g. for spans created outside
+    a run context, or when upstream W3C traceparent propagation provides the
+    trace_id via normal OTEL machinery).
+    """
+
+    def generate_trace_id(self) -> int:
+        seeded = _run_trace_id.get()
+        if seeded is not None:
+            _run_trace_id.set(None)
+            return seeded
+        trace_id = random.getrandbits(128)
+        while trace_id == trace.INVALID_TRACE_ID:
+            trace_id = random.getrandbits(128)
+        return trace_id
+
+    def generate_span_id(self) -> int:
+        span_id = random.getrandbits(64)
+        while span_id == trace.INVALID_SPAN_ID:
+            span_id = random.getrandbits(64)
+        return span_id
 
 
 def make_run_trace_context(

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -26,7 +26,7 @@ from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import _get_session_maker
 from aegra_api.core.redis_manager import redis_manager
 from aegra_api.models.run_job import RunJob
-from aegra_api.observability.span_enrichment import merge_run_metadata, set_trace_context
+from aegra_api.observability.span_enrichment import merge_run_metadata, seed_otel_trace_id, set_trace_context
 from aegra_api.services.base_executor import BaseExecutor
 from aegra_api.services.run_executor import _lease_loss_cancellations, execute_run
 from aegra_api.services.run_status import finalize_run, update_run_status
@@ -476,6 +476,7 @@ def _restore_trace_context(run_id: str, job: RunJob, trace: dict[str, str]) -> N
     if original_request_id:
         correlation_id.set(original_request_id)
 
+    seed_otel_trace_id(run_id)
     system_metadata: dict[str, str | int | float | bool] = {
         "run_id": run_id,
         "thread_id": job.identity.thread_id,

--- a/libs/aegra-api/tests/unit/test_observability/test_otel.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_otel.py
@@ -1,10 +1,11 @@
 """Unit tests for the OpenTelemetry provider."""
 
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from aegra_api.observability.otel import OpenTelemetryProvider
+from aegra_api.observability.span_enrichment import RunIdAwareIdGenerator
 from aegra_api.observability.targets import (
     BaseOtelTarget,
     GenericOtelTarget,
@@ -179,7 +180,9 @@ class TestOpenTelemetryProviderSetup:
                 "deployment.environment": "test",
             }
         )
-        mock_deps["tp"].assert_called_with(resource=mock_deps["resource"].create.return_value, id_generator=ANY)
+        id_generator = mock_deps["tp"].call_args.kwargs["id_generator"]
+        assert isinstance(id_generator, RunIdAwareIdGenerator)
+        assert mock_deps["tp"].call_args.kwargs["resource"] == mock_deps["resource"].create.return_value
 
     def test_setup_attaches_configured_targets(self, mock_deps):
         """Test that exporters from targets are attached to the tracer."""

--- a/libs/aegra-api/tests/unit/test_observability/test_otel.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_otel.py
@@ -1,6 +1,6 @@
 """Unit tests for the OpenTelemetry provider."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -179,7 +179,7 @@ class TestOpenTelemetryProviderSetup:
                 "deployment.environment": "test",
             }
         )
-        mock_deps["tp"].assert_called_with(resource=mock_deps["resource"].create.return_value)
+        mock_deps["tp"].assert_called_with(resource=mock_deps["resource"].create.return_value, id_generator=ANY)
 
     def test_setup_attaches_configured_targets(self, mock_deps):
         """Test that exporters from targets are attached to the tracer."""

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -211,37 +211,51 @@ class TestMakeRunTraceContext:
         """Reset context var before each test."""
         _trace_attrs.set(None)
 
+    _RUN_ID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+
     def test_returned_context_contains_expected_attributes(self) -> None:
         """Returned context has all trace attributes pre-set."""
-        ctx = make_run_trace_context("run-1", "thread-1", "my_graph", "user-1")
+        ctx = make_run_trace_context(self._RUN_ID, "thread-1", "my_graph", "user-1")
 
         attrs = ctx.run(_trace_attrs.get)
         assert attrs["langfuse.user.id"] == "user-1"
         assert attrs["langfuse.session.id"] == "thread-1"
         assert attrs["langfuse.trace.name"] == "my_graph"
-        assert attrs["langfuse.trace.metadata.run_id"] == "run-1"
+        assert attrs["langfuse.trace.metadata.run_id"] == self._RUN_ID
         assert attrs["langfuse.trace.metadata.thread_id"] == "thread-1"
         assert attrs["langfuse.trace.metadata.graph_id"] == "my_graph"
 
     def test_does_not_pollute_caller_context(self) -> None:
         """Calling make_run_trace_context() does not mutate the caller's context."""
-        make_run_trace_context("run-1", "thread-1", "my_graph", "user-1")
+        make_run_trace_context(self._RUN_ID, "thread-1", "my_graph", "user-1")
 
         assert _trace_attrs.get() is None
 
     def test_anonymous_user_omits_user_attributes(self) -> None:
         """Passing user_identity=None omits user.id keys from the context."""
-        ctx = make_run_trace_context("run-1", "thread-1", "my_graph", None)
+        ctx = make_run_trace_context(self._RUN_ID, "thread-1", "my_graph", None)
 
         attrs = ctx.run(_trace_attrs.get)
         assert "langfuse.user.id" not in attrs
         assert "user.id" not in attrs
         assert attrs["langfuse.trace.name"] == "my_graph"
 
+    def test_seeds_otel_trace_id_from_run_id(self) -> None:
+        """The returned context has an OTEL trace_id derived from run_id."""
+        import uuid
+
+        from opentelemetry import trace
+
+        ctx = make_run_trace_context(self._RUN_ID, "thread-1", "my_graph", "user-1")
+
+        span = ctx.run(trace.get_current_span)
+        trace_id = span.get_span_context().trace_id
+        assert trace_id == uuid.UUID(self._RUN_ID).int
+
     def test_extra_metadata_merged_into_trace_context(self) -> None:
         """User-supplied extra_metadata appears alongside system runtime keys."""
         ctx = make_run_trace_context(
-            "run-1",
+            self._RUN_ID,
             "thread-1",
             "my_graph",
             "user-1",
@@ -252,14 +266,14 @@ class TestMakeRunTraceContext:
         assert attrs["langfuse.trace.metadata.tenant"] == "acme"
         assert attrs["langfuse.trace.metadata.feature_flag"] is True
         # System keys preserved
-        assert attrs["langfuse.trace.metadata.run_id"] == "run-1"
+        assert attrs["langfuse.trace.metadata.run_id"] == self._RUN_ID
         assert attrs["langfuse.trace.metadata.thread_id"] == "thread-1"
         assert attrs["langfuse.trace.metadata.graph_id"] == "my_graph"
 
     def test_extra_metadata_cannot_override_system_keys(self) -> None:
         """Reserved system keys win on collision; user value is dropped."""
         ctx = make_run_trace_context(
-            "run-actual",
+            self._RUN_ID,
             "thread-1",
             "my_graph",
             "user-1",
@@ -267,7 +281,7 @@ class TestMakeRunTraceContext:
         )
 
         attrs = ctx.run(_trace_attrs.get)
-        assert attrs["langfuse.trace.metadata.run_id"] == "run-actual"
+        assert attrs["langfuse.trace.metadata.run_id"] == self._RUN_ID
         assert attrs["langfuse.trace.metadata.tenant"] == "acme"
 
 
@@ -383,6 +397,9 @@ class TestSpanEnrichmentEndToEnd:
     every other test in the file.
     """
 
+    _RUN_ID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+    _RUN_ID_2 = "bbbbbbbb-2222-3333-4444-cccccccccccc"
+
     def setup_method(self) -> None:
         _trace_attrs.set(None)
         self.exporter = InMemorySpanExporter()
@@ -409,7 +426,7 @@ class TestSpanEnrichmentEndToEnd:
     def test_user_metadata_reaches_root_span_attributes(self) -> None:
         """Happy path: every layer of the propagation pipeline cooperates."""
         ctx = make_run_trace_context(
-            run_id="run-1",
+            run_id=self._RUN_ID,
             thread_id="thread-1",
             graph_id="my_graph",
             user_identity="user-1",
@@ -430,7 +447,7 @@ class TestSpanEnrichmentEndToEnd:
         assert attrs["langfuse.trace.name"] == "my_graph"
 
         # System metadata is always present.
-        assert attrs["langfuse.trace.metadata.run_id"] == "run-1"
+        assert attrs["langfuse.trace.metadata.run_id"] == self._RUN_ID
         assert attrs["langfuse.trace.metadata.thread_id"] == "thread-1"
         assert attrs["langfuse.trace.metadata.graph_id"] == "my_graph"
 
@@ -445,7 +462,7 @@ class TestSpanEnrichmentEndToEnd:
         keys still flow through.  This is the contract surfaced via the
         warning in ``merge_run_metadata`` — verified end-to-end here."""
         ctx = make_run_trace_context(
-            run_id="actual-run",
+            run_id=self._RUN_ID_2,
             thread_id="thread-1",
             graph_id="my_graph",
             user_identity="user-1",
@@ -455,14 +472,14 @@ class TestSpanEnrichmentEndToEnd:
         self._emit_root_span(ctx)
 
         attrs = dict(self.exporter.get_finished_spans()[0].attributes or {})
-        assert attrs["langfuse.trace.metadata.run_id"] == "actual-run"
+        assert attrs["langfuse.trace.metadata.run_id"] == self._RUN_ID_2
         assert attrs["langfuse.trace.metadata.tenant"] == "acme"
 
     def test_anonymous_user_with_no_extra_metadata(self) -> None:
         """``user_identity=None`` + ``extra_metadata=None`` produces a span
         with system metadata only and no user.id keys at all."""
         ctx = make_run_trace_context(
-            run_id="r1",
+            run_id=self._RUN_ID,
             thread_id="t1",
             graph_id="g1",
             user_identity=None,
@@ -476,7 +493,7 @@ class TestSpanEnrichmentEndToEnd:
         assert "user.id" not in attrs
         assert attrs["langfuse.session.id"] == "t1"
         assert attrs["langfuse.trace.name"] == "g1"
-        assert attrs["langfuse.trace.metadata.run_id"] == "r1"
+        assert attrs["langfuse.trace.metadata.run_id"] == self._RUN_ID
         # No leftover metadata keys from a previous run/test.
         user_metadata_keys = [
             k
@@ -492,7 +509,7 @@ class TestSpanEnrichmentEndToEnd:
         value (which would otherwise be silently no-op'd inside
         ``span.set_attribute``)."""
         ctx = make_run_trace_context(
-            run_id="r1",
+            run_id=self._RUN_ID,
             thread_id="t1",
             graph_id="g1",
             user_identity="u1",

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import uuid
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,6 +13,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 )
 
 from aegra_api.observability.span_enrichment import (
+    RunIdAwareIdGenerator,
     SpanEnrichmentProcessor,
     _trace_attrs,
     make_run_trace_context,
@@ -241,16 +243,13 @@ class TestMakeRunTraceContext:
         assert attrs["langfuse.trace.name"] == "my_graph"
 
     def test_seeds_otel_trace_id_from_run_id(self) -> None:
-        """The returned context has an OTEL trace_id derived from run_id."""
-        import uuid
-
-        from opentelemetry import trace
+        """The IdGenerator produces a trace_id derived from run_id."""
+        from aegra_api.observability.span_enrichment import _run_trace_id
 
         ctx = make_run_trace_context(self._RUN_ID, "thread-1", "my_graph", "user-1")
 
-        span = ctx.run(trace.get_current_span)
-        trace_id = span.get_span_context().trace_id
-        assert trace_id == uuid.UUID(self._RUN_ID).int
+        seeded_value = ctx.run(_run_trace_id.get)
+        assert seeded_value == uuid.UUID(self._RUN_ID).int
 
     def test_extra_metadata_merged_into_trace_context(self) -> None:
         """User-supplied extra_metadata appears alongside system runtime keys."""
@@ -403,7 +402,7 @@ class TestSpanEnrichmentEndToEnd:
     def setup_method(self) -> None:
         _trace_attrs.set(None)
         self.exporter = InMemorySpanExporter()
-        self.provider = TracerProvider()
+        self.provider = TracerProvider(id_generator=RunIdAwareIdGenerator())
         # Order matters: enrichment must run BEFORE export so the
         # exporter sees attributes set by ``on_start``.
         self.provider.add_span_processor(SpanEnrichmentProcessor())
@@ -437,6 +436,11 @@ class TestSpanEnrichmentEndToEnd:
 
         spans = self.exporter.get_finished_spans()
         assert len(spans) == 1
+
+        # Core invariant: trace_id is deterministic and span is a true root.
+        assert spans[0].context.trace_id == uuid.UUID(self._RUN_ID).int
+        assert spans[0].parent is None
+
         attrs = dict(spans[0].attributes or {})
 
         # Langfuse-native + Phoenix/OpenInference aliases for first-class fields.
@@ -471,7 +475,11 @@ class TestSpanEnrichmentEndToEnd:
 
         self._emit_root_span(ctx)
 
-        attrs = dict(self.exporter.get_finished_spans()[0].attributes or {})
+        span = self.exporter.get_finished_spans()[0]
+        assert span.context.trace_id == uuid.UUID(self._RUN_ID_2).int
+        assert span.parent is None
+
+        attrs = dict(span.attributes or {})
         assert attrs["langfuse.trace.metadata.run_id"] == self._RUN_ID_2
         assert attrs["langfuse.trace.metadata.tenant"] == "acme"
 
@@ -488,7 +496,11 @@ class TestSpanEnrichmentEndToEnd:
 
         self._emit_root_span(ctx)
 
-        attrs = dict(self.exporter.get_finished_spans()[0].attributes or {})
+        span = self.exporter.get_finished_spans()[0]
+        assert span.context.trace_id == uuid.UUID(self._RUN_ID).int
+        assert span.parent is None
+
+        attrs = dict(span.attributes or {})
         assert "langfuse.user.id" not in attrs
         assert "user.id" not in attrs
         assert attrs["langfuse.session.id"] == "t1"


### PR DESCRIPTION
## Summary

- Seed the OpenTelemetry `trace_id` from the run's UUID instead of generating a random one. This makes Langfuse traces deterministically linkable to LangGraph runs by ID, simplifying feedback endpoints and trace correlation.

## Test plan

- [x] Unit tests for `trace_id` seeding logic added
- [x] Existing unit/integration tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic trace IDs can be seeded from run identifiers so root traces use reproducible IDs; the telemetry provider now uses a run-aware ID generator.

* **Bug Fixes**
  * Spans with remote parents are treated as local roots so per-request/system attributes are applied consistently.

* **Tests**
  * Strengthened unit and end-to-end tests to validate deterministic trace-context seeding and span enrichment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Seeds the OTEL `trace_id` from a run's UUID integer, making Langfuse traces deterministically linkable to LangGraph runs by ID without an extra lookup. A new `RunIdAwareIdGenerator` reads a per-context `_run_trace_id` ContextVar and falls back to random generation when no seed is present.

- `make_run_trace_context` now explicitly clears the OTEL current-span context (`INVALID_SPAN` attach) before seeding, ensuring the first span is always a true root regardless of the caller's context.
- `_restore_trace_context` (worker path) gains `seed_otel_trace_id` but lacks the symmetric OTEL-context clearing, leaving an edge-case gap where a live instrumentation span could silently bypass deterministic trace_id assignment.
- End-to-end tests now assert both `trace_id == UUID(run_id).int` and `parent is None` on the exported root span.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core seeding logic is sound and well-tested for the primary (make_run_trace_context) path.

The deterministic trace-ID mechanism is clean: a ContextVar seed consumed exactly once by RunIdAwareIdGenerator, with end-to-end tests confirming both the correct trace_id and root-span parentage. The one asymmetry — missing OTEL context clearing in the worker path — is an edge-case gap that only matters if an instrumentation span is active in the worker context at job pickup time, which is unlikely under normal worker operation.

libs/aegra-api/src/aegra_api/services/worker_executor.py — _restore_trace_context lacks the otel_context.attach(INVALID_SPAN) guard that make_run_trace_context uses to guarantee root-span creation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/observability/span_enrichment.py | Adds RunIdAwareIdGenerator (reads _run_trace_id ContextVar) and seed_otel_trace_id; make_run_trace_context now also clears the OTEL current-span context before seeding — solid approach. Fallback random generation in IdGenerator still uses non-cryptographic random (noted in prior threads). |
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Adds seed_otel_trace_id call in _restore_trace_context but lacks the otel_context.attach(INVALID_SPAN) guard present in make_run_trace_context; silently bypasses deterministic trace_id if an active OTEL span exists in the worker context. |
| libs/aegra-api/src/aegra_api/observability/otel.py | TracerProvider now receives RunIdAwareIdGenerator; minimal, correct change. |
| libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py | Test fixtures updated to use valid UUIDs; new assertions verify deterministic trace_id and root-span parentage end-to-end. |
| libs/aegra-api/tests/unit/test_observability/test_otel.py | Updated assertion correctly verifies RunIdAwareIdGenerator is wired into TracerProvider. |
| docs/guides/observability.mdx | Documentation addition accurately describes deterministic trace_id derivation and W3C traceparent handling. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fworker_executor.py%3A479%0A**Missing%20OTEL%20context%20clearing%20before%20trace-ID%20seed**%0A%0A%60seed_otel_trace_id%60%20is%20called%20here%2C%20but%20unlike%20%60make_run_trace_context%60%20%28which%20explicitly%20calls%20%60ctx.run%28otel_context.attach%2C%20trace.set_span_in_context%28trace.INVALID_SPAN%29%29%60%20before%20seeding%29%2C%20this%20path%20never%20clears%20any%20active%20span%20from%20the%20worker's%20OTEL%20context.%20If%20an%20instrumentation%20span%20is%20active%20in%20%60_execute_with_lease%60%20when%20%60execute_run%60%20starts%20its%20first%20span%2C%20that%20span%20is%20created%20as%20a%20*child*%20instead%20of%20a%20root%2C%20so%20%60generate_trace_id%28%29%60%20is%20never%20called%20and%20the%20seeded%20%60_run_trace_id%60%20is%20silently%20ignored%20%E2%80%94%20the%20run%20gets%20a%20random%20trace%20ID%20rather%20than%20the%20deterministic%20one%20derived%20from%20%60run_id%60.%0A%0A&repo=aegra%2Faegra&pr=372&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fworker_executor.py%3A479%0A**Missing%20OTEL%20context%20clearing%20before%20trace-ID%20seed**%0A%0A%60seed_otel_trace_id%60%20is%20called%20here%2C%20but%20unlike%20%60make_run_trace_context%60%20%28which%20explicitly%20calls%20%60ctx.run%28otel_context.attach%2C%20trace.set_span_in_context%28trace.INVALID_SPAN%29%29%60%20before%20seeding%29%2C%20this%20path%20never%20clears%20any%20active%20span%20from%20the%20worker's%20OTEL%20context.%20If%20an%20instrumentation%20span%20is%20active%20in%20%60_execute_with_lease%60%20when%20%60execute_run%60%20starts%20its%20first%20span%2C%20that%20span%20is%20created%20as%20a%20*child*%20instead%20of%20a%20root%2C%20so%20%60generate_trace_id%28%29%60%20is%20never%20called%20and%20the%20seeded%20%60_run_trace_id%60%20is%20silently%20ignored%20%E2%80%94%20the%20run%20gets%20a%20random%20trace%20ID%20rather%20than%20the%20deterministic%20one%20derived%20from%20%60run_id%60.%0A%0A&pr=372&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fseed-otel-trace-id-from-run-id-clean%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fseed-otel-trace-id-from-run-id-clean%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fworker_executor.py%3A479%0A**Missing%20OTEL%20context%20clearing%20before%20trace-ID%20seed**%0A%0A%60seed_otel_trace_id%60%20is%20called%20here%2C%20but%20unlike%20%60make_run_trace_context%60%20%28which%20explicitly%20calls%20%60ctx.run%28otel_context.attach%2C%20trace.set_span_in_context%28trace.INVALID_SPAN%29%29%60%20before%20seeding%29%2C%20this%20path%20never%20clears%20any%20active%20span%20from%20the%20worker's%20OTEL%20context.%20If%20an%20instrumentation%20span%20is%20active%20in%20%60_execute_with_lease%60%20when%20%60execute_run%60%20starts%20its%20first%20span%2C%20that%20span%20is%20created%20as%20a%20*child*%20instead%20of%20a%20root%2C%20so%20%60generate_trace_id%28%29%60%20is%20never%20called%20and%20the%20seeded%20%60_run_trace_id%60%20is%20silently%20ignored%20%E2%80%94%20the%20run%20gets%20a%20random%20trace%20ID%20rather%20than%20the%20deterministic%20one%20derived%20from%20%60run_id%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (6): Last reviewed commit: ["docs: document deterministic trace\_id an..."](https://github.com/aegra/aegra/commit/f2dc40d90be8088099f0e63cd55147fb23bf33b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31562762)</sub>

<!-- /greptile_comment -->