### PR TITLE
fix(serializer): guard against Pydantic class refs (#356)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.15"
+    "version": "0.9.16"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.15"
+version = "0.9.16"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/core/serializers/general.py
+++ b/libs/aegra-api/src/aegra_api/core/serializers/general.py
@@ -1,5 +1,6 @@
 """General-purpose object serialization for complex objects"""
 
+import inspect
 from typing import Any
 
 from aegra_api.core.serializers.base import SerializationError, Serializer
@@ -17,6 +18,13 @@ class GeneralSerializer(Serializer):
 
     def _serialize_object(self, obj: Any) -> Any:
         """Core serialization logic for Python objects"""
+        # Class objects (e.g. a Pydantic class passed to with_structured_output)
+        # carry bound-method descriptors but cannot be dump()'d without an
+        # instance. Render them by qualname so duck-typed checks below don't
+        # invoke unbound methods.
+        if inspect.isclass(obj):
+            return f"{obj.__module__}.{obj.__qualname__}"
+
         # Handle Pydantic v2 models (model_dump method)
         if hasattr(obj, "model_dump") and callable(obj.model_dump):
             return obj.model_dump()

--- a/libs/aegra-api/tests/unit/test_core/test_serializers/test_general.py
+++ b/libs/aegra-api/tests/unit/test_core/test_serializers/test_general.py
@@ -238,6 +238,29 @@ class TestGeneralSerializer:
         assert self.serializer.serialize(-42) == -42
         assert self.serializer.serialize(-3.14) == -3.14
 
+    def test_serialize_pydantic_class_not_instance(self):
+        """Regression for #356: passing a Pydantic class (not an instance) must
+        not invoke unbound model_dump(). LangChain's with_structured_output
+        stores the class reference inside the runnable chain, and LangGraph
+        checkpointing then walks it through this serializer."""
+        result = self.serializer.serialize(PydanticV2Model)
+        assert isinstance(result, str)
+        assert "PydanticV2Model" in result
+
+    def test_serialize_pydantic_v1_class_not_instance(self):
+        """Same defect on the .dict() branch — classes with a dict method
+        (Pydantic v1 style) would also crash without the isclass guard."""
+        result = self.serializer.serialize(PydanticV1Style)
+        assert isinstance(result, str)
+        assert "PydanticV1Style" in result
+
+    def test_serialize_builtin_class_passthrough(self):
+        """Builtin types (dict, list, str) hit the same path; render as str
+        rather than blowing up on missing __module__/__qualname__."""
+        result = self.serializer.serialize(dict)
+        assert isinstance(result, str)
+        assert "dict" in result
+
 
 class MockTask:
     """Mock LangGraph task"""

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.15"
+version = "0.9.16"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.15"
+version = "0.9.16"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -98,7 +98,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.15"
+version = "0.9.16"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary

Fixes #356. `GeneralSerializer._serialize_object` uses duck typing to detect Pydantic models:

```python
if hasattr(obj, "model_dump") and callable(obj.model_dump):
    return obj.model_dump()
```

That check passes for instances AND classes because methods live on the class. Calling `MyModel.model_dump()` on the class (unbound) raises `TypeError: missing 1 required positional argument: 'self'` and the entire run is marked `error`.

**Real-world trigger:** `llm.with_structured_output(PydanticClass)` — LangChain stores the class reference inside the runnable chain. LangGraph checkpointing serializes task state through Aegra's serializer, hits the class, crashes. Same defect on the `.dict()` branch for Pydantic v1.

## Fix

Single `inspect.isclass(obj)` early-return at the top of `_serialize_object`. Classes render as `{module}.{qualname}` strings. One guard covers every duck-typed method check (model_dump, dict, _asdict, future additions) — no scattering across branches.

```python
if inspect.isclass(obj):
    return f"{obj.__module__}.{obj.__qualname__}"
```

## Why this shape

- minimal diff, one guard, top of the function where it's most discoverable
- doesn't import pydantic (serializer stays dependency-free, duck-typed by design)
- works for any class type: Pydantic v2, Pydantic v1, dataclass classes, builtins, custom classes
- string fallback matches the existing `else: return str(obj)` philosophy for unknown types
- future duck-typed branches inherit the protection for free

## Tests

`libs/aegra-api/tests/unit/test_core/test_serializers/test_general.py` — 3 new regression cases:
- `test_serialize_pydantic_class_not_instance` — direct repro from the issue
- `test_serialize_pydantic_v1_class_not_instance` — same defect on `.dict()` branch
- `test_serialize_builtin_class_passthrough` — builtins like `dict` render cleanly

All 1038 existing unit tests still pass.

## Version

Bumps both packages 0.9.15 -> 0.9.16 (patch — bug fix, no breaking changes).

## Test plan

- [x] reproduce issue locally with `with_structured_output(MyModel)` pattern
- [x] unit tests pass (1038 existing + 3 new)
- [x] ruff clean
- [ ] e2e: graph using `before_agent` middleware with `with_structured_output(Pydantic class)` finalizes `success` instead of `error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped aegra-api, aegra-cli, and OpenAPI spec to version 0.9.16.

* **Bug Fixes**
  * Improved serializer to properly handle class objects (including Pydantic model classes and built-ins) to produce stable, readable output instead of falling back to raw stringification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/378)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash in `GeneralSerializer._serialize_object` when a Pydantic model *class* (rather than an instance) is passed in — triggered by LangChain's `with_structured_output` storing the class reference in a runnable that LangGraph then checkpoints through Aegra's serializer. The fix is a single `inspect.isclass` early-return at the top of `_serialize_object` that renders any class as `{module}.{qualname}`, protecting all existing duck-typed branches without touching them.

- **`general.py`**: Adds `import inspect` and a 1-line guard; any class object now serializes to a stable dotted-name string instead of raising `TypeError` on an unbound `model_dump()` or `dict()` call.
- **`test_general.py`**: Three new regression tests cover Pydantic v2 class, Pydantic v1-style class, and a builtin (`dict`) — directly reproducing the reported failure modes.
- **Version bumps**: Both `aegra-api` and `aegra-cli` bumped to 0.9.16 along with `uv.lock` and `docs/openapi.json`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single early-return guard that only activates when a class object (not an instance) is passed to the serializer, leaving all existing serialization paths completely unaffected.

The fix is minimal and well-scoped: one new import, one guard, three targeted regression tests. Existing instance serialization is untouched because `inspect.isclass` returns `False` for all normal runtime values (instances, dicts, lists, primitives). The returned `{module}.{qualname}` string is consistent with the existing `str(obj)` fallback philosophy.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/serializers/general.py | Adds `inspect.isclass` early-return guard to prevent unbound method calls on class objects; fix is minimal and well-placed. |
| libs/aegra-api/tests/unit/test_core/test_serializers/test_general.py | Adds 3 targeted regression tests covering Pydantic v2 class, Pydantic v1-style class, and builtin class — all correct direct reproductions of the bug. |
| libs/aegra-api/pyproject.toml | Patch version bump 0.9.15 → 0.9.16, consistent with a bug-fix release. |
| libs/aegra-cli/pyproject.toml | Patch version bump 0.9.15 → 0.9.16 to stay in sync with aegra-api. |
| docs/openapi.json | Version string updated to 0.9.16, no other changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_serialize_object(obj)"] --> B{"inspect.isclass(obj)?"}
    B -- "Yes (NEW guard)" --> C["return f'{obj.__module__}.{obj.__qualname__}'"]
    B -- No --> D{"hasattr model_dump?"}
    D -- Yes --> E["obj.model_dump()"]
    D -- No --> F{"hasattr dict?"}
    F -- Yes --> G["obj.dict()"]
    F -- No --> H{"Interrupt?"}
    H -- Yes --> I["{'value':..., 'id':...}"]
    H -- No --> J{"_asdict?"}
    J -- Yes --> K["_asdict() dict"]
    J -- No --> L{"set/frozenset?"}
    L -- Yes --> M["list(obj)"]
    L -- No --> N{"tuple/list?"}
    N -- Yes --> O["recursive list"]
    N -- No --> P{"dict?"}
    P -- Yes --> Q["recursive dict"]
    P -- No --> R{"str/int/float/bool/None?"}
    R -- Yes --> S["return obj"]
    R -- No --> T["str(obj)"]

    style C fill:#22c55e,color:#fff
    style B fill:#fbbf24
```

<sub>Reviews (2): Last reviewed commit: ["docs: bump openapi spec to 0.9.16"](https://github.com/aegra/aegra/commit/64afc73f25543fd636b44d01b82dc0f5dac63bd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31774226)</sub>

<!-- /greptile_comment -->