### PR TITLE
docs: Add FAQ section for common questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,58 @@ Apache 2.0 - see [LICENSE](LICENSE).
     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=aegra/aegra&type=Date" />
   </picture>
 </a>
+
+## ❓ FAQ
+
+### What is Aegra?
+Aegra is a drop-in replacement for LangSmith Deployments. Use the same LangGraph SDK and APIs, but run it on your own infrastructure with PostgreSQL persistence.
+
+### Key Features
+| Feature | Description |
+|---------|-------------|
+| **Agent Protocol Compliant** | Works with Agent Chat UI, LangGraph Studio, CopilotKit |
+| **Worker Architecture** | Redis job queue with 30 concurrent runs per instance |
+| **Custom Auth** | Python handlers for JWT/OAuth/Firebase |
+| **Self-hosted** | Always Apache 2.0, no license key required |
+| **OTLP Tracing** | Langfuse, Phoenix, or any OTLP backend |
+| **Bring Your Own Postgres** | Own database, own infrastructure |
+
+### How to Install
+```bash
+# Using CLI (Recommended)
+pip install aegra-cli
+aegra init
+
+# Or from source
+git clone https://github.com/aegra/aegra.git
+cd aegra
+cp .env.example .env
+docker compose up
+```
+
+### Works With
+| Platform | Link |
+|----------|------|
+| Agent Chat UI | [langchain-ai/agent-chat-ui](https://github.com/langchain-ai/agent-chat-ui) |
+| LangGraph Studio | [langchain-ai/langgraph-studio](https://github.com/langchain-ai/langgraph-studio) |
+| AG-UI / CopilotKit | [CopilotKit/CopilotKit](https://github.com/CopilotKit/CopilotKit) |
+
+### Requirements
+- Python 3.12+
+- Docker (for PostgreSQL)
+- OPENAI_API_KEY
+
+### Why Aegra vs LangSmith?
+- Free unlimited deployments (LangSmith: Local dev only / paid cloud)
+- Custom auth handlers (LangSmith: Not available on Free)
+- Apache 2.0 license (LangSmith: Enterprise only for self-hosted)
+- Own Postgres database (LangSmith: Managed only)
+- Any OTLP tracing backend (LangSmith: LangSmith only)
+
+### License
+Apache 2.0 License
+
+### Help Resources
+- [Documentation](https://docs.aegra.dev)
+- [Discord](https://discord.com/invite/D5M3ZPS25e)
+- [Issues](https://github.com/aegra/aegra/issues)


### PR DESCRIPTION
## Summary
Added a comprehensive FAQ section to help users understand aegra better.

## Changes
- Added FAQ section with:
  - Project overview
  - Key Features table
  - Installation instructions
  - Requirements/Dependencies
  - License information
  - Help resources links

## Checklist
- [ ] Documentation added
- [ ] No code changes
- [ ] Tested locally (README renders correctly)

Fixes common documentation gap for new users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive FAQ section to README including feature overview, key features comparison, installation guides, supported platforms, requirements, alternative comparison, license, and documentation links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR appends a FAQ section to the bottom of `README.md` covering project overview, key features, installation, compatibility, requirements, a LangSmith comparison, license, and help resources.

- The FAQ install instructions omit required post-`aegra init` steps (`cd`, `cp .env.example .env`, `uv sync`, `uv run aegra dev`) that exist in the Quick Start, and the source path omits the `OPENAI_API_KEY` note — a user following only the FAQ cannot successfully run the project.
- The LangSmith database comparison (\"Managed only\") is factually incomplete; the existing table at line 92 correctly notes that LangSmith Enterprise supports bring-your-own Postgres.
- The section largely reproduces content already in the README (intro, features, Quick Start, \"Works With\", license, community links) but with a reduced feature list, creating a dual-maintenance burden.

<h3>Confidence Score: 3/5</h3>

The FAQ install instructions are incomplete enough that a user following them exclusively cannot get the project running; the LangSmith comparison also contains a factual inaccuracy that could mislead potential adopters.

Two distinct factual defects in the new content — the truncated installation flow drops required steps that leave the user unable to run the project, and the database-tier comparison misrepresents LangSmith Enterprise capabilities. Both would be immediately visible to new users reading the FAQ as their first entry point.

README.md — specifically the "How to Install" and "Why Aegra vs LangSmith?" subsections of the new FAQ.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds a 57-line FAQ section after the star-history chart; contains two factual issues (incomplete CLI install steps, inaccurate LangSmith database-tier comparison) and largely duplicates information already in the document. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New User lands on README] --> B{Reads Quick Start?}
    B -- Yes --> C[Complete install steps\ncli path or source path]
    B -- No, scrolls to FAQ --> D[Reads How to Install FAQ]
    D --> E[pip install aegra-cli\naegra init]
    E --> F[Missing steps:\ncd, cp .env, uv sync,\nuv run aegra dev]
    F --> G[User stuck — project\nnot runnable]
    C --> H[Project running correctly]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0AREADME.md%3A197-208%0A**Incomplete%20CLI%20installation%20steps**%0A%0AThe%20%22How%20to%20Install%22%20block%20only%20shows%20%60pip%20install%20aegra-cli%60%20%2B%20%60aegra%20init%60%2C%20but%20the%20existing%20Quick%20Start%20%28lines%2038%E2%80%9348%29%20shows%20four%20additional%20required%20steps%3A%20%60cd%20%3Cyour-project%3E%60%2C%20%60cp%20.env.example%20.env%60%2C%20%60uv%20sync%60%2C%20and%20%60uv%20run%20aegra%20dev%60.%20A%20user%20following%20only%20the%20FAQ%20would%20be%20left%20with%20a%20project%20scaffold%20they%20can't%20run%20%E2%80%94%20no%20dependencies%20installed%20and%20no%20%60.env%60%20file%20created.%20The%20%22From%20source%22%20path%20also%20silently%20omits%20the%20required%20%60OPENAI_API_KEY%60%20step%20that%20the%20Quick%20Start%20highlights.%0A%0A%23%23%23%20Issue%202%20of%203%0AREADME.md%3A222-227%0AThe%20claim%20%22Own%20Postgres%20database%20%28LangSmith%3A%20Managed%20only%29%22%20is%20factually%20incomplete.%20The%20existing%20comparison%20table%20at%20line%2092%20correctly%20notes%20that%20LangSmith%20Enterprise%20does%20support%20bring-your-own%20database.%20Oversimplifying%20this%20could%20mislead%20users%20comparing%20plans.%0A%0A%60%60%60suggestion%0A%23%23%23%20Why%20Aegra%20vs%20LangSmith%3F%0A-%20Free%20unlimited%20deployments%20%28LangSmith%3A%20Local%20dev%20only%20%2F%20paid%20cloud%29%0A-%20Custom%20auth%20handlers%20%28LangSmith%3A%20Not%20available%20on%20Free%29%0A-%20Apache%202.0%20license%20%28LangSmith%3A%20Enterprise%20only%20for%20self-hosted%29%0A-%20Own%20Postgres%20database%20%28LangSmith%3A%20Managed%20only%20on%20Free%2FPlus%2C%20bring%20your%20own%20on%20Enterprise%29%0A-%20Any%20OTLP%20tracing%20backend%20%28LangSmith%3A%20LangSmith%20only%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0AREADME.md%3A182-235%0A**FAQ%20duplicates%20existing%20README%20content%20without%20adding%20new%20information**%0A%0AThe%20entire%20FAQ%20section%20reproduces%20content%20that%20already%20exists%20in%20the%20README%3A%20the%20intro%20paragraph%20%28%22What%20is%20Aegra%3F%22%29%2C%20the%20features%20table%2C%20the%20Quick%20Start%20commands%2C%20the%20%22Works%20With%22%20list%2C%20the%20license%2C%20and%20the%20community%20links.%20The%20%22Key%20Features%22%20table%20also%20omits%20features%20listed%20in%20the%20existing%20%60%E2%9C%A8%20Features%60%20section%20%28human-in-the-loop%2C%20streaming%2C%20persistent%20state%2C%20semantic%20store%2C%20custom%20routes%29%2C%20making%20it%20a%20reduced%20copy.%20This%20creates%20a%20maintenance%20burden%20%E2%80%94%20any%20future%20change%20to%20those%20sections%20must%20now%20be%20applied%20in%20two%20places%2C%20and%20drift%20between%20them%20will%20confuse%20readers.%0A%0A&repo=aegra%2Faegra&pr=396&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0AREADME.md%3A197-208%0A**Incomplete%20CLI%20installation%20steps**%0A%0AThe%20%22How%20to%20Install%22%20block%20only%20shows%20%60pip%20install%20aegra-cli%60%20%2B%20%60aegra%20init%60%2C%20but%20the%20existing%20Quick%20Start%20%28lines%2038%E2%80%9348%29%20shows%20four%20additional%20required%20steps%3A%20%60cd%20%3Cyour-project%3E%60%2C%20%60cp%20.env.example%20.env%60%2C%20%60uv%20sync%60%2C%20and%20%60uv%20run%20aegra%20dev%60.%20A%20user%20following%20only%20the%20FAQ%20would%20be%20left%20with%20a%20project%20scaffold%20they%20can't%20run%20%E2%80%94%20no%20dependencies%20installed%20and%20no%20%60.env%60%20file%20created.%20The%20%22From%20source%22%20path%20also%20silently%20omits%20the%20required%20%60OPENAI_API_KEY%60%20step%20that%20the%20Quick%20Start%20highlights.%0A%0A%23%23%23%20Issue%202%20of%203%0AREADME.md%3A222-227%0AThe%20claim%20%22Own%20Postgres%20database%20%28LangSmith%3A%20Managed%20only%29%22%20is%20factually%20incomplete.%20The%20existing%20comparison%20table%20at%20line%2092%20correctly%20notes%20that%20LangSmith%20Enterprise%20does%20support%20bring-your-own%20database.%20Oversimplifying%20this%20could%20mislead%20users%20comparing%20plans.%0A%0A%60%60%60suggestion%0A%23%23%23%20Why%20Aegra%20vs%20LangSmith%3F%0A-%20Free%20unlimited%20deployments%20%28LangSmith%3A%20Local%20dev%20only%20%2F%20paid%20cloud%29%0A-%20Custom%20auth%20handlers%20%28LangSmith%3A%20Not%20available%20on%20Free%29%0A-%20Apache%202.0%20license%20%28LangSmith%3A%20Enterprise%20only%20for%20self-hosted%29%0A-%20Own%20Postgres%20database%20%28LangSmith%3A%20Managed%20only%20on%20Free%2FPlus%2C%20bring%20your%20own%20on%20Enterprise%29%0A-%20Any%20OTLP%20tracing%20backend%20%28LangSmith%3A%20LangSmith%20only%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0AREADME.md%3A182-235%0A**FAQ%20duplicates%20existing%20README%20content%20without%20adding%20new%20information**%0A%0AThe%20entire%20FAQ%20section%20reproduces%20content%20that%20already%20exists%20in%20the%20README%3A%20the%20intro%20paragraph%20%28%22What%20is%20Aegra%3F%22%29%2C%20the%20features%20table%2C%20the%20Quick%20Start%20commands%2C%20the%20%22Works%20With%22%20list%2C%20the%20license%2C%20and%20the%20community%20links.%20The%20%22Key%20Features%22%20table%20also%20omits%20features%20listed%20in%20the%20existing%20%60%E2%9C%A8%20Features%60%20section%20%28human-in-the-loop%2C%20streaming%2C%20persistent%20state%2C%20semantic%20store%2C%20custom%20routes%29%2C%20making%20it%20a%20reduced%20copy.%20This%20creates%20a%20maintenance%20burden%20%E2%80%94%20any%20future%20change%20to%20those%20sections%20must%20now%20be%20applied%20in%20two%20places%2C%20and%20drift%20between%20them%20will%20confuse%20readers.%0A%0A&pr=396&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22docs%2Fadd-faq-section%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fadd-faq-section%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0AREADME.md%3A197-208%0A**Incomplete%20CLI%20installation%20steps**%0A%0AThe%20%22How%20to%20Install%22%20block%20only%20shows%20%60pip%20install%20aegra-cli%60%20%2B%20%60aegra%20init%60%2C%20but%20the%20existing%20Quick%20Start%20%28lines%2038%E2%80%9348%29%20shows%20four%20additional%20required%20steps%3A%20%60cd%20%3Cyour-project%3E%60%2C%20%60cp%20.env.example%20.env%60%2C%20%60uv%20sync%60%2C%20and%20%60uv%20run%20aegra%20dev%60.%20A%20user%20following%20only%20the%20FAQ%20would%20be%20left%20with%20a%20project%20scaffold%20they%20can't%20run%20%E2%80%94%20no%20dependencies%20installed%20and%20no%20%60.env%60%20file%20created.%20The%20%22From%20source%22%20path%20also%20silently%20omits%20the%20required%20%60OPENAI_API_KEY%60%20step%20that%20the%20Quick%20Start%20highlights.%0A%0A%23%23%23%20Issue%202%20of%203%0AREADME.md%3A222-227%0AThe%20claim%20%22Own%20Postgres%20database%20%28LangSmith%3A%20Managed%20only%29%22%20is%20factually%20incomplete.%20The%20existing%20comparison%20table%20at%20line%2092%20correctly%20notes%20that%20LangSmith%20Enterprise%20does%20support%20bring-your-own%20database.%20Oversimplifying%20this%20could%20mislead%20users%20comparing%20plans.%0A%0A%60%60%60suggestion%0A%23%23%23%20Why%20Aegra%20vs%20LangSmith%3F%0A-%20Free%20unlimited%20deployments%20%28LangSmith%3A%20Local%20dev%20only%20%2F%20paid%20cloud%29%0A-%20Custom%20auth%20handlers%20%28LangSmith%3A%20Not%20available%20on%20Free%29%0A-%20Apache%202.0%20license%20%28LangSmith%3A%20Enterprise%20only%20for%20self-hosted%29%0A-%20Own%20Postgres%20database%20%28LangSmith%3A%20Managed%20only%20on%20Free%2FPlus%2C%20bring%20your%20own%20on%20Enterprise%29%0A-%20Any%20OTLP%20tracing%20backend%20%28LangSmith%3A%20LangSmith%20only%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0AREADME.md%3A182-235%0A**FAQ%20duplicates%20existing%20README%20content%20without%20adding%20new%20information**%0A%0AThe%20entire%20FAQ%20section%20reproduces%20content%20that%20already%20exists%20in%20the%20README%3A%20the%20intro%20paragraph%20%28%22What%20is%20Aegra%3F%22%29%2C%20the%20features%20table%2C%20the%20Quick%20Start%20commands%2C%20the%20%22Works%20With%22%20list%2C%20the%20license%2C%20and%20the%20community%20links.%20The%20%22Key%20Features%22%20table%20also%20omits%20features%20listed%20in%20the%20existing%20%60%E2%9C%A8%20Features%60%20section%20%28human-in-the-loop%2C%20streaming%2C%20persistent%20state%2C%20semantic%20store%2C%20custom%20routes%29%2C%20making%20it%20a%20reduced%20copy.%20This%20creates%20a%20maintenance%20burden%20%E2%80%94%20any%20future%20change%20to%20those%20sections%20must%20now%20be%20applied%20in%20two%20places%2C%20and%20drift%20between%20them%20will%20confuse%20readers.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: Add FAQ section for common questio..."](https://github.com/aegra/aegra/commit/9f2ee871137103d092afe3859cfc199d011cdbb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34384786)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->