### PR TITLE
fix(orm): strip NULL bytes from JSONB writes (#370)

### DIFF
--- a/libs/aegra-api/src/aegra_api/core/orm.py
+++ b/libs/aegra-api/src/aegra_api/core/orm.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from datetime import datetime
+from typing import Any
 
 from sqlalchemy import (
     TIMESTAMP,
@@ -25,8 +26,41 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.engine import Dialect
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import Mapped, declarative_base, mapped_column
+from sqlalchemy.types import TypeDecorator
+
+
+def _strip_null_bytes(value: Any) -> Any:
+    """Recursively strip U+0000 from strings inside JSON-compatible structures.
+
+    Postgres JSONB rejects \\u0000 with UntranslatableCharacterError; agent
+    output can contain literal NULL bytes from untrusted input or model
+    hallucination. Stripping at the type boundary protects every JSONB column.
+    """
+    if isinstance(value, str):
+        return value.replace("\x00", "") if "\x00" in value else value
+    if isinstance(value, dict):
+        return {_strip_null_bytes(k): _strip_null_bytes(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_strip_null_bytes(v) for v in value]
+    return value
+
+
+class JsonbSafe(TypeDecorator):
+    """JSONB column that strips NULL bytes from string values before write.
+
+    Drop-in replacement for ``JSONB``. Read path is untouched — only
+    ``process_bind_param`` runs, so existing rows are unaffected.
+    """
+
+    impl = JSONB
+    cache_ok = True
+
+    def process_bind_param(self, value: Any, dialect: Dialect) -> Any:
+        return _strip_null_bytes(value)
+
 
 Base = declarative_base()
 
@@ -41,11 +75,11 @@ class Assistant(Base):
     name: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
     graph_id: Mapped[str] = mapped_column(Text, nullable=False)
-    config: Mapped[dict] = mapped_column(JSONB, server_default=text("'{}'::jsonb"))
-    context: Mapped[dict] = mapped_column(JSONB, server_default=text("'{}'::jsonb"))
+    config: Mapped[dict] = mapped_column(JsonbSafe, server_default=text("'{}'::jsonb"))
+    context: Mapped[dict] = mapped_column(JsonbSafe, server_default=text("'{}'::jsonb"))
     user_id: Mapped[str] = mapped_column(Text, nullable=False)
     version: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("1"))
-    metadata_dict: Mapped[dict] = mapped_column(JSONB, server_default=text("'{}'::jsonb"), name="metadata")
+    metadata_dict: Mapped[dict] = mapped_column(JsonbSafe, server_default=text("'{}'::jsonb"), name="metadata")
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=text("now()"))
     updated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=text("now()"))
 
@@ -71,10 +105,10 @@ class AssistantVersion(Base):
     )
     version: Mapped[int] = mapped_column(Integer, primary_key=True)
     graph_id: Mapped[str] = mapped_column(Text, nullable=False)
-    config: Mapped[dict | None] = mapped_column(JSONB)
-    context: Mapped[dict | None] = mapped_column(JSONB)
+    config: Mapped[dict | None] = mapped_column(JsonbSafe)
+    context: Mapped[dict | None] = mapped_column(JsonbSafe)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=text("now()"))
-    metadata_dict: Mapped[dict] = mapped_column(JSONB, server_default=text("'{}'::jsonb"), name="metadata")
+    metadata_dict: Mapped[dict] = mapped_column(JsonbSafe, server_default=text("'{}'::jsonb"), name="metadata")
     name: Mapped[str | None] = mapped_column(Text)
     description: Mapped[str | None] = mapped_column(Text)
 
@@ -85,7 +119,7 @@ class Thread(Base):
     thread_id: Mapped[str] = mapped_column(Text, primary_key=True)
     status: Mapped[str] = mapped_column(Text, server_default=text("'idle'"))
     # Database column is 'metadata_json' (per database.py). ORM attribute 'metadata_json' must map to that column.
-    metadata_json: Mapped[dict] = mapped_column("metadata_json", JSONB, server_default=text("'{}'::jsonb"))
+    metadata_json: Mapped[dict] = mapped_column("metadata_json", JsonbSafe, server_default=text("'{}'::jsonb"))
     user_id: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=text("now()"))
     updated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=text("now()"))
@@ -102,12 +136,12 @@ class Run(Base):
     thread_id: Mapped[str] = mapped_column(Text, ForeignKey("thread.thread_id", ondelete="CASCADE"), nullable=False)
     assistant_id: Mapped[str | None] = mapped_column(Text, ForeignKey("assistant.assistant_id", ondelete="CASCADE"))
     status: Mapped[str] = mapped_column(Text, server_default=text("'pending'"))
-    input: Mapped[dict | None] = mapped_column(JSONB, server_default=text("'{}'::jsonb"))
+    input: Mapped[dict | None] = mapped_column(JsonbSafe, server_default=text("'{}'::jsonb"))
     # Some environments may not yet have a 'config' column; make it nullable without default to match existing DB.
     # If migrations add this column later, it's already represented here.
-    config: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    context: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    output: Mapped[dict | None] = mapped_column(JSONB)
+    config: Mapped[dict | None] = mapped_column(JsonbSafe, nullable=True)
+    context: Mapped[dict | None] = mapped_column(JsonbSafe, nullable=True)
+    output: Mapped[dict | None] = mapped_column(JsonbSafe)
     error_message: Mapped[str | None] = mapped_column(Text)
     user_id: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=text("now()"))
@@ -115,7 +149,7 @@ class Run(Base):
 
     # Worker execution: stores RunJob params so workers can reconstruct
     # the job from the database after receiving a run_id via Redis.
-    execution_params: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    execution_params: Mapped[dict | None] = mapped_column(JsonbSafe, nullable=True)
 
     # Lease-based crash recovery: tracks which worker owns a run and
     # when the lease expires. A background reaper re-enqueues runs

--- a/libs/aegra-api/src/aegra_api/core/orm.py
+++ b/libs/aegra-api/src/aegra_api/core/orm.py
@@ -17,6 +17,7 @@ from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any
 
+import structlog
 from sqlalchemy import (
     TIMESTAMP,
     ForeignKey,
@@ -31,20 +32,43 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import Mapped, declarative_base, mapped_column
 from sqlalchemy.types import TypeDecorator
 
+_logger = structlog.getLogger(__name__)
 
-def _strip_null_bytes(value: Any) -> Any:
+# Safety net against pathological/adversarial nesting. Real agent JSON rarely
+# exceeds a few dozen levels; Python's default frame limit is ~1000. 200 is
+# well above any legitimate payload and well below the interpreter ceiling.
+_MAX_STRIP_DEPTH = 200
+
+
+def _strip_null_bytes(value: Any, _depth: int = 0) -> Any:
     """Recursively strip U+0000 from strings inside JSON-compatible structures.
 
     Postgres JSONB rejects \\u0000 with UntranslatableCharacterError; agent
     output can contain literal NULL bytes from untrusted input or model
     hallucination. Stripping at the type boundary protects every JSONB column.
+
+    Beyond ``_MAX_STRIP_DEPTH`` the value is returned untouched — a deeper
+    payload than that is almost certainly adversarial, and letting Postgres
+    reject it surfaces a clearer signal than a RecursionError at bind time.
     """
+    if _depth >= _MAX_STRIP_DEPTH:
+        _logger.warning("jsonb_strip_depth_exceeded", depth=_depth, type=type(value).__name__)
+        return value
     if isinstance(value, str):
         return value.replace("\x00", "") if "\x00" in value else value
     if isinstance(value, dict):
-        return {_strip_null_bytes(k): _strip_null_bytes(v) for k, v in value.items()}
+        result: dict[Any, Any] = {}
+        for k, v in value.items():
+            stripped_k = _strip_null_bytes(k, _depth + 1)
+            if stripped_k in result:
+                # Two distinct raw keys collapsed to the same stripped key — the
+                # earlier value is being dropped by last-wins. Surface so silent
+                # data loss is visible in logs.
+                _logger.warning("jsonb_strip_key_collision", stripped_key=stripped_k)
+            result[stripped_k] = _strip_null_bytes(v, _depth + 1)
+        return result
     if isinstance(value, (list, tuple)):
-        return [_strip_null_bytes(v) for v in value]
+        return [_strip_null_bytes(v, _depth + 1) for v in value]
     return value
 
 

--- a/libs/aegra-api/tests/unit/test_core/test_orm_jsonb_safe.py
+++ b/libs/aegra-api/tests/unit/test_core/test_orm_jsonb_safe.py
@@ -1,0 +1,75 @@
+"""Unit tests for JsonbSafe TypeDecorator NULL byte stripping.
+
+Regression cover for issue #370: Postgres JSONB rejects U+0000 with
+asyncpg ``UntranslatableCharacterError``. ``JsonbSafe.process_bind_param``
+strips NULL bytes recursively at the type boundary so every JSONB column
+on the ORM is protected uniformly.
+"""
+
+from typing import Any
+
+import pytest
+
+from aegra_api.core.orm import JsonbSafe, _strip_null_bytes
+
+
+class TestStripNullBytes:
+    """Recursive NULL byte stripping across nested JSON-compatible structures."""
+
+    def test_clean_string_returned_identical(self) -> None:
+        s = "hello world"
+        assert _strip_null_bytes(s) is s
+
+    def test_string_with_null_byte_stripped(self) -> None:
+        assert _strip_null_bytes("before\x00after") == "beforeafter"
+
+    def test_only_null_bytes(self) -> None:
+        assert _strip_null_bytes("\x00\x00\x00") == ""
+
+    def test_other_control_chars_preserved(self) -> None:
+        # JSONB only rejects U+0000; other control chars (\n, \t, \x01) are valid.
+        s = "line1\nline2\ttab\x01ctrl"
+        assert _strip_null_bytes(s) == s
+
+    def test_dict_recursive(self) -> None:
+        result = _strip_null_bytes({"a": "x\x00y", "b": {"c": "z\x00"}})
+        assert result == {"a": "xy", "b": {"c": "z"}}
+
+    def test_list_recursive(self) -> None:
+        assert _strip_null_bytes(["a\x00", "b", ["c\x00d"]]) == ["a", "b", ["cd"]]
+
+    def test_tuple_returned_as_list(self) -> None:
+        # JSON has no tuples; serialize as list (matches GeneralSerializer behaviour).
+        assert _strip_null_bytes(("a\x00", "b")) == ["a", "b"]
+
+    def test_deeply_nested(self) -> None:
+        value = {"k": [{"inner": ["deep\x00val", {"deeper": "x\x00"}]}]}
+        expected = {"k": [{"inner": ["deepval", {"deeper": "x"}]}]}
+        assert _strip_null_bytes(value) == expected
+
+    @pytest.mark.parametrize("value", [None, 42, 3.14, True, False])
+    def test_non_string_scalars_passthrough(self, value: Any) -> None:
+        assert _strip_null_bytes(value) is value
+
+    def test_dict_keys_with_null_byte_stripped(self) -> None:
+        # NULL bytes in keys are also illegal in JSONB text; strip both sides.
+        result = _strip_null_bytes({"key\x00": "value"})
+        assert result == {"key": "value"}
+
+
+class TestJsonbSafeBindParam:
+    """The TypeDecorator hook is the only DB-facing surface."""
+
+    def test_process_bind_param_strips_nulls(self) -> None:
+        col = JsonbSafe()
+        result = col.process_bind_param({"out": "a\x00b"}, dialect=None)  # type: ignore[arg-type]
+        assert result == {"out": "ab"}
+
+    def test_process_bind_param_none_passthrough(self) -> None:
+        col = JsonbSafe()
+        assert col.process_bind_param(None, dialect=None) is None  # type: ignore[arg-type]
+
+    def test_cache_ok_set(self) -> None:
+        # SQLAlchemy requires cache_ok on user-defined TypeDecorators to participate
+        # in statement caching; without it every statement is re-compiled.
+        assert JsonbSafe.cache_ok is True

--- a/libs/aegra-api/tests/unit/test_core/test_orm_jsonb_safe.py
+++ b/libs/aegra-api/tests/unit/test_core/test_orm_jsonb_safe.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import pytest
 
-from aegra_api.core.orm import JsonbSafe, _strip_null_bytes
+from aegra_api.core.orm import _MAX_STRIP_DEPTH, JsonbSafe, _strip_null_bytes
 
 
 class TestStripNullBytes:
@@ -73,3 +73,60 @@ class TestJsonbSafeBindParam:
         # SQLAlchemy requires cache_ok on user-defined TypeDecorators to participate
         # in statement caching; without it every statement is re-compiled.
         assert JsonbSafe.cache_ok is True
+
+
+class TestDepthGuard:
+    """Recursion stops at _MAX_STRIP_DEPTH to avoid RecursionError on adversarial payloads."""
+
+    def test_depth_within_limit_processed(self) -> None:
+        # Build a nested chain just under the limit; stripping must still work.
+        depth = _MAX_STRIP_DEPTH - 10
+        value: Any = "leaf\x00"
+        for _ in range(depth):
+            value = [value]
+        result = _strip_null_bytes(value)
+        # Walk down to leaf and verify it was stripped.
+        cursor = result
+        for _ in range(depth):
+            cursor = cursor[0]
+        assert cursor == "leaf"
+
+    def test_depth_overflow_returns_untouched(self, caplog: pytest.LogCaptureFixture) -> None:
+        # Build a payload deeper than the guard; deepest values must come back
+        # unchanged (no RecursionError, no infinite loop).
+        depth = _MAX_STRIP_DEPTH + 50
+        value: Any = "leaf\x00"
+        for _ in range(depth):
+            value = [value]
+        result = _strip_null_bytes(value)
+        # First _MAX_STRIP_DEPTH levels were entered; below that, value returned
+        # as-is. We don't assert the exact pivot, only that no exception fired
+        # and the result is structurally a list (recursion didn't crash).
+        assert isinstance(result, list)
+
+
+class TestKeyCollisionWarning:
+    """Stripped-key collisions must log a warning so silent data loss is visible."""
+
+    def test_collision_logs_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Patch the module-level structlog logger to capture warning calls
+        # without relying on the structlog config (caplog only sees stdlib logs).
+        from aegra_api.core import orm
+
+        calls: list[tuple[str, dict[str, Any]]] = []
+
+        def _record(event: str, **kw: Any) -> None:
+            calls.append((event, kw))
+
+        monkeypatch.setattr(orm._logger, "warning", _record)
+        result = orm._strip_null_bytes({"a\x00": "first", "a": "second"})
+        assert result == {"a": "second"}
+        assert any(event == "jsonb_strip_key_collision" for event, _ in calls)
+
+    def test_no_collision_no_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from aegra_api.core import orm
+
+        calls: list[str] = []
+        monkeypatch.setattr(orm._logger, "warning", lambda event, **kw: calls.append(event))
+        orm._strip_null_bytes({"a\x00": "v1", "b": "v2"})
+        assert "jsonb_strip_key_collision" not in calls


### PR DESCRIPTION
## Summary

Fixes #370. Postgres JSONB rejects U+0000; asyncpg surfaces it as `UntranslatableCharacterError` and the run gets marked `error` even though the graph completed successfully.

Root cause: `GeneralSerializer` passes strings through untouched, so any agent state containing a literal NULL byte (untrusted input, model hallucination, agent-generated test data) crashes the `UPDATE runs SET output=$2::JSONB` statement. Every JSONB column on the ORM (~10 across `assistant`, `assistant_versions`, `thread`, `runs`) has the same exposure.

## Fix

Add a `JsonbSafe` TypeDecorator in `core/orm.py` that recursively strips `\x00` from strings and dict keys in `process_bind_param`, then swap `JSONB` -> `JsonbSafe` on every JSONB column declaration. The read path is untouched, so existing rows are unaffected.

Single defense at the DB boundary covers all current and future JSONB columns uniformly — no scattering strip helpers across services.

## Why this shape

- one place to look — the column type says what it does
- new JSONB columns are auto-protected
- `"\x00" in v` short-circuits before allocating on clean strings (the 99.99% case)
- non-string scalars and other control chars (`\n`, `\t`, `\x01`) pass through untouched — JSONB only rejects U+0000

## Tests

New `tests/unit/test_core/test_orm_jsonb_safe.py` — 17 cases covering:
- clean strings returned identical (identity check)
- NULL byte stripping in strings, dict values, dict keys, lists, tuples, deeply nested
- other control chars preserved
- non-string scalars passthrough (None, int, float, bool)
- `process_bind_param` strips on the TypeDecorator instance
- `cache_ok = True` (required for SQLAlchemy statement caching)

All 1027 existing unit tests still pass.

## Version

Bumps both packages 0.9.14 -> 0.9.15 (patch — bug fix, no breaking changes).

## Test plan

- [x] unit tests pass (1027 + 17 new)
- [x] ruff clean
- [ ] e2e: graph node returning `{"out": "a\x00b"}` completes `success`, output queryable, NULL stripped
- [ ] regression: cover `input` (request body), `metadata_json` (thread metadata), `context` (assistant context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Postgres errors by sanitizing null (U+0000) characters in JSON fields used by assistants, versions, threads, and runs.

* **Tests**
  * Added comprehensive unit tests for null-byte handling, deep nesting, and key-collision scenarios in JSON payloads.

* **Chores**
  * Version bumped to 0.9.16.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/376)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `JsonbSafe` SQLAlchemy `TypeDecorator` that recursively strips `\x00` (NULL bytes) from string values and dict keys before writing to any JSONB column, fixing a crash where Postgres raised `UntranslatableCharacterError` on agent-generated payloads containing literal NULL bytes.

- Introduces `_strip_null_bytes` with a depth guard at 200 levels (preventing `RecursionError` on adversarial nesting) and a key-collision warning log when distinct raw keys collapse to the same stripped key.
- Replaces every `JSONB` column declaration across `Assistant`, `AssistantVersion`, `Thread`, and `Run` with `JsonbSafe`.
- Adds 17 unit tests covering clean strings, deep nesting, scalars, key collisions, and the depth guard.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is well-scoped and both concerns from the prior review round are properly addressed.

All JSONB columns are uniformly protected at the ORM boundary. The depth guard at 200 sits comfortably below Python's frame limit while covering every realistic payload. Key collisions now emit a structured log warning rather than silently dropping data. Tests cover the full decision tree including edge cases, and existing tests are unaffected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/orm.py | Adds JsonbSafe TypeDecorator with depth-guarded, collision-warning recursive NULL-byte stripping; swaps JSONB → JsonbSafe across all 10 JSONB columns cleanly. |
| libs/aegra-api/tests/unit/test_core/test_orm_jsonb_safe.py | 17 unit tests covering string stripping, deep nesting, scalars, tuples-as-lists, key collision warning, and depth-guard behaviour — good coverage of the new logic. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(orm): guard recursion depth and log ..."](https://github.com/aegra/aegra/commit/4aaac99feb601a060d942a741b34d9d9ae99da83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31755427)</sub>

<!-- /greptile_comment -->