### PR TITLE
fix(api): call auth handlers in stream and wait run endpoints

### DIFF
--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.24"
+version = "0.9.25"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -41,6 +41,24 @@ logger = structlog.getLogger(__name__)
 DEFAULT_STREAM_MODES = ["values"]
 
 
+async def _apply_create_run_auth(user: User, thread_id: str, request: RunCreate) -> None:
+    """Authorize threads.create_run and merge config/context overrides into request.
+
+    Handler-returned filter dict wins; otherwise fall back to in-place value mutations.
+    """
+    ctx = build_auth_context(user, "threads", "create_run")
+    value = {**request.model_dump(), "thread_id": thread_id}
+    filters = await handle_event(ctx, value)
+
+    source = filters if filters is not None else value
+    config_overrides = source.get("config")
+    if isinstance(config_overrides, dict):
+        request.config = {**(request.config or {}), **config_overrides}
+    context_overrides = source.get("context")
+    if isinstance(context_overrides, dict):
+        request.context = {**(request.context or {}), **context_overrides}
+
+
 @router.post("/threads/{thread_id}/runs", response_model=Run, responses={**NOT_FOUND, **CONFLICT})
 async def create_run(
     thread_id: str,
@@ -59,25 +77,7 @@ async def create_run(
     if existing_thread and existing_thread.user_id != user.identity:
         raise HTTPException(404, f"Thread '{thread_id}' not found")
 
-    # Authorization check (create_run action on threads resource)
-    ctx = build_auth_context(user, "threads", "create_run")
-    value = {**request.model_dump(), "thread_id": thread_id}
-    filters = await handle_event(ctx, value)
-
-    # If handler modified config/context, update request
-    if filters:
-        if "config" in filters and isinstance(filters["config"], dict):
-            request.config = {**(request.config or {}), **filters["config"]}
-        if "context" in filters and isinstance(filters["context"], dict):
-            request.context = {**(request.context or {}), **filters["context"]}
-    else:
-        value_config = value.get("config")
-        if isinstance(value_config, dict):
-            request.config = {**(request.config or {}), **value_config}
-
-        value_context = value.get("context")
-        if isinstance(value_context, dict):
-            request.context = {**(request.context or {}), **value_context}
+    await _apply_create_run_auth(user, thread_id, request)
 
     _run_id, run, _job = await _prepare_run(session, thread_id, request, user, initial_status="pending")
 
@@ -109,6 +109,8 @@ async def create_and_stream_run(
         existing_thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == thread_id))
         if existing_thread and existing_thread.user_id != user.identity:
             raise HTTPException(404, f"Thread '{thread_id}' not found")
+
+        await _apply_create_run_auth(user, thread_id, request)
 
         run_id, run, _job = await _prepare_run(session, thread_id, request, user, initial_status="pending")
 
@@ -340,6 +342,8 @@ async def wait_for_run(
         existing_thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == thread_id))
         if existing_thread and existing_thread.user_id != user.identity:
             raise HTTPException(404, f"Thread '{thread_id}' not found")
+
+        await _apply_create_run_auth(user, thread_id, request)
 
         run_id, _run, _job = await _prepare_run(session, thread_id, request, user, initial_status="pending")
 

--- a/libs/aegra-api/tests/unit/test_api/test_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import pytest
 from fastapi import HTTPException
 
-from aegra_api.api.runs import create_run, get_run, join_run, list_runs, update_run
+from aegra_api.api.runs import _apply_create_run_auth, create_run, get_run, join_run, list_runs, update_run
 from aegra_api.core.orm import Assistant as AssistantORM
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
@@ -382,3 +382,58 @@ class TestRunsEndpoints:
 # Note: _resolve_context was removed from runs.py during the worker architecture
 # refactor — context resolution is now handled in services/run_preparation.py.
 # The equivalent tests live in tests/unit/test_services/.
+
+
+class TestApplyCreateRunAuth:
+    """Unit tests for the threads.create_run auth helper's config/context merge contract."""
+
+    @pytest.fixture
+    def mock_user(self) -> User:
+        return User(identity="test-user", scopes=[])
+
+    @pytest.mark.asyncio
+    async def test_empty_filter_dict_wins_over_value_mutations(self, mock_user: User) -> None:
+        """An explicit empty dict {} suppresses in-place value mutations.
+
+        Regression: ``filters if filters`` treated {} as falsy and fell back to
+        ``value``, applying in-place mutations despite the handler returning a dict.
+        """
+        request = RunCreate(assistant_id="a", input={}, config={"original": "kept"})
+
+        def _handler(_ctx: object, value: dict) -> dict:
+            value["config"] = {"injected_via_value": True}
+            return {}
+
+        with patch("aegra_api.api.runs.handle_event", new_callable=AsyncMock, side_effect=_handler):
+            await _apply_create_run_auth(mock_user, "t", request)
+
+        assert request.config == {"original": "kept"}
+
+    @pytest.mark.asyncio
+    async def test_none_result_falls_back_to_value_mutations(self, mock_user: User) -> None:
+        """A handler returning None applies its in-place value mutations."""
+        request = RunCreate(assistant_id="a", input={}, config={"original": "kept"})
+
+        def _handler(_ctx: object, value: dict) -> None:
+            value["config"] = {"injected_via_value": True}
+            return None
+
+        with patch("aegra_api.api.runs.handle_event", new_callable=AsyncMock, side_effect=_handler):
+            await _apply_create_run_auth(mock_user, "t", request)
+
+        assert request.config == {"original": "kept", "injected_via_value": True}
+
+    @pytest.mark.asyncio
+    async def test_filter_dict_overrides_merge_into_request(self, mock_user: User) -> None:
+        """Config/context keys in the returned filter dict merge over the request."""
+        request = RunCreate(assistant_id="a", input={}, config={"original": "kept"})
+
+        with patch(
+            "aegra_api.api.runs.handle_event",
+            new_callable=AsyncMock,
+            return_value={"config": {"injected": True}, "context": {"injected_ctx": 2}},
+        ):
+            await _apply_create_run_auth(mock_user, "t", request)
+
+        assert request.config == {"original": "kept", "injected": True}
+        assert request.context == {"injected_ctx": 2}

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -23,6 +23,11 @@ def _make_session_maker(session: AsyncMock) -> MagicMock:
     return MagicMock(return_value=ctx)
 
 
+async def _single_event_stream() -> AsyncGenerator:
+    """Minimal async generator standing in for the streaming service output."""
+    yield "data"
+
+
 class TestRunsStreamingEndpoints:
     """Test streaming run endpoints."""
 
@@ -223,6 +228,101 @@ class TestRunsStreamingEndpoints:
             assert handler is not None
             # Must not raise even though the broker side-effect blows up
             await handler({"type": "http.disconnect"})
+
+    @pytest.mark.asyncio
+    async def test_create_and_stream_run_invokes_create_run_auth_handler(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+    ) -> None:
+        """The threads.create_run auth handler must fire for the stream endpoint.
+
+        Regression for the silent skip: previously the streaming endpoint never
+        dispatched ``@auth.on.threads.create_run``, so handler-based usage
+        metering, throttling, or metadata injection silently no-op'd here.
+        """
+        thread_id = "t"
+        run_id = str(uuid4())
+        request = RunCreate(assistant_id="test-assistant", input={})
+
+        with (
+            patch("aegra_api.api.runs.handle_event", new_callable=AsyncMock) as mock_handle,
+            patch("aegra_api.api.runs._prepare_run", new_callable=AsyncMock) as mock_prepare,
+            patch("aegra_api.api.runs.streaming_service.stream_run_execution", return_value=_single_event_stream()),
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
+        ):
+            mock_session.scalar.return_value = None  # new thread passes ownership check
+            mock_handle.return_value = None  # default-allow
+            mock_prepare.return_value = (run_id, MagicMock(), MagicMock())
+
+            response = await create_and_stream_run(thread_id, request, mock_user)
+
+        assert response.status_code == 200
+        mock_handle.assert_awaited_once()
+        ctx, value = mock_handle.call_args[0]
+        assert ctx.resource == "threads"
+        assert ctx.action == "create_run"
+        assert value["thread_id"] == thread_id
+
+    @pytest.mark.asyncio
+    async def test_create_and_stream_run_auth_handler_denies_with_403(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+    ) -> None:
+        """A create_run handler that denies must abort the stream before run prep."""
+        thread_id = "t"
+        request = RunCreate(assistant_id="test-assistant", input={})
+
+        with (
+            patch("aegra_api.api.runs.handle_event", new_callable=AsyncMock) as mock_handle,
+            patch("aegra_api.api.runs._prepare_run", new_callable=AsyncMock) as mock_prepare,
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
+            pytest.raises(HTTPException) as exc,
+        ):
+            mock_session.scalar.return_value = None
+            mock_handle.side_effect = HTTPException(status_code=403, detail="forbidden")
+
+            await create_and_stream_run(thread_id, request, mock_user)
+
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "forbidden"
+        mock_prepare.assert_not_called()  # never reached run creation
+
+    @pytest.mark.asyncio
+    async def test_create_and_stream_run_auth_handler_merges_config_context(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+    ) -> None:
+        """Handler-returned config/context overrides merge into the run request."""
+        thread_id = "t"
+        run_id = str(uuid4())
+        request = RunCreate(
+            assistant_id="test-assistant",
+            input={},
+            config={"original": "kept"},
+            context={"orig_ctx": "kept"},
+        )
+
+        with (
+            patch("aegra_api.api.runs.handle_event", new_callable=AsyncMock) as mock_handle,
+            patch("aegra_api.api.runs._prepare_run", new_callable=AsyncMock) as mock_prepare,
+            patch("aegra_api.api.runs.streaming_service.stream_run_execution", return_value=_single_event_stream()),
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
+        ):
+            mock_session.scalar.return_value = None
+            mock_handle.return_value = {"config": {"injected": True}, "context": {"injected_ctx": 2}}
+            mock_prepare.return_value = (run_id, MagicMock(), MagicMock())
+
+            response = await create_and_stream_run(thread_id, request, mock_user)
+
+        assert response.status_code == 200
+        # Originals preserved, handler overrides merged on top.
+        assert request.config == {"original": "kept", "injected": True}
+        assert request.context == {"orig_ctx": "kept", "injected_ctx": 2}
+        # Merged request reached run preparation.
+        assert mock_prepare.call_args[0][2] is request
 
     @pytest.mark.asyncio
     async def test_stream_run_success(self, mock_user: User, mock_session: AsyncMock) -> None:

--- a/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
@@ -5,6 +5,7 @@ tests consume the body and parse the JSON result from the concatenated chunks.
 """
 
 import json
+from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -24,6 +25,11 @@ def _make_session_maker(session: AsyncMock) -> MagicMock:
     ctx.__aenter__ = AsyncMock(return_value=session)
     ctx.__aexit__ = AsyncMock(return_value=False)
     return MagicMock(return_value=ctx)
+
+
+async def _single_event_stream() -> AsyncGenerator:
+    """Minimal async generator standing in for the wait-response body."""
+    yield "data"
 
 
 def _make_multi_session_maker(*sessions: AsyncMock) -> MagicMock:
@@ -370,3 +376,97 @@ class TestWaitForRunExceptionPaths:
         assert response.media_type == "application/json"
         assert "Location" in response.headers
         assert f"/runs/{run_id}/join" in response.headers["Location"]
+
+
+class TestWaitForRunAuthHandlers:
+    """Regression coverage for the threads.create_run auth dispatch in wait_for_run.
+
+    ``@auth.on.threads.create_run`` was previously silently skipped on the wait
+    endpoint. These tests pin the dispatch (deny, merge, invocation) so the
+    auth bypass cannot silently return.
+    """
+
+    @pytest.mark.asyncio
+    async def test_wait_for_run_invokes_create_run_auth_handler(self) -> None:
+        """The threads.create_run handler must fire for the wait endpoint."""
+        thread_id = "t"
+        run_id = str(uuid4())
+        user = User(identity="test-user", scopes=[])
+        request = _make_request()
+
+        session = AsyncMock()
+        session.scalar.return_value = None  # new thread passes ownership check
+
+        with (
+            patch("aegra_api.api.runs.handle_event", new_callable=AsyncMock) as mock_handle,
+            patch("aegra_api.api.runs._prepare_run", new_callable=AsyncMock) as mock_prepare,
+            patch("aegra_api.api.runs.heartbeat_wait_body", return_value=_single_event_stream()),
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(session)),
+        ):
+            mock_handle.return_value = None  # default-allow
+            mock_prepare.return_value = (run_id, MagicMock(), MagicMock())
+
+            response = await wait_for_run(thread_id, request, user)
+
+        from fastapi.responses import StreamingResponse
+
+        assert isinstance(response, StreamingResponse)
+        mock_handle.assert_awaited_once()
+        ctx, value = mock_handle.call_args[0]
+        assert ctx.resource == "threads"
+        assert ctx.action == "create_run"
+        assert value["thread_id"] == thread_id
+
+    @pytest.mark.asyncio
+    async def test_wait_for_run_auth_handler_denies_with_403(self) -> None:
+        """A create_run handler that denies must abort the wait before run prep."""
+        thread_id = "t"
+        user = User(identity="test-user", scopes=[])
+        request = _make_request()
+
+        session = AsyncMock()
+        session.scalar.return_value = None
+
+        with (
+            patch("aegra_api.api.runs.handle_event", new_callable=AsyncMock) as mock_handle,
+            patch("aegra_api.api.runs._prepare_run", new_callable=AsyncMock) as mock_prepare,
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(session)),
+            pytest.raises(HTTPException) as exc,
+        ):
+            mock_handle.side_effect = HTTPException(status_code=403, detail="forbidden")
+
+            await wait_for_run(thread_id, request, user)
+
+        assert exc.value.status_code == 403
+        assert exc.value.detail == "forbidden"
+        mock_prepare.assert_not_called()  # never reached run creation
+
+    @pytest.mark.asyncio
+    async def test_wait_for_run_auth_handler_merges_config_context(self) -> None:
+        """Handler-returned config/context overrides merge into the run request."""
+        thread_id = "t"
+        run_id = str(uuid4())
+        user = User(identity="test-user", scopes=[])
+        request = _make_request()
+        request.config = {"original": "kept"}
+        request.context = {"orig_ctx": "kept"}
+
+        session = AsyncMock()
+        session.scalar.return_value = None
+
+        with (
+            patch("aegra_api.api.runs.handle_event", new_callable=AsyncMock) as mock_handle,
+            patch("aegra_api.api.runs._prepare_run", new_callable=AsyncMock) as mock_prepare,
+            patch("aegra_api.api.runs.heartbeat_wait_body", return_value=_single_event_stream()),
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(session)),
+        ):
+            mock_handle.return_value = {"config": {"injected": True}, "context": {"injected_ctx": 2}}
+            mock_prepare.return_value = (run_id, MagicMock(), MagicMock())
+
+            await wait_for_run(thread_id, request, user)
+
+        # Originals preserved, handler overrides merged on top.
+        assert request.config == {"original": "kept", "injected": True}
+        assert request.context == {"orig_ctx": "kept", "injected_ctx": 2}
+        # Merged request reached run preparation.
+        assert mock_prepare.call_args[0][2] is request

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.24"
+version = "0.9.25"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.24"
+version = "0.9.25"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.24"
+version = "0.9.25"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary

- The `create_and_stream_run` (`POST /threads/{id}/runs/stream`) and `wait_for_run` (`POST /threads/{id}/runs/wait`) endpoints were missing the `handle_event` call for the `threads.create_run` auth action.
- This meant `@auth.on.threads.create_run` handlers were only invoked for the non-streaming `POST /threads/{id}/runs` endpoint, but silently skipped for the streaming and wait variants.
- This broke any authorization logic registered via `@auth.on.threads.create_run` (e.g. usage tracking, rate limiting, metadata injection) when using the streaming endpoint.

## Changes

Added the same `build_auth_context` + `handle_event` + config/context merge pattern (already present in `create_run`) to both `create_and_stream_run` and `wait_for_run`.

## Test plan

- [x] Verify `@auth.on.threads.create_run` handler is called when using `POST /threads/{id}/runs/stream`
- [x] Verify `@auth.on.threads.create_run` handler is called when using `POST /threads/{id}/runs/wait`
- [x] Verify handler can reject requests (returns False or raises HTTPException)
- [x] Verify handler can modify config/context via return dict
- [x] Verify existing `POST /threads/{id}/runs` behavior is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run management (create, streaming, and wait) now honors `config`/`context` overrides returned by authorization handlers during run initialization, including correct precedence rules.
* **Bug Fixes**
  * Authorization denials (403) now consistently halt run preparation before it proceeds.
  * Empty handler returns no longer trigger unintended fallback behavior for `config`/`context`.
* **Tests**
  * Added unit coverage for handler dispatch, denial behavior, and `config`/`context` merging across streaming and wait flows.
* **Chores**
  * Version bumps for both the API and CLI (0.9.24 → 0.9.25).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR consistently applies create-run authorization across all threaded run creation variants.
- Extracts the authorization and config/context override logic into a shared helper.
- Calls the helper from standard, streaming, and wait run endpoints.
- Adds regression coverage for handler invocation, denial, and override semantics.
- Keeps API and CLI package versions synchronized at 0.9.25.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previous missing-test and duplicated-auth-logic findings are addressed by endpoint regression coverage and the shared authorization helper.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/runs.py | Centralizes create-run authorization and applies it before preparation in all three run creation endpoints. |
| libs/aegra-api/tests/unit/test_api/test_runs.py | Covers the shared helper's returned-filter and in-place mutation semantics. |
| libs/aegra-api/tests/unit/test_api/test_runs_streaming.py | Adds streaming endpoint regression tests for authorization invocation, denial, and request overrides. |
| libs/aegra-api/tests/unit/test_api/test_runs_wait.py | Adds wait endpoint regression tests for authorization invocation, denial, and request overrides. |
| libs/aegra-api/pyproject.toml | Bumps the API package version to 0.9.25. |
| libs/aegra-cli/pyproject.toml | Keeps the CLI package version synchronized at 0.9.25. |
| uv.lock | Synchronizes workspace package metadata with the new API and CLI versions. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant RunsAPI
    participant AuthHandler
    participant RunPreparation

    Client->>RunsAPI: Create, stream, or wait for run
    RunsAPI->>AuthHandler: threads.create_run
    alt Request denied
        AuthHandler-->>Client: 403 Forbidden
    else Request allowed
        AuthHandler-->>RunsAPI: Config/context overrides
        RunsAPI->>RunPreparation: Prepare merged request
        RunPreparation-->>Client: Run response or stream
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/stream-endp..."](https://github.com/aegra/aegra/commit/460d10c20b6fa0a8a2dca61158ec038f04e8563f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32440260)</sub>

**Context used:**

- Knowledge Base — [Authentication and Authorization](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/auth.md)
- Knowledge Base — [Threads and Runs](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/threads-and-runs.md)

<!-- /greptile_comment -->