### PR TITLE
feat(auth): inject path/method into @auth.authenticate handlers

### DIFF
--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -8,7 +8,9 @@ using Starlette's AuthenticationMiddleware.
 import functools
 import importlib
 import importlib.util
+import inspect
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +31,106 @@ from aegra_api.models.errors import AgentProtocolError
 from aegra_api.settings import settings
 
 logger = structlog.getLogger(__name__)
+
+
+def _headers_from_connection(conn: HTTPConnection) -> dict[str, str]:
+    """Normalize Starlette headers to ``str -> str`` for auth handlers."""
+    return {
+        key.decode() if isinstance(key, bytes) else key: value.decode() if isinstance(value, bytes) else value
+        for key, value in conn.headers.items()
+    }
+
+
+def _authorization_from_headers(headers: dict[str, str]) -> str | None:
+    return headers.get("authorization") or headers.get("Authorization")
+
+
+def _authenticate_kwargs_for_handler(
+    conn: HTTPConnection,
+    handler: Callable[..., Any],
+) -> dict[str, Any]:
+    """Build kwargs for ``@auth.authenticate`` using LangGraph SDK inject-by-name rules.
+
+    See ``langgraph_sdk.auth.types.Authenticator`` — supported parameter names:
+    ``request``, ``body``, ``path``, ``method``, ``path_params``, ``query_params``,
+    ``headers``, ``authorization``.
+
+    Handlers that only declare ``headers`` (Aegra's historical contract) keep
+    receiving only that argument.
+    """
+    headers = _headers_from_connection(conn)
+    scope = getattr(conn, "scope", None) or {}
+    path_params = scope.get("path_params") or {}
+    if not isinstance(path_params, dict):
+        path_params = dict(path_params)
+
+    url = getattr(conn, "url", None)
+    path = getattr(url, "path", "/") if url is not None else "/"
+
+    candidates: dict[str, Any] = {
+        "headers": headers,
+        "path": path,
+        "method": scope.get("method", "GET"),
+        "path_params": path_params,
+        "query_params": dict(getattr(conn, "query_params", {})),
+        "authorization": _authorization_from_headers(headers),
+        # Request body is not consumed here; match LangGraph API behavior for auth hooks.
+        "body": {},
+        "request": conn,
+    }
+
+    try:
+        sig = inspect.signature(handler)
+    except (TypeError, ValueError):
+        return {"headers": headers}
+
+    kwargs: dict[str, Any] = {}
+
+    for name, param in sig.parameters.items():
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            continue
+        if param.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ) and name in candidates:
+            value = candidates[name]
+            if name == "request":
+                from starlette.requests import Request
+
+                receive = getattr(conn, "receive", None)
+                send = getattr(conn, "send", None)
+                value = Request(scope, receive, send)
+            kwargs[name] = value
+
+    # Legacy handlers: single ``headers`` parameter (positional or keyword).
+    if not kwargs:
+        params = [
+            p
+            for p in sig.parameters.values()
+            if p.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+        ]
+        if len(params) == 1 and params[0].name == "headers":
+            kwargs["headers"] = headers
+
+    return kwargs
+
+
+async def _call_authenticate_handler(
+    handler: Callable[..., Any],
+    conn: HTTPConnection,
+) -> Any:
+    """Invoke the user's ``@auth.authenticate`` handler with injected request context."""
+    kwargs = _authenticate_kwargs_for_handler(conn, handler)
+    result = handler(**kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 class LangGraphUser(BaseUser):
@@ -240,14 +342,10 @@ class LangGraphAuthBackend(AuthenticationBackend):
             return None
 
         try:
-            # Convert headers to dict format expected by auth handlers
-            headers = {
-                key.decode() if isinstance(key, bytes) else key: value.decode() if isinstance(value, bytes) else value
-                for key, value in conn.headers.items()
-            }
-
-            # Call the authenticate handler
-            user_data = await self.auth_instance._authenticate_handler(headers)
+            user_data = await _call_authenticate_handler(
+                self.auth_instance._authenticate_handler,
+                conn,
+            )
 
             if not user_data or not isinstance(user_data, dict):
                 raise AuthenticationError("Invalid user data returned from auth handler")

--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -42,6 +42,7 @@ def _headers_from_connection(conn: HTTPConnection) -> dict[str, str]:
 
 
 def _authorization_from_headers(headers: dict[str, str]) -> str | None:
+    """Return the ``Authorization`` header value, if present."""
     return headers.get("authorization") or headers.get("Authorization")
 
 

--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -49,20 +49,20 @@ def _authenticate_kwargs_for_handler(
     conn: HTTPConnection,
     handler: Callable[..., Any],
 ) -> dict[str, Any]:
-    """Build kwargs for ``@auth.authenticate`` using LangGraph SDK inject-by-name rules.
+    """Build kwargs for ``@auth.authenticate`` using inject-by-name rules.
 
-    See ``langgraph_sdk.auth.types.Authenticator`` — supported parameter names:
-    ``request``, ``body``, ``path``, ``method``, ``path_params``, ``query_params``,
-    ``headers``, ``authorization``.
+    Aegra injects only a focused subset of ``langgraph_sdk`` Authenticator
+    parameters — enough for route-aware auth without exposing ``request`` or
+    ``body`` (reading the ASGI body in middleware would break downstream handlers).
+
+    Supported parameter names: ``path``, ``method``, ``headers``,
+    ``authorization``.
 
     Handlers that only declare ``headers`` (Aegra's historical contract) keep
     receiving only that argument.
     """
     headers = _headers_from_connection(conn)
     scope = getattr(conn, "scope", None) or {}
-    path_params = scope.get("path_params") or {}
-    if not isinstance(path_params, dict):
-        path_params = dict(path_params)
 
     url = getattr(conn, "url", None)
     path = getattr(url, "path", "/") if url is not None else "/"
@@ -71,12 +71,7 @@ def _authenticate_kwargs_for_handler(
         "headers": headers,
         "path": path,
         "method": scope.get("method", "GET"),
-        "path_params": path_params,
-        "query_params": dict(getattr(conn, "query_params", {})),
         "authorization": _authorization_from_headers(headers),
-        # Request body is not consumed here; match LangGraph API behavior for auth hooks.
-        "body": {},
-        "request": conn,
     }
 
     try:
@@ -94,29 +89,7 @@ def _authenticate_kwargs_for_handler(
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
             inspect.Parameter.KEYWORD_ONLY,
         ) and name in candidates:
-            value = candidates[name]
-            if name == "request":
-                from starlette.requests import Request
-
-                receive = getattr(conn, "receive", None)
-                send = getattr(conn, "send", None)
-                value = Request(scope, receive, send)
-            kwargs[name] = value
-
-    # Legacy handlers: single ``headers`` parameter (positional or keyword).
-    if not kwargs:
-        params = [
-            p
-            for p in sig.parameters.values()
-            if p.kind
-            in (
-                inspect.Parameter.POSITIONAL_ONLY,
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                inspect.Parameter.KEYWORD_ONLY,
-            )
-        ]
-        if len(params) == 1 and params[0].name == "headers":
-            kwargs["headers"] = headers
+            kwargs[name] = candidates[name]
 
     return kwargs
 

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -12,9 +12,21 @@ from starlette.responses import JSONResponse
 from aegra_api.core.auth_middleware import (
     LangGraphAuthBackend,
     LangGraphUser,
+    _authenticate_kwargs_for_handler,
+    _call_authenticate_handler,
     get_auth_backend,
     on_auth_error,
 )
+
+
+def _http_connection(headers: dict) -> Mock:
+    """Minimal HTTPConnection mock with fields used by auth injection."""
+    mock_conn = Mock(spec=HTTPConnection)
+    mock_conn.headers = headers
+    mock_conn.scope = {"method": "GET", "path_params": {}}
+    mock_conn.url = Mock(path="/")
+    mock_conn.query_params = {}
+    return mock_conn
 
 
 class TestLangGraphUser:
@@ -267,11 +279,10 @@ class TestLangGraphAuthBackend:
         backend = LangGraphAuthBackend()
         backend.auth_instance = mock_auth_instance
 
-        mock_conn = Mock(spec=HTTPConnection)
-        mock_conn.headers = {
+        mock_conn = _http_connection({
             "authorization": b"Bearer token123",
             "content-type": b"application/json",
-        }
+        })
 
         credentials, user = await backend.authenticate(mock_conn)
 
@@ -292,8 +303,7 @@ class TestLangGraphAuthBackend:
         backend = LangGraphAuthBackend()
         backend.auth_instance = mock_auth_instance
 
-        mock_conn = Mock(spec=HTTPConnection)
-        mock_conn.headers = {"authorization": b"Bearer token123"}
+        mock_conn = _http_connection({"authorization": b"Bearer token123"})
 
         credentials, user = await backend.authenticate(mock_conn)
 
@@ -308,8 +318,7 @@ class TestLangGraphAuthBackend:
         backend = LangGraphAuthBackend()
         backend.auth_instance = mock_auth_instance
 
-        mock_conn = Mock(spec=HTTPConnection)
-        mock_conn.headers = {"authorization": b"Bearer token123"}
+        mock_conn = _http_connection({"authorization": b"Bearer token123"})
 
         with pytest.raises(AuthenticationError, match="Authentication system error"):
             await backend.authenticate(mock_conn)
@@ -323,8 +332,7 @@ class TestLangGraphAuthBackend:
         backend = LangGraphAuthBackend()
         backend.auth_instance = mock_auth_instance
 
-        mock_conn = Mock(spec=HTTPConnection)
-        mock_conn.headers = {"authorization": b"Bearer token123"}
+        mock_conn = _http_connection({"authorization": b"Bearer token123"})
 
         with pytest.raises(AuthenticationError, match="Authentication system error"):
             await backend.authenticate(mock_conn)
@@ -346,8 +354,7 @@ class TestLangGraphAuthBackend:
         with patch("aegra_api.core.auth_middleware.Auth") as mock_auth:
             mock_auth.exceptions.HTTPException = Exception
 
-            mock_conn = Mock(spec=HTTPConnection)
-            mock_conn.headers = {"authorization": b"Bearer token123"}
+            mock_conn = _http_connection({"authorization": b"Bearer token123"})
 
             with pytest.raises(AuthenticationError, match="Invalid token"):
                 await backend.authenticate(mock_conn)
@@ -355,28 +362,116 @@ class TestLangGraphAuthBackend:
     @pytest.mark.asyncio
     async def test_authenticate_headers_conversion(self):
         """Test header conversion for different types"""
+        captured: dict = {}
+
+        async def authenticate(headers: dict) -> dict:
+            captured["headers"] = headers
+            return {"identity": "user-123"}
+
         mock_auth_instance = Mock()
-        mock_auth_instance._authenticate_handler = AsyncMock(return_value={"identity": "user-123"})
+        mock_auth_instance._authenticate_handler = authenticate
 
         backend = LangGraphAuthBackend()
         backend.auth_instance = mock_auth_instance
 
-        mock_conn = Mock(spec=HTTPConnection)
-        mock_conn.headers = {
+        mock_conn = _http_connection({
             b"authorization": b"Bearer token123",  # bytes key and value
             "content-type": "application/json",  # str key and value
             b"user-agent": "test-agent",  # bytes key, str value
-        }
+        })
 
         await backend.authenticate(mock_conn)
 
-        # Verify headers were converted properly
         expected_headers = {
             "authorization": "Bearer token123",
             "content-type": "application/json",
             "user-agent": "test-agent",
         }
-        mock_auth_instance._authenticate_handler.assert_called_once_with(expected_headers)
+        assert captured["headers"] == expected_headers
+
+
+class TestAuthenticateHandlerInjection:
+    """LangGraph SDK inject-by-name support for @auth.authenticate handlers."""
+
+    def _mock_connection(
+        self,
+        *,
+        path: str = "/threads/t1/runs/wait",
+        method: str = "POST",
+        path_params: dict | None = None,
+        headers: dict | None = None,
+    ) -> Mock:
+        mock_conn = Mock(spec=HTTPConnection)
+        mock_conn.url = Mock()
+        mock_conn.url.path = path
+        mock_conn.scope = {
+            "method": method,
+            "path_params": path_params or {"thread_id": "t1"},
+        }
+        mock_conn.query_params = {}
+        mock_conn.headers = headers or {b"authorization": b"Bearer tok"}
+        mock_conn.receive = Mock()
+        mock_conn.send = Mock()
+        return mock_conn
+
+    def test_kwargs_headers_only_signature(self):
+        async def authenticate(headers: dict) -> dict:
+            return {"identity": "x"}
+
+        conn = self._mock_connection()
+        kwargs = _authenticate_kwargs_for_handler(conn, authenticate)
+        assert set(kwargs.keys()) == {"headers"}
+        assert kwargs["headers"]["authorization"] == "Bearer tok"
+
+    def test_kwargs_path_method_included_when_declared(self):
+        seen: dict = {}
+
+        async def authenticate(method: str, path: str, headers: dict) -> dict:
+            seen["method"] = method
+            seen["path"] = path
+            seen["headers"] = headers
+            return {"identity": "x"}
+
+        conn = self._mock_connection(path="/assistants/search", method="POST")
+        kwargs = _authenticate_kwargs_for_handler(conn, authenticate)
+        assert kwargs["method"] == "POST"
+        assert kwargs["path"] == "/assistants/search"
+        assert "headers" in kwargs
+
+    @pytest.mark.asyncio
+    async def test_call_authenticate_handler_invokes_with_path(self):
+        captured: dict = {}
+
+        async def authenticate(method: str, path: str, headers: dict) -> dict:
+            captured["method"] = method
+            captured["path"] = path
+            return {"identity": "user-1"}
+
+        conn = self._mock_connection(path="/runs/wait", method="POST")
+        result = await _call_authenticate_handler(authenticate, conn)
+        assert result["identity"] == "user-1"
+        assert captured["method"] == "POST"
+        assert captured["path"] == "/runs/wait"
+
+    @pytest.mark.asyncio
+    async def test_backend_passes_path_to_multi_arg_handler(self):
+        captured: dict = {}
+
+        async def authenticate(method: str, path: str, headers: dict) -> dict:
+            captured["path"] = path
+            return {"identity": "user-1"}
+
+        mock_auth_instance = Mock()
+        mock_auth_instance._authenticate_handler = authenticate
+
+        backend = LangGraphAuthBackend()
+        backend.auth_instance = mock_auth_instance
+
+        conn = self._mock_connection(path="/threads/abc/runs/wait", method="POST")
+        credentials, user = await backend.authenticate(conn)
+        assert user.identity == "user-1"
+        assert captured["path"] == "/threads/abc/runs/wait"
+        assert isinstance(credentials, AuthCredentials)
 
 
 class TestGetAuthBackend:
@@ -475,11 +570,10 @@ class TestAuthMiddlewareIntegration:
         backend.auth_instance = mock_auth_instance
 
         # Mock connection
-        mock_conn = Mock(spec=HTTPConnection)
-        mock_conn.headers = {
+        mock_conn = _http_connection({
             "authorization": "Bearer valid-token",
             "content-type": "application/json",
-        }
+        })
 
         # Authenticate
         credentials, user = await backend.authenticate(mock_conn)
@@ -509,8 +603,7 @@ class TestAuthMiddlewareIntegration:
         backend = LangGraphAuthBackend()
         backend.auth_instance = mock_auth_instance
 
-        mock_conn = Mock(spec=HTTPConnection)
-        mock_conn.headers = {"authorization": "Bearer invalid-token"}
+        mock_conn = _http_connection({"authorization": "Bearer invalid-token"})
 
         # Should raise AuthenticationError
         with pytest.raises(AuthenticationError):

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -424,19 +424,38 @@ class TestAuthenticateHandlerInjection:
         assert kwargs["headers"]["authorization"] == "Bearer tok"
 
     def test_kwargs_path_method_included_when_declared(self):
-        seen: dict = {}
-
         async def authenticate(method: str, path: str, headers: dict) -> dict:
-            seen["method"] = method
-            seen["path"] = path
-            seen["headers"] = headers
             return {"identity": "x"}
 
         conn = self._mock_connection(path="/assistants/search", method="POST")
         kwargs = _authenticate_kwargs_for_handler(conn, authenticate)
-        assert kwargs["method"] == "POST"
-        assert kwargs["path"] == "/assistants/search"
-        assert "headers" in kwargs
+        assert kwargs == {
+            "method": "POST",
+            "path": "/assistants/search",
+            "headers": {"authorization": "Bearer tok"},
+        }
+
+    def test_request_and_body_not_injected(self):
+        """``request`` / ``body`` are intentionally unsupported in middleware auth."""
+
+        async def authenticate(request, body: dict, headers: dict) -> dict:
+            return {"identity": "x"}
+
+        conn = self._mock_connection()
+        kwargs = _authenticate_kwargs_for_handler(conn, authenticate)
+        assert set(kwargs.keys()) == {"headers"}
+
+    def test_path_params_and_query_params_not_injected(self):
+        async def authenticate(
+            path_params: dict,
+            query_params: dict,
+            headers: dict,
+        ) -> dict:
+            return {"identity": "x"}
+
+        conn = self._mock_connection()
+        kwargs = _authenticate_kwargs_for_handler(conn, authenticate)
+        assert set(kwargs.keys()) == {"headers"}
 
     @pytest.mark.asyncio
     async def test_call_authenticate_handler_invokes_with_path(self):

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -20,7 +20,7 @@ from aegra_api.core.auth_middleware import (
 
 
 def _http_connection(headers: dict) -> Mock:
-    """Minimal HTTPConnection mock with fields used by auth injection."""
+    """Build a minimal ``HTTPConnection`` mock for auth middleware tests."""
     mock_conn = Mock(spec=HTTPConnection)
     mock_conn.headers = headers
     mock_conn.scope = {"method": "GET", "path_params": {}}
@@ -365,6 +365,7 @@ class TestLangGraphAuthBackend:
         captured: dict = {}
 
         async def authenticate(headers: dict) -> dict:
+            """Record headers passed by the auth backend."""
             captured["headers"] = headers
             return {"identity": "user-123"}
 
@@ -401,6 +402,7 @@ class TestAuthenticateHandlerInjection:
         path_params: dict | None = None,
         headers: dict | None = None,
     ) -> Mock:
+        """Build an ``HTTPConnection`` mock with path/method scope fields."""
         mock_conn = Mock(spec=HTTPConnection)
         mock_conn.url = Mock()
         mock_conn.url.path = path
@@ -416,6 +418,7 @@ class TestAuthenticateHandlerInjection:
 
     def test_kwargs_headers_only_signature(self):
         async def authenticate(headers: dict) -> dict:
+            """Headers-only handler stub."""
             return {"identity": "x"}
 
         conn = self._mock_connection()
@@ -425,6 +428,7 @@ class TestAuthenticateHandlerInjection:
 
     def test_kwargs_path_method_included_when_declared(self):
         async def authenticate(method: str, path: str, headers: dict) -> dict:
+            """Handler stub that declares path and method."""
             return {"identity": "x"}
 
         conn = self._mock_connection(path="/assistants/search", method="POST")
@@ -439,6 +443,7 @@ class TestAuthenticateHandlerInjection:
         """``request`` / ``body`` are intentionally unsupported in middleware auth."""
 
         async def authenticate(request, body: dict, headers: dict) -> dict:
+            """Handler stub declaring unsupported request/body params."""
             return {"identity": "x"}
 
         conn = self._mock_connection()
@@ -451,6 +456,7 @@ class TestAuthenticateHandlerInjection:
             query_params: dict,
             headers: dict,
         ) -> dict:
+            """Handler stub declaring unsupported path/query params."""
             return {"identity": "x"}
 
         conn = self._mock_connection()
@@ -462,6 +468,7 @@ class TestAuthenticateHandlerInjection:
         captured: dict = {}
 
         async def authenticate(method: str, path: str, headers: dict) -> dict:
+            """Capture path/method from injected kwargs."""
             captured["method"] = method
             captured["path"] = path
             return {"identity": "user-1"}
@@ -477,6 +484,7 @@ class TestAuthenticateHandlerInjection:
         captured: dict = {}
 
         async def authenticate(method: str, path: str, headers: dict) -> dict:
+            """Capture path from backend authenticate flow."""
             captured["path"] = path
             return {"identity": "user-1"}
 

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -463,6 +463,40 @@ class TestAuthenticateHandlerInjection:
         kwargs = _authenticate_kwargs_for_handler(conn, authenticate)
         assert set(kwargs.keys()) == {"headers"}
 
+    def test_signature_errors_fallback_to_headers_only(self):
+        """When signature inspection fails, kwargs fall back to headers only."""
+
+        async def authenticate(headers: dict) -> dict:
+            """Headers-only handler stub."""
+            return {"identity": "x"}
+
+        conn = self._mock_connection()
+        with patch("aegra_api.core.auth_middleware.inspect.signature", side_effect=ValueError):
+            kwargs = _authenticate_kwargs_for_handler(conn, authenticate)
+        assert kwargs == {"headers": {"authorization": "Bearer tok"}}
+
+    @pytest.mark.asyncio
+    async def test_call_authenticate_handler_supports_sync_handler(self):
+        """Synchronous handlers should return through the non-awaitable branch."""
+
+        def authenticate(method: str, path: str, headers: dict) -> dict:
+            """Sync handler stub for non-awaitable path."""
+            return {
+                "identity": "sync-user",
+                "method": method,
+                "path": path,
+                "authorization": headers.get("authorization"),
+            }
+
+        conn = self._mock_connection(path="/runs/wait", method="POST")
+        result = await _call_authenticate_handler(authenticate, conn)
+        assert result == {
+            "identity": "sync-user",
+            "method": "POST",
+            "path": "/runs/wait",
+            "authorization": "Bearer tok",
+        }
+
     @pytest.mark.asyncio
     async def test_call_authenticate_handler_invokes_with_path(self):
         captured: dict = {}

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -463,7 +463,8 @@ class TestAuthenticateHandlerInjection:
         kwargs = _authenticate_kwargs_for_handler(conn, authenticate)
         assert set(kwargs.keys()) == {"headers"}
 
-    def test_signature_errors_fallback_to_headers_only(self):
+    @pytest.mark.parametrize("sig_exc", [ValueError, TypeError])
+    def test_signature_errors_fallback_to_headers_only(self, sig_exc):
         """When signature inspection fails, kwargs fall back to headers only."""
 
         async def authenticate(headers: dict) -> dict:
@@ -471,7 +472,7 @@ class TestAuthenticateHandlerInjection:
             return {"identity": "x"}
 
         conn = self._mock_connection()
-        with patch("aegra_api.core.auth_middleware.inspect.signature", side_effect=ValueError):
+        with patch("aegra_api.core.auth_middleware.inspect.signature", side_effect=sig_exc):
             kwargs = _authenticate_kwargs_for_handler(conn, authenticate)
         assert kwargs == {"headers": {"authorization": "Bearer tok"}}
 


### PR DESCRIPTION
Match langgraph-sdk `Authenticator` inject-by-name semantics so custom auth handlers can branch on request path/method. Preserves existing headers-only handler signatures.

## Description

Aegra's `LangGraphAuthBackend` previously called `@auth.authenticate` handlers with only a `headers` dict, even though **langgraph-sdk** documents inject-by-name support for `path`, `method`, `path_params`, `query_params`, `authorization`, `request`, and `body`.

This change adds `_authenticate_kwargs_for_handler` and `_call_authenticate_handler` so the backend passes only the parameters declared on the handler signature—aligned with `langgraph_sdk.auth.types.Authenticator`.

**Backward compatible:** handlers that only declare `headers` (Aegra's existing pattern) still receive only `headers`; no changes required for existing auth modules.

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues

N/A — enables route-aware `@auth.authenticate` handlers.

## Changes Made

- Add `_headers_from_connection`, `_authenticate_kwargs_for_handler`, and `_call_authenticate_handler` in `auth_middleware.py`
- Replace direct `_authenticate_handler(headers)` with inject-by-name invocation
- Inject `path`, `method`, `path_params`, `query_params`, `authorization`, `request`, and `body` when the handler signature requests them
- Map `request` to Starlette `Request` when declared
- Use `body={}` at auth time (body not consumed in middleware)
- Extend unit tests for injection behavior and headers-only backward compatibility

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

```bash
cd libs/aegra-api && uv run pytest tests/unit/test_core/test_auth_middleware.py -q
# 38 passed
```

## Checklist
<!-- Ensure all items are checked before requesting review -->
- [ ] Code follows project style (Ruff formatting)
- [ ] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`)
- [ ] All tests pass (`make test`)
- [ ] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->
N/A — server-side auth only.

## Additional Notes
<!-- Any additional information for reviewers -->
Example handler after this change:
```python
@auth.authenticate
async def authenticate(method: str, path: str, headers: dict) -> dict:
    if path.endswith("/runs/wait"):
        ...
    if path.startswith("/assistants"):
        ...
    return {"identity": "...", ...}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Authentication handlers can be synchronous or asynchronous and now receive richer request context (headers, method, path) only when declared; legacy behavior preserved.
  * Request headers are normalized robustly and handler invocation is limited to declared parameter names for safer execution.
  * Improved handling and reporting of authentication failures.

* **Tests**
  * Expanded unit and integration tests covering header normalization, parameter injection, sync/async handlers, and full auth success/error flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds inject-by-name semantics to `@auth.authenticate` handlers in `LangGraphAuthBackend`, mirroring the langgraph-sdk `Authenticator` interface. The three new helpers (`_headers_from_connection`, `_authenticate_kwargs_for_handler`, `_call_authenticate_handler`) inspect the handler's declared parameter names and pass only the matching subset of `path`, `method`, `headers`, and `authorization` — keeping both sync and async handlers working without breaking existing headers-only handlers.

- `_authenticate_kwargs_for_handler` builds a safe candidates dict scoped to four supported keys (`path`, `method`, `headers`, `authorization`); `request`, `body`, `path_params`, and `query_params` are intentionally excluded to prevent ASGI body exhaustion and stay consistent with the docstring's stated contract.
- `_call_authenticate_handler` adds transparent sync/async dispatch via `inspect.isawaitable`, and the signature-inspection failure path falls back to headers-only, preserving backward compatibility.
- Test suite is extended with a dedicated `TestAuthenticateHandlerInjection` class covering injection, exclusion, fallback, and end-to-end backend flow.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The inject-by-name dispatch is narrowly scoped, backward-compatible, and the tests exercise all the edge cases.

The implementation correctly limits the candidates dict to four safe keys with no ASGI body consumption risk. The only finding is a stale bullet list in the PR description that does not affect runtime behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/auth_middleware.py | Adds three helper functions for inject-by-name auth dispatch; candidates dict is narrowly scoped to `path`, `method`, `headers`, `authorization` — `request`/`body` are intentionally absent. Logic is correct and backward-compatible. |
| libs/aegra-api/tests/unit/test_core/test_auth_middleware.py | Adds `TestAuthenticateHandlerInjection` with good coverage of headers-only backward compat, path/method injection, unsupported-param exclusion, signature-error fallback, and sync/async dispatch. Existing tests refactored to real functions for better fidelity. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant MW as Starlette AuthMiddleware
    participant BE as LangGraphAuthBackend.authenticate()
    participant KW as _authenticate_kwargs_for_handler()
    participant CH as _call_authenticate_handler()
    participant H as @auth.authenticate handler

    MW->>BE: authenticate(conn)
    BE->>CH: _call_authenticate_handler(handler, conn)
    CH->>KW: _authenticate_kwargs_for_handler(conn, handler)
    KW->>KW: _headers_from_connection(conn)
    KW->>KW: inspect.signature(handler)
    note over KW: Build candidates {headers, path, method, authorization}
    KW-->>CH: kwargs dict (subset of candidates)
    CH->>H: "handler(**kwargs)"
    note over CH: Supports sync and async via isawaitable()
    H-->>CH: user_data dict
    CH-->>BE: user_data
    BE-->>MW: (AuthCredentials, LangGraphUser)
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%3A53-63%0A**PR%20description%20diverges%20from%20the%20actual%20supported%20parameter%20set**%0A%0AThe%20%22Changes%20Made%22%20section%20of%20the%20PR%20description%20lists%20%60path_params%60%2C%20%60query_params%60%2C%20%60request%60%2C%20and%20%60body%60%20as%20injected%20parameters%2C%20and%20also%20mentions%20%60Map%20request%20to%20Starlette%20Request%20when%20declared%60%20and%20%60Use%20body%3D%7B%7D%60.%20None%20of%20those%20four%20are%20in%20%60candidates%60%2C%20and%20the%20tests%20%60test_request_and_body_not_injected%60%20%2F%20%60test_path_params_and_query_params_not_injected%60%20confirm%20they%20are%20intentionally%20excluded.%20Additionally%2C%20%60headers%60%20is%20not%20mentioned%20in%20the%20PR%20description%20at%20all%2C%20even%20though%20it%20is%20the%20primary%20supported%20key.%20The%20code's%20docstring%20here%20is%20accurate%3B%20the%20PR%20description%20is%20not%20and%20may%20mislead%20future%20contributors%20who%20read%20one%20without%20the%20other.%0A%0A&repo=aegra%2Faegra&pr=389&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%3A53-63%0A**PR%20description%20diverges%20from%20the%20actual%20supported%20parameter%20set**%0A%0AThe%20%22Changes%20Made%22%20section%20of%20the%20PR%20description%20lists%20%60path_params%60%2C%20%60query_params%60%2C%20%60request%60%2C%20and%20%60body%60%20as%20injected%20parameters%2C%20and%20also%20mentions%20%60Map%20request%20to%20Starlette%20Request%20when%20declared%60%20and%20%60Use%20body%3D%7B%7D%60.%20None%20of%20those%20four%20are%20in%20%60candidates%60%2C%20and%20the%20tests%20%60test_request_and_body_not_injected%60%20%2F%20%60test_path_params_and_query_params_not_injected%60%20confirm%20they%20are%20intentionally%20excluded.%20Additionally%2C%20%60headers%60%20is%20not%20mentioned%20in%20the%20PR%20description%20at%20all%2C%20even%20though%20it%20is%20the%20primary%20supported%20key.%20The%20code's%20docstring%20here%20is%20accurate%3B%20the%20PR%20description%20is%20not%20and%20may%20mislead%20future%20contributors%20who%20read%20one%20without%20the%20other.%0A%0A&pr=389&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fauth-authenticate-path-injection%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fauth-authenticate-path-injection%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%3A53-63%0A**PR%20description%20diverges%20from%20the%20actual%20supported%20parameter%20set**%0A%0AThe%20%22Changes%20Made%22%20section%20of%20the%20PR%20description%20lists%20%60path_params%60%2C%20%60query_params%60%2C%20%60request%60%2C%20and%20%60body%60%20as%20injected%20parameters%2C%20and%20also%20mentions%20%60Map%20request%20to%20Starlette%20Request%20when%20declared%60%20and%20%60Use%20body%3D%7B%7D%60.%20None%20of%20those%20four%20are%20in%20%60candidates%60%2C%20and%20the%20tests%20%60test_request_and_body_not_injected%60%20%2F%20%60test_path_params_and_query_params_not_injected%60%20confirm%20they%20are%20intentionally%20excluded.%20Additionally%2C%20%60headers%60%20is%20not%20mentioned%20in%20the%20PR%20description%20at%20all%2C%20even%20though%20it%20is%20the%20primary%20supported%20key.%20The%20code's%20docstring%20here%20is%20accurate%3B%20the%20PR%20description%20is%20not%20and%20may%20mislead%20future%20contributors%20who%20read%20one%20without%20the%20other.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["test(auth): parametrize signature fallba..."](https://github.com/aegra/aegra/commit/9d980111b061068d25ed54ef2bb6ae32c6c116a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32821959)</sub>

<!-- /greptile_comment -->