### PR TITLE
fix(models): use default_factory=dict for assistant Field defaults (closes #361)

### DIFF
--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.14"
+version = "0.9.15"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/models/assistants.py
+++ b/libs/aegra-api/src/aegra_api/models/assistants.py
@@ -15,10 +15,12 @@ class AssistantCreate(BaseModel):
         description="Human-readable assistant name (auto-generated if not provided)",
     )
     description: str | None = Field(None, description="Assistant description")
-    config: dict[str, Any] | None = Field({}, description="Assistant configuration")
-    context: dict[str, Any] | None = Field({}, description="Assistant context")
+    config: dict[str, Any] | None = Field(default_factory=dict, description="Assistant configuration")
+    context: dict[str, Any] | None = Field(default_factory=dict, description="Assistant context")
     graph_id: str = Field(..., description="LangGraph graph ID from aegra.json")
-    metadata: dict[str, Any] | None = Field({}, description="Metadata to use for searching and filtering assistants.")
+    metadata: dict[str, Any] | None = Field(
+        default_factory=dict, description="Metadata to use for searching and filtering assistants."
+    )
     if_exists: str | None = Field("error", description="What to do if assistant exists: error or do_nothing")
 
 
@@ -49,13 +51,15 @@ class AssistantUpdate(BaseModel):
 
     name: str | None = Field(None, description="The name of the assistant (auto-generated if not provided)")
     description: str | None = Field(None, description="The description of the assistant. Defaults to null.")
-    config: dict[str, Any] | None = Field({}, description="Configuration to use for the graph.")
+    config: dict[str, Any] | None = Field(default_factory=dict, description="Configuration to use for the graph.")
     graph_id: str = Field("agent", description="The ID of the graph")
     context: dict[str, Any] | None = Field(
-        {},
+        default_factory=dict,
         description="The context to use for the graph. Useful when graph is configurable.",
     )
-    metadata: dict[str, Any] | None = Field({}, description="Metadata to use for searching and filtering assistants.")
+    metadata: dict[str, Any] | None = Field(
+        default_factory=dict, description="Metadata to use for searching and filtering assistants."
+    )
 
 
 class AssistantList(BaseModel):

--- a/libs/aegra-api/tests/unit/test_models/test_assistants_defaults.py
+++ b/libs/aegra-api/tests/unit/test_models/test_assistants_defaults.py
@@ -1,0 +1,59 @@
+"""Regression: AssistantCreate / AssistantUpdate must not share mutable default dicts.
+
+Pydantic v2 currently deep-copies on assignment so the historical
+`Field({})` shape hasn't bitten us, but the pattern is brittle. These tests
+pin the safe `default_factory=dict` behavior so a future revert can't sneak
+shared state across instances.
+"""
+
+from aegra_api.models.assistants import AssistantCreate, AssistantUpdate
+
+
+def test_assistant_create_defaults_do_not_share_state() -> None:
+    a = AssistantCreate(graph_id="agent")
+    b = AssistantCreate(graph_id="agent")
+    assert a.config is not None
+    assert a.context is not None
+    assert a.metadata is not None
+
+    a.config["x"] = 1
+    a.context["y"] = 2
+    a.metadata["z"] = 3
+
+    assert b.config == {}
+    assert b.context == {}
+    assert b.metadata == {}
+
+
+def test_assistant_update_defaults_do_not_share_state() -> None:
+    a = AssistantUpdate()
+    b = AssistantUpdate()
+    assert a.config is not None
+    assert a.context is not None
+    assert a.metadata is not None
+
+    a.config["x"] = 1
+    a.context["y"] = 2
+    a.metadata["z"] = 3
+
+    assert b.config == {}
+    assert b.context == {}
+    assert b.metadata == {}
+
+
+def test_assistant_create_defaults_are_distinct_instances() -> None:
+    a = AssistantCreate(graph_id="agent")
+    b = AssistantCreate(graph_id="agent")
+
+    assert a.config is not b.config
+    assert a.context is not b.context
+    assert a.metadata is not b.metadata
+
+
+def test_assistant_update_defaults_are_distinct_instances() -> None:
+    a = AssistantUpdate()
+    b = AssistantUpdate()
+
+    assert a.config is not b.config
+    assert a.context is not b.context
+    assert a.metadata is not b.metadata

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.14"
+version = "0.9.15"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.14"
+version = "0.9.15"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -98,7 +98,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.14"
+version = "0.9.15"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary
- Swap `Field({})` to `Field(default_factory=dict)` on `AssistantCreate.{config,context,metadata}` and `AssistantUpdate.{config,context,metadata}`.
- Brings these fields in line with `AssistantSearchRequest.metadata`, which was already migrated in #348.
- Adds unit regression tests pinning the distinct-instance invariant so a future revert can't reintroduce shared state.

Pydantic v2 deep-copies on assignment so the bug never surfaced in practice, but relying on that is brittle — the fix is a one-liner per field, no API surface change.

Closes #361.

## Test plan
- [x] `uv run --package aegra-api pytest libs/aegra-api/tests/unit/test_models/test_assistants_defaults.py -v` (4/4 pass)
- [x] `uv run --package aegra-api pytest libs/aegra-api/tests/unit/test_models/ libs/aegra-api/tests/unit/test_services/test_assistant_service*.py libs/aegra-api/tests/unit/test_utils/test_assistants_utils.py libs/aegra-api/tests/unit/test_api/test_assistants_search_sort.py` (99/99 pass)
- [x] `uv run ruff check` and `uv run ruff format` clean
- [x] `uv run ty check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where assistant configuration, context, and metadata fields could inadvertently share state between instances.

* **Tests**
  * Added unit tests to verify assistant model fields initialize correctly without shared state.

* **Chores**
  * Bumped aegra-api and aegra-cli versions to 0.9.15.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/373)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a mutable-default antipattern in `AssistantCreate` and `AssistantUpdate` by replacing `Field({})` with `Field(default_factory=dict)` for the `config`, `context`, and `metadata` fields, bringing them in line with `AssistantSearchRequest.metadata` changed in #348. Regression tests are added to pin the distinct-instance invariant.

- **`assistants.py`**: Six field defaults updated across two model classes; no API surface change.
- **Tests**: New `test_assistants_defaults.py` adds 4 tests covering both state-isolation and identity-distinctness for each model.
- **Versions**: Both `aegra-api` and `aegra-cli` bumped to `0.9.15`, with `uv.lock` updated accordingly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-liner-per-field cleanup with no API surface modification and no observable runtime difference under Pydantic v2.

All six field defaults are updated correctly and consistently, the new regression tests cover both state-isolation and identity-distinctness, and the change aligns with the already-migrated pattern on AssistantSearchRequest. No logic, schema, or serialization behavior is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/models/assistants.py | Replaces Field({}) with Field(default_factory=dict) on config, context, and metadata in AssistantCreate and AssistantUpdate — a clean, correct fix with no behavior change under current Pydantic v2 |
| libs/aegra-api/tests/unit/test_models/test_assistants_defaults.py | New regression test file with 4 tests covering state isolation and instance distinctness for both model classes; well structured and complete |
| libs/aegra-api/pyproject.toml | Patch version bump from 0.9.14 to 0.9.15 |
| libs/aegra-cli/pyproject.toml | Patch version bump from 0.9.14 to 0.9.15, in sync with aegra-api |
| uv.lock | Lock file updated to reflect the version bumps in both packages |

</details>

<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class AssistantCreate {
        +str|None assistant_id
        +str|None name
        +str|None description
        +dict|None config [default_factory=dict]
        +dict|None context [default_factory=dict]
        +str graph_id
        +dict|None metadata [default_factory=dict]
        +str|None if_exists
    }

    class AssistantUpdate {
        +str|None name
        +str|None description
        +dict|None config [default_factory=dict]
        +str graph_id
        +dict|None context [default_factory=dict]
        +dict|None metadata [default_factory=dict]
    }

    class AssistantSearchRequest {
        +str|None name
        +str|None description
        +str|None graph_id
        +int|None limit
        +int|None offset
        +dict|None metadata [default_factory=dict]
    }

    note for AssistantCreate "config/context/metadata now use default_factory=dict"
    note for AssistantUpdate "config/context/metadata now use default_factory=dict"
    note for AssistantSearchRequest "already used default_factory=dict since #348"
```

<sub>Reviews (1): Last reviewed commit: ["fix(models): use default\_factory for ass..."](https://github.com/aegra/aegra/commit/b0eaafcda77e17b06d2a52480de518fea4bc018e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31586795)</sub>

<!-- /greptile_comment -->