### PR TITLE
fix(settings): translate libpq sslmode for the asyncpg engine URL (closes #388)

### DIFF
--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -165,10 +165,11 @@ Two ways to configure the database connection:
 <Tabs>
   <Tab title="Connection string (recommended for production)">
     ```bash
-    DATABASE_URL=postgresql://user:password@host:5432/mydb?sslmode=require
+    DATABASE_URL=postgresql://user:password@host:5432/mydb
+    PGSSLMODE=require
     ```
 
-    The URL is used directly by both SQLAlchemy and LangGraph with the appropriate driver prefix applied automatically. Query parameters (like `?sslmode=require`) are preserved.
+    The URL is used directly by both SQLAlchemy and LangGraph with the appropriate driver prefix applied automatically. Set `PGSSLMODE` as an env var for managed Postgres (RDS, Azure, GCP) that requires TLS; both drivers read it. See [TLS/SSL options](/reference/environment-variables#tls--ssl) for details, including how `?sslmode=` in the URL is handled.
   </Tab>
   <Tab title="Individual fields">
     Used when `DATABASE_URL` is not set:

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -25,10 +25,31 @@ Two ways to configure the database connection:
 ### Option 1: Connection string
 
 ```bash
-DATABASE_URL=postgresql://user:password@host:5432/aegra?sslmode=require
+DATABASE_URL=postgresql://user:password@host:5432/aegra
 ```
 
-The URL is used by both SQLAlchemy (async) and LangGraph (sync) with the appropriate driver prefix applied automatically. Query parameters are preserved.
+The URL is used by both SQLAlchemy (async) and LangGraph (sync) with the appropriate driver prefix applied automatically.
+
+#### TLS / SSL
+
+For managed Postgres (RDS, Azure, GCP CloudSQL, etc.) that requires TLS, set `PGSSLMODE` as an environment variable rather than embedding `?sslmode=` in the URL:
+
+```bash
+DATABASE_URL=postgresql://user:password@host:5432/aegra
+PGSSLMODE=require
+```
+
+Both drivers Aegra uses (psycopg and asyncpg) read `PGSSLMODE` from the environment.
+
+If you keep `?sslmode=...` in the URL (e.g. when pasting a connection string from a cloud console), Aegra translates it for the async driver automatically:
+
+| `sslmode` | Behavior on the async path |
+|---|---|
+| `disable`, `allow`, `prefer` | TLS off |
+| `require` | TLS on |
+| `verify-ca`, `verify-full` | TLS on, but cert verification requires `PGSSLMODE` + `PGSSLROOTCERT` env vars — the URL form cannot configure an `SSLContext` |
+
+Other libpq-only parameters (`sslcert`, `sslkey`, `sslrootcert`, `channel_binding`, `gssencmode`, `target_session_attrs`) are stripped from the async URL with a warning. Use the matching `PG*` env vars instead — those are honored by both drivers.
 
 ### Option 2: Individual fields
 

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -1,12 +1,43 @@
+import logging
 import re
 from typing import Annotated
-from urllib.parse import quote_plus
+from urllib.parse import parse_qsl, quote_plus, urlencode
 
 from pydantic import BeforeValidator, computed_field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from aegra_api import __version__
 from aegra_api.constants import MULTIHOST_URL_RE
+
+_logger = logging.getLogger(__name__)
+
+# libpq sslmode → asyncpg ssl query param. asyncpg has no analog for
+# "allow"/"prefer" (try-then-fallback) — both map to off, matching the
+# safer-of-the-two interpretation for an application server.
+_SSLMODE_TO_ASYNCPG: dict[str, str] = {
+    "disable": "false",
+    "allow": "false",
+    "prefer": "false",
+    "require": "true",
+    "verify-ca": "true",
+    "verify-full": "true",
+}
+
+# libpq params that asyncpg rejects as unknown kwargs. We strip these from
+# the async URL — users who need them must use PG* env vars or a custom
+# SSLContext, neither of which fits the URL-only fast path.
+_LIBPQ_ONLY_PARAMS: frozenset[str] = frozenset(
+    {
+        "sslmode",
+        "sslcert",
+        "sslkey",
+        "sslrootcert",
+        "sslcrl",
+        "channel_binding",
+        "gssencmode",
+        "target_session_attrs",
+    }
+)
 
 
 def parse_lower(v: str) -> str:
@@ -116,6 +147,64 @@ class DatabaseSettings(EnvBase):
         return re.sub(r"^postgres(?:ql)?(\+\w+)?://", f"{target_scheme}://", url)
 
     @staticmethod
+    def _translate_libpq_params_for_asyncpg(url: str) -> str:
+        """Strip libpq-only query params from an asyncpg URL.
+
+        SQLAlchemy's asyncpg dialect forwards every URL query param as a
+        kwarg to ``asyncpg.connect()``. asyncpg rejects libpq spellings
+        (``sslmode``, ``channel_binding``, ``sslcert``, …) as unknown
+        kwargs, so a URL copied from any libpq-aware tool crashes at
+        startup. We translate ``sslmode`` to asyncpg's ``ssl`` query param
+        and drop the rest with a warning.
+
+        psycopg (sync) accepts libpq syntax natively — ``database_url_sync``
+        is not affected.
+        """
+        # String-splice on "?" rather than urlsplit/urlunsplit: stdlib drops
+        # the "//" authority marker when netloc is empty (e.g. multi-host
+        # URLs with no userinfo), corrupting ``postgresql+asyncpg:///db``
+        # into ``postgresql+asyncpg:/db``.
+        head, sep, query = url.partition("?")
+        if not sep:
+            return url
+
+        rewritten: list[tuple[str, str]] = []
+        dropped: list[str] = []
+
+        for key, value in parse_qsl(query, keep_blank_values=True):
+            if key == "sslmode":
+                mapped = _SSLMODE_TO_ASYNCPG.get(value.lower())
+                if mapped is None:
+                    _logger.warning("Unknown sslmode=%r in DATABASE_URL; ignoring", value)
+                    continue
+                if value.lower() in ("verify-ca", "verify-full"):
+                    _logger.warning(
+                        "DATABASE_URL sslmode=%s requires an SSLContext for cert verification; "
+                        "asyncpg will negotiate TLS but skip the verify-* check. "
+                        "Use PGSSLMODE + PGSSLROOTCERT env vars for full verification.",
+                        value,
+                    )
+                rewritten.append(("ssl", mapped))
+            elif key in _LIBPQ_ONLY_PARAMS:
+                dropped.append(key)
+            else:
+                rewritten.append((key, value))
+
+        if dropped:
+            _logger.warning(
+                "DATABASE_URL contains libpq-only params %s that asyncpg cannot accept; "
+                "set them via PG* env vars instead.",
+                sorted(dropped),
+            )
+
+        if not rewritten:
+            return head
+        # safe=",[]:" preserves the comma-separated host/port lists and
+        # IPv6 literals (``[::1]``) produced by _to_sqlalchemy_multihost —
+        # asyncpg's URL parser expects these raw, not percent-encoded.
+        return f"{head}?{urlencode(rewritten, safe=',[]:')}"
+
+    @staticmethod
     def _to_sqlalchemy_multihost(url: str) -> str:
         """Convert a libpq multi-host URL to SQLAlchemy query-param format.
 
@@ -180,7 +269,8 @@ class DatabaseSettings(EnvBase):
         """
         if self.DATABASE_URL:
             url = self._normalize_scheme(self.DATABASE_URL, "postgresql+asyncpg")
-            return self._to_sqlalchemy_multihost(url)
+            url = self._to_sqlalchemy_multihost(url)
+            return self._translate_libpq_params_for_asyncpg(url)
         return (
             f"postgresql+asyncpg://{quote_plus(self.POSTGRES_USER)}:{quote_plus(self.POSTGRES_PASSWORD)}@"
             f"{self.POSTGRES_HOST}:{self.POSTGRES_PORT}/{self.POSTGRES_DB}"

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -136,8 +136,9 @@ class TestDatabaseURLSupport:
         assert db.database_url == "postgresql+asyncpg://rdsuser:rdspass@rds.aws.com:5432/prod"
         assert db.database_url_sync == "postgresql://rdsuser:rdspass@rds.aws.com:5432/prod"
 
-    def test_query_params_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """SSL and other query params from DATABASE_URL are preserved."""
+    def test_query_params_preserved_for_sync_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Sync URL (psycopg) preserves libpq query params verbatim — psycopg
+        speaks libpq natively."""
         monkeypatch.setenv(
             "DATABASE_URL",
             "postgresql://user:pass@host:5432/db?sslmode=require&connect_timeout=10",
@@ -145,11 +146,79 @@ class TestDatabaseURLSupport:
 
         db = DatabaseSettings(_env_file=None)
 
-        assert "sslmode=require" in db.database_url
-        assert "connect_timeout=10" in db.database_url
         assert "sslmode=require" in db.database_url_sync
-        assert db.database_url.startswith("postgresql+asyncpg://")
+        assert "connect_timeout=10" in db.database_url_sync
         assert db.database_url_sync.startswith("postgresql://")
+
+    def test_async_url_translates_sslmode_require_to_ssl_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """asyncpg rejects ``sslmode`` as an unknown kwarg. We translate it
+        to ``ssl=true`` so the async engine starts cleanly when users paste
+        a libpq-style URL (the common shape from RDS/Azure/GCP consoles)."""
+        monkeypatch.setenv(
+            "DATABASE_URL",
+            "postgresql://user:pass@host:5432/db?sslmode=require",
+        )
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert "sslmode" not in db.database_url
+        assert "ssl=true" in db.database_url
+        assert db.database_url.startswith("postgresql+asyncpg://")
+
+    @pytest.mark.parametrize(
+        ("sslmode", "expected_ssl"),
+        [
+            ("disable", "false"),
+            ("allow", "false"),
+            ("prefer", "false"),
+            ("require", "true"),
+            ("verify-ca", "true"),
+            ("verify-full", "true"),
+        ],
+    )
+    def test_async_url_translates_all_sslmode_values(
+        self, monkeypatch: pytest.MonkeyPatch, sslmode: str, expected_ssl: str
+    ) -> None:
+        monkeypatch.setenv("DATABASE_URL", f"postgresql://u:p@h:5432/db?sslmode={sslmode}")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert f"ssl={expected_ssl}" in db.database_url
+        assert "sslmode" not in db.database_url
+
+    def test_async_url_strips_other_libpq_only_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``channel_binding`` / ``sslcert`` etc. also crash asyncpg as unknown
+        kwargs. Strip them from the async URL; users needing them must set
+        PG* env vars instead (psycopg sync path still sees the libpq form)."""
+        monkeypatch.setenv(
+            "DATABASE_URL",
+            "postgresql://u:p@h:5432/db?channel_binding=require&sslcert=/x.pem&connect_timeout=10",
+        )
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert "channel_binding" not in db.database_url
+        assert "sslcert" not in db.database_url
+        # Non-libpq-only params are preserved.
+        assert "connect_timeout=10" in db.database_url
+
+    def test_async_url_unknown_sslmode_is_dropped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unknown sslmode values are dropped (with a warning) rather than
+        forwarded to asyncpg, which would crash on the unknown kwarg."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h:5432/db?sslmode=bogus")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert "sslmode" not in db.database_url
+        assert "ssl=" not in db.database_url
+
+    def test_async_url_no_query_params_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@h:5432/db")
+
+        db = DatabaseSettings(_env_file=None)
+
+        assert "?" not in db.database_url
+        assert db.database_url.endswith("/db")
 
     def test_driver_prefix_normalized(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Driver prefix is always normalized regardless of input."""
@@ -310,7 +379,10 @@ class TestMultiHostDatabaseURL:
         assert db.database_url_sync == "postgresql://user:pass@h1:5432,h2:5433/db"
 
     def test_multihost_preserves_query_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Query params like target_session_attrs are preserved after conversion."""
+        """Multi-host conversion plays nicely with the libpq → asyncpg
+        translation layer: hosts/ports preserved verbatim, ``sslmode`` rewritten
+        to ``ssl``, and libpq-only kwargs (``target_session_attrs``) stripped
+        because asyncpg rejects them."""
         monkeypatch.setenv(
             "DATABASE_URL",
             "postgresql://user:pass@h1:5432,h2:5432/db?target_session_attrs=read-write&sslmode=require",
@@ -322,8 +394,13 @@ class TestMultiHostDatabaseURL:
         assert url.startswith("postgresql+asyncpg://user:pass@/db?")
         assert "host=h1,h2" in url
         assert "port=5432,5432" in url
-        assert "target_session_attrs=read-write" in url
-        assert "sslmode=require" in url
+        assert "ssl=true" in url
+        # libpq-only kwargs that asyncpg would reject are stripped.
+        assert "target_session_attrs" not in url
+        assert "sslmode" not in url
+        # Sync (psycopg) URL keeps the libpq spelling — psycopg accepts it.
+        assert "target_session_attrs=read-write" in db.database_url_sync
+        assert "sslmode=require" in db.database_url_sync
 
     @pytest.mark.parametrize(
         ("env_url", "expected_hosts", "expected_ports"),
@@ -416,7 +493,11 @@ class TestMultiHostDatabaseURL:
         assert db.database_url == "postgresql+asyncpg:///db?host=h1,h2&port=5432,5432"
 
     def test_multihost_rewritten_url_parses_with_sqlalchemy(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Asyncpg multi-host URL must parse via SQLAlchemy (alembic env path)."""
+        """Asyncpg multi-host URL must parse via SQLAlchemy (alembic env path).
+
+        ``target_session_attrs`` is libpq-only and stripped from the async URL
+        (asyncpg would reject it as an unknown kwarg). The sync URL retains it.
+        """
         monkeypatch.setenv(
             "DATABASE_URL",
             "postgresql://user:pass@h1:5432,h2:5432/db?target_session_attrs=read-write",
@@ -430,7 +511,7 @@ class TestMultiHostDatabaseURL:
         # Multi-host details live in query params, not in url.host.
         assert url.query["host"] == "h1,h2"
         assert url.query["port"] == "5432,5432"
-        assert url.query["target_session_attrs"] == "read-write"
+        assert "target_session_attrs" not in url.query
 
     def test_database_url_sync_preserves_libpq_multihost(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """database_url_sync must preserve libpq comma-host syntax (psycopg consumers)."""


### PR DESCRIPTION
## Summary

Closes #388.

`DATABASE_URL=...?sslmode=require` is the standard libpq shape and what our docs recommended, but it crashed the asyncpg engine at startup:

```
TypeError: connect() got an unexpected keyword argument 'sslmode'
```

SQLAlchemy's asyncpg dialect forwards every URL query param as a kwarg to `asyncpg.connect()`. asyncpg accepts `ssl=`, not `sslmode=`. psycopg (the sync driver) accepts libpq syntax natively, so the bug only fired on the async path — i.e. against managed Postgres (RDS, Azure, GCP) that requires TLS, which is exactly when users copied libpq URLs from a cloud console.

## Changes

- **`database_url`** translates `sslmode` to asyncpg's `ssl` query param:

  | libpq `sslmode` | asyncpg `ssl` |
  |---|---|
  | `disable` / `allow` / `prefer` | `false` |
  | `require` / `verify-ca` / `verify-full` | `true` |

  Other libpq-only params (`channel_binding`, `sslcert`, `sslkey`, `sslrootcert`, `sslcrl`, `gssencmode`, `target_session_attrs`) are stripped with a warning. Users needing them set the matching `PG*` env var — both drivers read those.

- **`database_url_sync`** unchanged. psycopg reads libpq syntax natively.

- **Docs** flip to recommending `PGSSLMODE=require` as the primary path since both drivers read it. Fallback note explains how `?sslmode=` in the URL is handled.

- **`verify-ca` / `verify-full`** logs a warning. Full cert verification needs an `SSLContext`, which can't be expressed via a URL — users set `PGSSLMODE` + `PGSSLROOTCERT` in the environment for that.

## Test plan

- [x] `uv run --package aegra-api pytest libs/aegra-api/tests/unit/ libs/aegra-api/tests/integration/` → 1346 passed
- [x] New tests pin each sslmode → ssl mapping (parametrized over all 6 libpq values)
- [x] Strip-and-warn behavior for `channel_binding`, `sslcert`, `target_session_attrs`
- [x] Multi-host + ipv6 + empty-userinfo URLs still parse correctly (the translation is string-splice on `?` to dodge stdlib's `urlunsplit` quirk that drops `//` on empty netloc)
- [x] Sync URL keeps libpq spellings verbatim
- [x] `uv run ruff check .` + `format --check .` clean

## Acknowledgements

Thanks to @arturbagramyan1 for the detailed root-cause analysis in #388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Deployment guide updated with simplified DATABASE_URL configuration and enhanced TLS/SSL guidance for managed PostgreSQL deployments in production
  * Environment variables reference expanded: PGSSLMODE environment variable documented for PostgreSQL TLS configuration; migration guidance provided for moving libpq parameters from URL to environment variables

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a startup crash (`TypeError: connect() got an unexpected keyword argument 'sslmode'`) that occurred when `DATABASE_URL` contained libpq-style query params (e.g. `?sslmode=require`) and the asyncpg engine was used. The fix adds a translation layer that rewrites `sslmode` to asyncpg's `ssl` query param and strips other libpq-only params with a warning, leaving the sync (psycopg) URL untouched.

- **`settings.py`**: Adds `_translate_libpq_params_for_asyncpg` which maps the six libpq `sslmode` values to `ssl=true/false` and drops params asyncpg rejects (`sslcert`, `sslkey`, `channel_binding`, `target_session_attrs`, etc.); uses string-splice on `?` to avoid `urlsplit`/`urlunsplit` dropping the `//` authority marker on multi-host URLs.
- **Tests**: Parametrized coverage of all six `sslmode` values, strip-and-warn behavior, unknown `sslmode`, no-params pass-through, and interaction with the existing multi-host rewrite; sync URL is verified to retain libpq spellings verbatim.
- **Docs**: Updates deployment guide and env-variable reference to recommend `PGSSLMODE` env var as the primary TLS path, with an explicit table documenting how `?sslmode=` in the URL is translated on the async path.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the fix correctly targets a real startup crash on the asyncpg path and leaves the sync URL untouched; two minor edge cases exist but neither affects the common production path.

The translation logic is correct and comprehensively tested across all six sslmode values and the multi-host interaction. Two small issues exist: sslmode is listed in _LIBPQ_ONLY_PARAMS with a comment saying 'we strip these' even though it is translated by an earlier branch (not stripped), which could mislead a future refactor into accidentally dropping the translation; and a URL that contains both an explicit ssl= param and sslmode= would produce duplicate ssl= entries, with asyncpg silently using the last one — a ?ssl=false&sslmode=require input would yield TLS enabled despite the explicit ssl=false.

libs/aegra-api/src/aegra_api/settings.py — the _translate_libpq_params_for_asyncpg function and _LIBPQ_ONLY_PARAMS set

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/settings.py | Adds _translate_libpq_params_for_asyncpg to rewrite sslmode→ssl and strip other libpq-only params from the async URL; logic is sound with two minor style/edge-case observations |
| libs/aegra-api/tests/unit/test_settings.py | Comprehensive parametrized tests covering all 6 libpq sslmode values, strip-and-warn behavior, unknown sslmode, no-query-param case, and multi-host interaction |
| docs/guides/deployment.mdx | Docs updated to recommend PGSSLMODE env var over ?sslmode= in URL, with a reference to the new TLS/SSL section |
| docs/reference/environment-variables.mdx | New TLS/SSL section documents the sslmode→ssl mapping table, verify-ca/verify-full SSLContext caveat, and strip-with-warning behavior for other libpq-only params |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DATABASE_URL env var] --> B[_normalize_scheme]
    B --> C[_to_sqlalchemy_multihost]
    C --> D[_translate_libpq_params_for_asyncpg]
    D --> E{Has query string?}
    E -- No --> F[return URL unchanged]
    E -- Yes --> G[parse_qsl each param]
    G --> H{key == sslmode?}
    H -- Yes --> I{value in mapping?}
    I -- No --> J[log warning, drop]
    I -- Yes --> K{verify-ca or verify-full?}
    K -- Yes --> L[log SSLContext warning]
    K -- No --> M[append ssl=true/false]
    L --> M
    H -- No --> N{key in LIBPQ_ONLY_PARAMS?}
    N -- Yes --> O[collect in dropped list]
    N -- No --> P[pass through unchanged]
    O --> Q{any dropped?}
    M --> Q
    P --> Q
    Q -- Yes --> R[log warning for dropped params]
    Q -- No --> S[urlencode and rebuild URL]
    R --> S
    S --> T[async database_url]
    A --> U[_normalize_scheme for sync]
    U --> V[sync database_url_sync - no translation]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%3A29-40%0A%60sslmode%60%20listed%20in%20%60_LIBPQ_ONLY_PARAMS%60%20but%20never%20reached%20by%20that%20branch%20%E2%80%94%20the%20%60if%20key%20%3D%3D%20%22sslmode%22%3A%60%20guard%20intercepts%20it%20first%2C%20so%20the%20%60elif%20key%20in%20_LIBPQ_ONLY_PARAMS%60%20path%20is%20dead%20for%20this%20key.%20The%20module-level%20comment%20%22We%20strip%20these%22%20is%20therefore%20inaccurate%20for%20%60sslmode%60%20%28it%20is%20translated%2C%20not%20stripped%29.%20Leaving%20it%20in%20the%20set%20is%20harmless%20today%2C%20but%20a%20future%20refactor%20that%20merges%20or%20reorders%20the%20branches%20could%20accidentally%20drop%20%60sslmode%60%20silently%20instead%20of%20translating%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%3A171-205%0AIf%20an%20existing%20URL%20already%20contains%20an%20explicit%20%60ssl%3D%60%20query%20parameter%20alongside%20%60sslmode%3D%60%2C%20both%20contribute%20an%20entry%20to%20%60rewritten%60%2C%20producing%20a%20duplicate%20%60ssl%3Dtrue%26ssl%3Dtrue%60%20%28or%20mismatched%20%60ssl%3Dfalse%26ssl%3Dtrue%60%29.%20asyncpg's%20URL%20parser%20uses%20the%20last%20occurrence%2C%20so%20a%20URL%20like%20%60%3Fssl%3Dfalse%26sslmode%3Drequire%60%20would%20yield%20%60ssl%3Dfalse%26ssl%3Dtrue%60%20%E2%80%94%20asyncpg%20would%20connect%20with%20TLS%20%28last%20wins%29%2C%20which%20contradicts%20the%20explicit%20%60ssl%3Dfalse%60.%20A%20guard%20that%20skips%20appending%20the%20translated%20%60ssl%60%20param%20when%20%60ssl%60%20is%20already%20in%20%60rewritten%60%20would%20prevent%20this.%0A%0A&repo=aegra%2Faegra&pr=390&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%3A29-40%0A%60sslmode%60%20listed%20in%20%60_LIBPQ_ONLY_PARAMS%60%20but%20never%20reached%20by%20that%20branch%20%E2%80%94%20the%20%60if%20key%20%3D%3D%20%22sslmode%22%3A%60%20guard%20intercepts%20it%20first%2C%20so%20the%20%60elif%20key%20in%20_LIBPQ_ONLY_PARAMS%60%20path%20is%20dead%20for%20this%20key.%20The%20module-level%20comment%20%22We%20strip%20these%22%20is%20therefore%20inaccurate%20for%20%60sslmode%60%20%28it%20is%20translated%2C%20not%20stripped%29.%20Leaving%20it%20in%20the%20set%20is%20harmless%20today%2C%20but%20a%20future%20refactor%20that%20merges%20or%20reorders%20the%20branches%20could%20accidentally%20drop%20%60sslmode%60%20silently%20instead%20of%20translating%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%3A171-205%0AIf%20an%20existing%20URL%20already%20contains%20an%20explicit%20%60ssl%3D%60%20query%20parameter%20alongside%20%60sslmode%3D%60%2C%20both%20contribute%20an%20entry%20to%20%60rewritten%60%2C%20producing%20a%20duplicate%20%60ssl%3Dtrue%26ssl%3Dtrue%60%20%28or%20mismatched%20%60ssl%3Dfalse%26ssl%3Dtrue%60%29.%20asyncpg's%20URL%20parser%20uses%20the%20last%20occurrence%2C%20so%20a%20URL%20like%20%60%3Fssl%3Dfalse%26sslmode%3Drequire%60%20would%20yield%20%60ssl%3Dfalse%26ssl%3Dtrue%60%20%E2%80%94%20asyncpg%20would%20connect%20with%20TLS%20%28last%20wins%29%2C%20which%20contradicts%20the%20explicit%20%60ssl%3Dfalse%60.%20A%20guard%20that%20skips%20appending%20the%20translated%20%60ssl%60%20param%20when%20%60ssl%60%20is%20already%20in%20%60rewritten%60%20would%20prevent%20this.%0A%0A&pr=390&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fdatabase-url-sslmode%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdatabase-url-sslmode%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%3A29-40%0A%60sslmode%60%20listed%20in%20%60_LIBPQ_ONLY_PARAMS%60%20but%20never%20reached%20by%20that%20branch%20%E2%80%94%20the%20%60if%20key%20%3D%3D%20%22sslmode%22%3A%60%20guard%20intercepts%20it%20first%2C%20so%20the%20%60elif%20key%20in%20_LIBPQ_ONLY_PARAMS%60%20path%20is%20dead%20for%20this%20key.%20The%20module-level%20comment%20%22We%20strip%20these%22%20is%20therefore%20inaccurate%20for%20%60sslmode%60%20%28it%20is%20translated%2C%20not%20stripped%29.%20Leaving%20it%20in%20the%20set%20is%20harmless%20today%2C%20but%20a%20future%20refactor%20that%20merges%20or%20reorders%20the%20branches%20could%20accidentally%20drop%20%60sslmode%60%20silently%20instead%20of%20translating%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%3A171-205%0AIf%20an%20existing%20URL%20already%20contains%20an%20explicit%20%60ssl%3D%60%20query%20parameter%20alongside%20%60sslmode%3D%60%2C%20both%20contribute%20an%20entry%20to%20%60rewritten%60%2C%20producing%20a%20duplicate%20%60ssl%3Dtrue%26ssl%3Dtrue%60%20%28or%20mismatched%20%60ssl%3Dfalse%26ssl%3Dtrue%60%29.%20asyncpg's%20URL%20parser%20uses%20the%20last%20occurrence%2C%20so%20a%20URL%20like%20%60%3Fssl%3Dfalse%26sslmode%3Drequire%60%20would%20yield%20%60ssl%3Dfalse%26ssl%3Dtrue%60%20%E2%80%94%20asyncpg%20would%20connect%20with%20TLS%20%28last%20wins%29%2C%20which%20contradicts%20the%20explicit%20%60ssl%3Dfalse%60.%20A%20guard%20that%20skips%20appending%20the%20translated%20%60ssl%60%20param%20when%20%60ssl%60%20is%20already%20in%20%60rewritten%60%20would%20prevent%20this.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(settings): translate libpq sslmode f..."](https://github.com/aegra/aegra/commit/706b3a30b801426e7fdbf95084be41f333a591ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32837576)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->