### PR TITLE
fix(migrations): rebuild GIN metadata indexes CONCURRENTLY (closes #362)

### DIFF
--- a/libs/aegra-api/alembic/versions/20260511000000_rebuild_thread_metadata_gin_concurrently.py
+++ b/libs/aegra-api/alembic/versions/20260511000000_rebuild_thread_metadata_gin_concurrently.py
@@ -1,0 +1,47 @@
+"""Rebuild idx_thread_metadata_gin without a SHARE lock
+
+The original ``b7c8d9e0f123`` migration created this GIN index inside
+Alembic's transaction, which acquires a ``SHARE`` lock on ``thread`` for the
+full build. On large thread tables that lock window blocks every concurrent
+INSERT/UPDATE/DELETE — a write-side stall on every deploy that runs the
+migration.
+
+This migration drops and recreates the index via ``CREATE INDEX
+CONCURRENTLY``, which only holds a ``SHARE UPDATE EXCLUSIVE`` lock and lets
+writes proceed during the build. Must run outside a transaction; the
+``autocommit_block`` exits the wrapping Alembic transaction for the duration.
+
+Recovery: if ``CREATE INDEX CONCURRENTLY`` is interrupted, Postgres leaves
+an INVALID index behind that won't satisfy queries. Drop it and re-run::
+
+    DROP INDEX IF EXISTS idx_thread_metadata_gin;
+
+This migration's ``DROP INDEX CONCURRENTLY IF EXISTS`` handles both the
+first-time and the post-failure retry case idempotently.
+
+Revision ID: d9e0f1a23456
+Revises: c8d9e0f1a234
+Create Date: 2026-05-11 00:00:00.000000
+
+"""
+
+from alembic import op
+
+revision = "d9e0f1a23456"
+down_revision = "c8d9e0f1a234"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "idx_thread_metadata_gin"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")
+        op.execute(f"CREATE INDEX CONCURRENTLY {INDEX_NAME} ON thread USING gin (metadata_json jsonb_path_ops)")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")

--- a/libs/aegra-api/alembic/versions/20260511000000_rebuild_thread_metadata_gin_concurrently.py
+++ b/libs/aegra-api/alembic/versions/20260511000000_rebuild_thread_metadata_gin_concurrently.py
@@ -43,5 +43,10 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Restore the index so the schema state at c8d9e0f1a234 still has the
+    # GIN predicate /threads/search relies on. We rebuild CONCURRENTLY rather
+    # than reproducing the original transactional lock-build — the schema
+    # outcome is identical and downgrade should be safe to run live.
     with op.get_context().autocommit_block():
         op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")
+        op.execute(f"CREATE INDEX CONCURRENTLY {INDEX_NAME} ON thread USING gin (metadata_json jsonb_path_ops)")

--- a/libs/aegra-api/alembic/versions/20260511000001_rebuild_assistant_metadata_gin_concurrently.py
+++ b/libs/aegra-api/alembic/versions/20260511000001_rebuild_assistant_metadata_gin_concurrently.py
@@ -35,5 +35,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Restore the index so the schema state at d9e0f1a23456 still has the
+    # GIN predicate /assistants/search relies on. See the thread rebuild
+    # for the rebuild-via-CONCURRENTLY rationale.
     with op.get_context().autocommit_block():
         op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")
+        op.execute(f"CREATE INDEX CONCURRENTLY {INDEX_NAME} ON assistant USING gin (metadata jsonb_path_ops)")

--- a/libs/aegra-api/alembic/versions/20260511000001_rebuild_assistant_metadata_gin_concurrently.py
+++ b/libs/aegra-api/alembic/versions/20260511000001_rebuild_assistant_metadata_gin_concurrently.py
@@ -1,0 +1,39 @@
+"""Rebuild idx_assistant_metadata_gin without a SHARE lock
+
+The original ``c8d9e0f1a234`` migration created this GIN index inside
+Alembic's transaction, which acquires a ``SHARE`` lock on ``assistant`` for
+the full build. On large assistant tables that lock window blocks every
+concurrent INSERT/UPDATE/DELETE — a write-side stall on every deploy that
+runs the migration.
+
+This migration drops and recreates the index via ``CREATE INDEX
+CONCURRENTLY``. Mirrors the thread.metadata_json rebuild in revision
+``d9e0f1a23456``. See that revision for the autocommit-block / INVALID-index
+recovery notes; the same pattern applies here.
+
+Revision ID: e0f1a234b567
+Revises: d9e0f1a23456
+Create Date: 2026-05-11 00:00:00.000001
+
+"""
+
+from alembic import op
+
+revision = "e0f1a234b567"
+down_revision = "d9e0f1a23456"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "idx_assistant_metadata_gin"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")
+        op.execute(f"CREATE INDEX CONCURRENTLY {INDEX_NAME} ON assistant USING gin (metadata jsonb_path_ops)")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.14"
+version = "0.9.15"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.14"
+version = "0.9.15"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.14"
+version = "0.9.15"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -98,7 +98,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.14"
+version = "0.9.15"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary
- Add two new alembic migrations (`d9e0f1a23456`, `e0f1a234b567`) that drop and recreate `idx_thread_metadata_gin` and `idx_assistant_metadata_gin` via `CREATE INDEX CONCURRENTLY`.
- Uses `op.get_context().autocommit_block()` to exit Alembic's wrapping transaction for the duration — the standard alembic pattern for non-transactional DDL. Generated SQL is `COMMIT; DROP INDEX CONCURRENTLY IF EXISTS …; CREATE INDEX CONCURRENTLY …; BEGIN; UPDATE alembic_version …; COMMIT;`.
- `DROP INDEX CONCURRENTLY IF EXISTS` is idempotent and recovers gracefully from the INVALID-index case if a previous CREATE was interrupted.

The original migrations (`b7c8d9e0f123`, `c8d9e0f1a234`) created these indexes inside a transaction, acquiring a `SHARE` lock on the host table for the full build. On large thread/assistant tables that stalled every concurrent INSERT/UPDATE/DELETE for the duration — a write-side outage on every deploy that runs migrations.

Closes #362.

## Test plan
- [x] `uv run --package aegra-api pytest libs/aegra-api/tests/unit/test_migrations.py` (18/18 pass)
- [x] `uv run --package aegra-api alembic upgrade --sql head` emits expected non-transactional pattern (`COMMIT; CREATE INDEX CONCURRENTLY …; BEGIN; UPDATE alembic_version …`)
- [x] `uv run --package aegra-api alembic downgrade --sql` emits matching reverse pattern
- [x] `uv run ruff check` and `uv run ruff format` clean
- [ ] Verify against a live Postgres (start `docker compose up -d`, confirm `\d thread` shows index built with `CONCURRENTLY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Rebuilt key database indexes using concurrent, non-blocking operations to reduce lock contention and minimize service interruptions during maintenance.

* **Chores**
  * Package versions bumped to 0.9.15.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/374)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two Alembic migrations that rebuild `idx_thread_metadata_gin` and `idx_assistant_metadata_gin` using `CREATE INDEX CONCURRENTLY` inside `autocommit_block()`, eliminating the `SHARE` lock that previously stalled writes for the full index-build duration on every deploy.

- **Thread migration (`d9e0f1a23456`)**: drops and recreates `idx_thread_metadata_gin ON thread USING gin (metadata_json jsonb_path_ops)` concurrently; `downgrade()` is symmetric — it also drops and rebuilds, leaving the index present as required by the prior revision.
- **Assistant migration (`e0f1a234b567`)**: mirrors the thread migration for `idx_assistant_metadata_gin ON assistant USING gin (metadata jsonb_path_ops)`, with identical `autocommit_block` usage and the same symmetric downgrade.
- Both index definitions (column names, operator class, table names) match the originals in `b7c8d9e0f123` and `c8d9e0f1a234` exactly; the `down_revision` chain is correct.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both migrations use the correct Alembic autocommit pattern for non-transactional DDL and leave the indexes intact after both upgrade and downgrade.

The previous review flagged that downgrade() was missing the index recreation; both migration files now correctly drop and rebuild the index concurrently in downgrade(), matching the required schema state of the preceding revision. Index definitions (column names, operator class, table names) are identical to the originals, the down_revision chain is correct, and the autocommit_block usage is the standard Alembic pattern for CREATE INDEX CONCURRENTLY.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/alembic/versions/20260511000000_rebuild_thread_metadata_gin_concurrently.py | Adds migration to drop and rebuild idx_thread_metadata_gin via CREATE INDEX CONCURRENTLY inside autocommit_block; upgrade and downgrade are symmetric and both correctly preserve the index. |
| libs/aegra-api/alembic/versions/20260511000001_rebuild_assistant_metadata_gin_concurrently.py | Mirrors the thread migration for idx_assistant_metadata_gin on assistant.metadata; index definition, operator class, and downgrade reconstruction all match the original c8d9e0f1a234 migration. |
| libs/aegra-api/pyproject.toml | Version bump from 0.9.14 to 0.9.15. |
| libs/aegra-cli/pyproject.toml | Version bump from 0.9.14 to 0.9.15. |
| uv.lock | Lock file updated to reflect 0.9.15 version for both aegra-api and aegra-cli packages. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as Alembic Runner
    participant PG as PostgreSQL

    Note over A,PG: upgrade thread migration
    A->>PG: COMMIT
    A->>PG: DROP INDEX CONCURRENTLY IF EXISTS idx_thread_metadata_gin
    PG-->>A: OK
    A->>PG: CREATE INDEX CONCURRENTLY idx_thread_metadata_gin ON thread USING gin
    PG-->>A: OK
    A->>PG: BEGIN
    A->>PG: UPDATE alembic_version
    A->>PG: COMMIT

    Note over A,PG: upgrade assistant migration
    A->>PG: COMMIT
    A->>PG: DROP INDEX CONCURRENTLY IF EXISTS idx_assistant_metadata_gin
    PG-->>A: OK
    A->>PG: CREATE INDEX CONCURRENTLY idx_assistant_metadata_gin ON assistant USING gin
    PG-->>A: OK
    A->>PG: BEGIN
    A->>PG: UPDATE alembic_version
    A->>PG: COMMIT
```

<sub>Reviews (2): Last reviewed commit: ["fix(migrations): recreate GIN indexes in..."](https://github.com/aegra/aegra/commit/7947399b890b40b06f38d9db530e672908be87ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31587348)</sub>

<!-- /greptile_comment -->