### PR TITLE
style: ruff format escape_like test

### DIFF
--- a/libs/aegra-api/tests/unit/test_services/test_assistant_service_escape_like.py
+++ b/libs/aegra-api/tests/unit/test_services/test_assistant_service_escape_like.py
@@ -31,7 +31,5 @@ def test_escape_like_is_idempotent_under_repeated_escape_then_unescape() -> None
     raw = "weird%_\\input"
     escaped = _escape_like(raw)
     # Simulate the ILIKE engine consuming '\\' as an escape character.
-    unescaped = (
-        escaped.replace(r"\%", "%").replace(r"\_", "_").replace("\\\\", "\\")
-    )
+    unescaped = escaped.replace(r"\%", "%").replace(r"\_", "_").replace("\\\\", "\\")
     assert unescaped == raw


### PR DESCRIPTION
## Summary
- ruff format check is failing on main since #368 merged (the new `test_assistant_service_escape_like.py` was committed without running the formatter)
- single 3-line statement collapses to 1 line per ruff format rules

## Test plan
- [x] `uv run ruff format --check .` passes locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test logic for internal validation procedures with no impact to end-user functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reformats a single multi-line chained method call in `test_assistant_service_escape_like.py` to a one-liner so it passes `ruff format --check`. No logic or test coverage is changed.

- Collapses the parenthesized three-line `escaped.replace(…).replace(…).replace(…)` expression onto a single line, matching ruff's line-length rules.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only change is collapsing a parenthesized expression to a single line with no effect on runtime behavior.

The diff touches only whitespace/formatting of a test helper expression; the test logic, assertions, and parametrize cases are completely unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/tests/unit/test_services/test_assistant_service_escape_like.py | Pure ruff formatting fix — three-line chained replace call collapsed to one line; no logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ruff format --check runs on CI] -->|Fails on multi-line expression| B[PR #368 introduced unformatted file]
    B --> C[This PR: collapse 3-line expression to 1 line]
    C --> D[ruff format --check passes]
```

<sub>Reviews (1): Last reviewed commit: ["style: ruff format escape\_like test"](https://github.com/aegra/aegra/commit/1a02dfb6414e3e64d9cd8d2a503f0fad1feb8435) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33653443)</sub>

<!-- /greptile_comment -->