### PR TITLE
fix(auth): cache auth backend to avoid reloading module per-request

### DIFF
--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -276,9 +276,12 @@ class LangGraphAuthBackend(AuthenticationBackend):
             raise AuthenticationError("Authentication system error") from e
 
 
+@functools.lru_cache(maxsize=1)
 def get_auth_backend() -> AuthenticationBackend:
     """
     Get authentication backend based on AUTH_TYPE environment variable.
+
+    Cached so the auth module is loaded once at first use, not per-request.
 
     Returns:
         AuthenticationBackend instance
@@ -316,16 +319,16 @@ def on_auth_error(conn: HTTPConnection, exc: AuthenticationError) -> JSONRespons
     )
 
 
-@functools.lru_cache(maxsize=1)
 def get_auth_instance() -> Auth | None:
-    """Get cached Auth instance for use by other modules.
+    """Get the Auth instance from the cached backend.
 
-    Uses LRU cache to ensure only one Auth instance is loaded per process.
-    This allows other modules to access the same Auth instance used by
-    the middleware without re-loading it.
+    Delegates to get_auth_backend() so only one Auth instance exists
+    per process.
 
     Returns:
         Auth instance or None if not configured/found
     """
-    backend = LangGraphAuthBackend()
-    return backend.auth_instance
+    backend = get_auth_backend()
+    if isinstance(backend, LangGraphAuthBackend):
+        return backend.auth_instance
+    return None

--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -331,4 +331,8 @@ def get_auth_instance() -> Auth | None:
     backend = get_auth_backend()
     if isinstance(backend, LangGraphAuthBackend):
         return backend.auth_instance
+    logger.warning(
+        "get_auth_instance() called but backend is not LangGraphAuthBackend: %s",
+        type(backend).__name__,
+    )
     return None

--- a/libs/aegra-api/tests/conftest.py
+++ b/libs/aegra-api/tests/conftest.py
@@ -123,17 +123,16 @@ def runs_client():
 
 @pytest.fixture(autouse=True)
 def clear_auth_cache():
-    """Clear auth instance cache before and after each test.
+    """Clear auth caches before and after each test.
 
-    The get_auth_instance() function uses @lru_cache which can cause
-    test isolation issues when different tests need different auth configurations.
-    This fixture ensures each test starts with a clean auth state.
+    get_auth_backend() uses @lru_cache which can cause test isolation
+    issues when different tests need different auth configurations.
     """
-    from aegra_api.core.auth_middleware import get_auth_instance
+    from aegra_api.core.auth_middleware import get_auth_backend
 
-    get_auth_instance.cache_clear()
+    get_auth_backend.cache_clear()
     yield
-    get_auth_instance.cache_clear()
+    get_auth_backend.cache_clear()
 
 
 # --- AUTO-SKIP GEO-BLOCK FAILURES ---


### PR DESCRIPTION
## Summary

- `get_auth_backend()` was creating a new `LangGraphAuthBackend` on every call, re-reading `aegra.json` and re-importing the user's `auth.py` via `importlib` on every request.
- Add `@functools.lru_cache(maxsize=1)` to `get_auth_backend()` so the auth module is loaded once and reused.
- Update `get_auth_instance()` to reuse the cached backend instead of creating a redundant one.

## Test plan

- [x] `uv run --package aegra-api pytest libs/aegra-api/tests/ -k "auth"` — 126 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Authentication backend is now cached so it initializes once per process, reducing repeated setup and improving runtime performance.

* **Tests**
  * Test fixture updated to clear the authentication backend cache before and after each test, ensuring isolation and more reliable test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/384)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR caches the `get_auth_backend()` function with `@functools.lru_cache(maxsize=1)` so the auth module is loaded (including file I/O and `importlib` import of `auth.py`) only once per process instead of on every request. `get_auth_instance()` is updated to delegate to the now-cached backend rather than carrying its own `@lru_cache`.

- `get_auth_backend()` gains `@functools.lru_cache(maxsize=1)`, eliminating repeated `aegra.json` reads and `importlib` module loads per request.
- `get_auth_instance()` loses its own `@lru_cache` and delegates to `get_auth_backend()`, keeping a single `Auth` instance across the process.
- Test fixture `clear_auth_cache` is updated to clear `get_auth_backend`'s cache (instead of the now-uncached `get_auth_instance`) before and after each test.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward caching optimization with no altered auth logic and correct test isolation via the updated fixture.

The only thing that changed is where the @lru_cache decorator lives. Auth logic, error handling, and the Auth instance lifecycle are all untouched. The conftest fixture is correctly updated to clear the right cache, maintaining per-test isolation.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/auth_middleware.py | Moves @lru_cache(maxsize=1) from get_auth_instance() to get_auth_backend() and updates get_auth_instance() to delegate; logic is correct and thread-safe. |
| libs/aegra-api/tests/conftest.py | Updates clear_auth_cache fixture to clear get_auth_backend cache instead of the now-uncached get_auth_instance; correctly maintains test isolation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(auth): add warning log for unreachab..."](https://github.com/aegra/aegra/commit/4f30d6d556bd61299b0e7708495c556d3b062cdc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32269570)</sub>

<!-- /greptile_comment -->