### PR TITLE
docs: Add FAQ section for common questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,57 @@ Apache 2.0 - see [LICENSE](LICENSE).
     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=aegra/aegra&type=Date" />
   </picture>
 </a>
+
+## ❓ FAQ
+
+### What is Aegra?
+Aegra is a drop-in replacement for LangSmith Deployments. Use the same LangGraph SDK and APIs, but run it on your own infrastructure with PostgreSQL persistence.
+
+### Key Features
+| Feature | Description |
+|---------|-------------|
+| **Agent Protocol Compliant** | Works with Agent Chat UI, LangGraph Studio, CopilotKit |
+| **Worker Architecture** | Redis job queue with 30 concurrent runs per instance |
+| **Custom Auth** | Python handlers for JWT/OAuth/Firebase |
+| **Self-hosted** | Always Apache 2.0, no license key required |
+| **OTLP Tracing** | Langfuse, Phoenix, or any OTLP backend |
+| **Bring Your Own Postgres** | Own database, own infrastructure |
+
+### How to Install
+```bash
+pip install aegra-cli
+aegra init
+
+# Or from source:
+git clone https://github.com/aegra/aegra.git
+cd aegra
+cp .env.example .env
+docker compose up
+```
+
+### Works With
+| Platform | Link |
+|----------|------|
+| Agent Chat UI | langchain-ai/agent-chat-ui |
+| LangGraph Studio | langchain-ai/langgraph-studio |
+| CopilotKit | CopilotKit/CopilotKit |
+
+### Requirements
+- Python 3.12+
+- Docker (for PostgreSQL)
+- OPENAI_API_KEY
+
+### Why Aegra vs LangSmith?
+- Free unlimited deployments
+- Custom auth handlers
+- Apache 2.0 license
+- Own Postgres database
+- Any OTLP tracing backend
+
+### License
+Apache 2.0 License
+
+### Help Resources
+- [Documentation](https://docs.aegra.dev)
+- [Discord](https://discord.com/invite/D5M3ZPS25e)
+- [Issues](https://github.com/aegra/aegra/issues)


### PR DESCRIPTION
## Summary
Added a comprehensive FAQ section to help users understand aegra better.

## Changes
- Added FAQ section with project overview, Key Features table, Installation instructions, Requirements, License, and Help resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive FAQ section covering product overview, key features, installation steps, supported platforms, system requirements, feature comparison, licensing details, and support resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR appends a FAQ section to the bottom of `README.md`, after the star history chart that was previously the document's closing element. The FAQ content largely restates information already present in the document and introduces two correctness problems.

- **Pervasive duplication**: "What is Aegra?", "Key Features", "How to Install", "Works With", "Requirements", "Why Aegra vs LangSmith?", "License", and "Help Resources" all mirror existing README sections almost verbatim, adding length without new information.
- **Broken links**: The "Works With" table lists platforms as bare `owner/repo` strings instead of Markdown hyperlinks, unlike the equivalent linked text on line 29.
- **Incomplete install steps**: The FAQ installation flow omits `cp .env.example .env`, the `OPENAI_API_KEY` note, `uv sync`, and `uv run aegra dev` — steps that are required and already documented in the Quick Start section.

<h3>Confidence Score: 3/5</h3>

The change is documentation-only and cannot break runtime behaviour, but it introduces misleading content on the repository's front page that users will follow directly.

The 'How to Install' FAQ steps skip `.env` setup and the required `uv sync`/`uv run aegra dev` commands, meaning a reader who follows only the FAQ will fail to get a working server. The 'Works With' table renders as unclickable plain text where linked entries are expected. These are documentation defects on a high-visibility page that will actively mislead new users.

README.md — the FAQ section added at lines 182–235 needs revision before the file is in a mergeable state.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | FAQ section appended after the document's visual closing element; nearly all content duplicates existing sections; 'Works With' table uses unlinked plain-text paths instead of hyperlinks; installation instructions are missing several required steps present in the Quick Start. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md] --> B[Quick Start / Install]
    A --> C[Why Aegra? Comparison table]
    A --> D[Features section]
    A --> E[Community & Support]
    A --> F[License section]
    A --> G[Star History Chart]
    G --> H[❓ FAQ added here]

    H --> I[What is Aegra?]
    H --> J[Key Features table]
    H --> K[How to Install]
    H --> L[Works With table]
    H --> M[Requirements]
    H --> N[Why Aegra vs LangSmith?]
    H --> O[License]
    H --> P[Help Resources]

    I -.->|duplicates| B
    J -.->|duplicates| D
    K -.->|duplicates, incomplete| B
    L -.->|duplicates, broken links| B
    N -.->|duplicates| C
    O -.->|duplicates| F
    P -.->|duplicates| E

    style H fill:#f96,stroke:#c00
    style L fill:#f96,stroke:#c00
    style K fill:#f96,stroke:#c00
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `README.md`, line 182-235 ([link](https://github.com/aegra/aegra/blob/bea63f527ba7086d2bef38777a58db3c6610f420/README.md#L182-L235)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **FAQ duplicates most of the existing README content**

   Nearly every subsection in the new FAQ repeats content that already exists higher up in the document: "What is Aegra?" mirrors line 27, "Key Features" duplicates the ✨ Features section (lines 97–108), "How to Install" mirrors the 🚀 Quick Start (lines 32–61), "Works With" mirrors line 29, "Requirements" mirrors the Prerequisites note, "Why Aegra vs LangSmith?" mirrors the 🔥 comparison table (lines 83–96), "License" mirrors the 📄 License section, and "Help Resources" mirrors the 💬 Community & Support section. A FAQ section is most useful when it answers questions not already covered inline — as written, this section adds significant length with no new information for the reader.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20README.md%0ALine%3A%20182-235%0A%0AComment%3A%0A**FAQ%20duplicates%20most%20of%20the%20existing%20README%20content**%0A%0ANearly%20every%20subsection%20in%20the%20new%20FAQ%20repeats%20content%20that%20already%20exists%20higher%20up%20in%20the%20document%3A%20%22What%20is%20Aegra%3F%22%20mirrors%20line%2027%2C%20%22Key%20Features%22%20duplicates%20the%20%E2%9C%A8%20Features%20section%20%28lines%2097%E2%80%93108%29%2C%20%22How%20to%20Install%22%20mirrors%20the%20%F0%9F%9A%80%20Quick%20Start%20%28lines%2032%E2%80%9361%29%2C%20%22Works%20With%22%20mirrors%20line%2029%2C%20%22Requirements%22%20mirrors%20the%20Prerequisites%20note%2C%20%22Why%20Aegra%20vs%20LangSmith%3F%22%20mirrors%20the%20%F0%9F%94%A5%20comparison%20table%20%28lines%2083%E2%80%9396%29%2C%20%22License%22%20mirrors%20the%20%F0%9F%93%84%20License%20section%2C%20and%20%22Help%20Resources%22%20mirrors%20the%20%F0%9F%92%AC%20Community%20%26%20Support%20section.%20A%20FAQ%20section%20is%20most%20useful%20when%20it%20answers%20questions%20not%20already%20covered%20inline%20%E2%80%94%20as%20written%2C%20this%20section%20adds%20significant%20length%20with%20no%20new%20information%20for%20the%20reader.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=397&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20README.md%0ALine%3A%20182-235%0A%0AComment%3A%0A**FAQ%20duplicates%20most%20of%20the%20existing%20README%20content**%0A%0ANearly%20every%20subsection%20in%20the%20new%20FAQ%20repeats%20content%20that%20already%20exists%20higher%20up%20in%20the%20document%3A%20%22What%20is%20Aegra%3F%22%20mirrors%20line%2027%2C%20%22Key%20Features%22%20duplicates%20the%20%E2%9C%A8%20Features%20section%20%28lines%2097%E2%80%93108%29%2C%20%22How%20to%20Install%22%20mirrors%20the%20%F0%9F%9A%80%20Quick%20Start%20%28lines%2032%E2%80%9361%29%2C%20%22Works%20With%22%20mirrors%20line%2029%2C%20%22Requirements%22%20mirrors%20the%20Prerequisites%20note%2C%20%22Why%20Aegra%20vs%20LangSmith%3F%22%20mirrors%20the%20%F0%9F%94%A5%20comparison%20table%20%28lines%2083%E2%80%9396%29%2C%20%22License%22%20mirrors%20the%20%F0%9F%93%84%20License%20section%2C%20and%20%22Help%20Resources%22%20mirrors%20the%20%F0%9F%92%AC%20Community%20%26%20Support%20section.%20A%20FAQ%20section%20is%20most%20useful%20when%20it%20answers%20questions%20not%20already%20covered%20inline%20%E2%80%94%20as%20written%2C%20this%20section%20adds%20significant%20length%20with%20no%20new%20information%20for%20the%20reader.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=397&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22docs%2Fadd-faq-section%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fadd-faq-section%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20README.md%0ALine%3A%20182-235%0A%0AComment%3A%0A**FAQ%20duplicates%20most%20of%20the%20existing%20README%20content**%0A%0ANearly%20every%20subsection%20in%20the%20new%20FAQ%20repeats%20content%20that%20already%20exists%20higher%20up%20in%20the%20document%3A%20%22What%20is%20Aegra%3F%22%20mirrors%20line%2027%2C%20%22Key%20Features%22%20duplicates%20the%20%E2%9C%A8%20Features%20section%20%28lines%2097%E2%80%93108%29%2C%20%22How%20to%20Install%22%20mirrors%20the%20%F0%9F%9A%80%20Quick%20Start%20%28lines%2032%E2%80%9361%29%2C%20%22Works%20With%22%20mirrors%20line%2029%2C%20%22Requirements%22%20mirrors%20the%20Prerequisites%20note%2C%20%22Why%20Aegra%20vs%20LangSmith%3F%22%20mirrors%20the%20%F0%9F%94%A5%20comparison%20table%20%28lines%2083%E2%80%9396%29%2C%20%22License%22%20mirrors%20the%20%F0%9F%93%84%20License%20section%2C%20and%20%22Help%20Resources%22%20mirrors%20the%20%F0%9F%92%AC%20Community%20%26%20Support%20section.%20A%20FAQ%20section%20is%20most%20useful%20when%20it%20answers%20questions%20not%20already%20covered%20inline%20%E2%80%94%20as%20written%2C%20this%20section%20adds%20significant%20length%20with%20no%20new%20information%20for%20the%20reader.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0AREADME.md%3A182-235%0A**FAQ%20duplicates%20most%20of%20the%20existing%20README%20content**%0A%0ANearly%20every%20subsection%20in%20the%20new%20FAQ%20repeats%20content%20that%20already%20exists%20higher%20up%20in%20the%20document%3A%20%22What%20is%20Aegra%3F%22%20mirrors%20line%2027%2C%20%22Key%20Features%22%20duplicates%20the%20%E2%9C%A8%20Features%20section%20%28lines%2097%E2%80%93108%29%2C%20%22How%20to%20Install%22%20mirrors%20the%20%F0%9F%9A%80%20Quick%20Start%20%28lines%2032%E2%80%9361%29%2C%20%22Works%20With%22%20mirrors%20line%2029%2C%20%22Requirements%22%20mirrors%20the%20Prerequisites%20note%2C%20%22Why%20Aegra%20vs%20LangSmith%3F%22%20mirrors%20the%20%F0%9F%94%A5%20comparison%20table%20%28lines%2083%E2%80%9396%29%2C%20%22License%22%20mirrors%20the%20%F0%9F%93%84%20License%20section%2C%20and%20%22Help%20Resources%22%20mirrors%20the%20%F0%9F%92%AC%20Community%20%26%20Support%20section.%20A%20FAQ%20section%20is%20most%20useful%20when%20it%20answers%20questions%20not%20already%20covered%20inline%20%E2%80%94%20as%20written%2C%20this%20section%20adds%20significant%20length%20with%20no%20new%20information%20for%20the%20reader.%0A%0A%23%23%23%20Issue%202%20of%204%0AREADME.md%3A182%0A**FAQ%20section%20placed%20after%20the%20document's%20visual%20closing%20element**%0A%0AThe%20FAQ%20is%20appended%20after%20the%20closing%20%60%3C%2Fa%3E%60%20of%20the%20star%20history%20chart%2C%20which%20was%20the%20intended%20final%20flourish%20of%20the%20document.%20Inserting%20substantial%20text%20after%20it%20breaks%20the%20reading%20flow%20and%20will%20appear%20after%20the%20chart%20image%20in%20rendered%20Markdown.%20It%20should%20be%20placed%20before%20the%20star%20history%20section%2C%20or%20at%20the%20very%20least%20before%20the%20%60---%60%20separator%20on%20line%20168.%0A%0A%23%23%23%20Issue%203%20of%204%0AREADME.md%3A209-214%0A**%22Works%20With%22%20links%20are%20plain%20text%20paths%2C%20not%20hyperlinks**%0A%0AThe%20existing%20README%20%28line%2029%29%20already%20links%20these%20platforms%20with%20full%20GitHub%20URLs%20%28%60https%3A%2F%2Fgithub.com%2Flangchain-ai%2Fagent-chat-ui%60%2C%20etc.%29%2C%20but%20the%20FAQ%20table%20shows%20bare%20paths%20like%20%60langchain-ai%2Fagent-chat-ui%60%20as%20unlinked%20text.%20Readers%20clicking%20on%20them%20will%20get%20nothing.%20The%20table%20either%20needs%20proper%20Markdown%20links%20or%20should%20be%20dropped%20in%20favour%20of%20the%20already-linked%20line%2029.%0A%0A%23%23%23%20Issue%204%20of%204%0AREADME.md%3A197-207%0A**Installation%20instructions%20are%20incomplete%20compared%20to%20the%20Quick%20Start**%0A%0AThe%20existing%20Quick%20Start%20%28lines%2034%E2%80%9348%29%20shows%20the%20full%20CLI%20flow%3A%20%60pip%20install%20aegra-cli%60%2C%20%60aegra%20init%60%2C%20%60cd%20%3Cproject%3E%60%2C%20%60cp%20.env.example%20.env%60%20%28with%20a%20note%20to%20add%20%60OPENAI_API_KEY%60%29%2C%20%60uv%20sync%60%2C%20and%20%60uv%20run%20aegra%20dev%60.%20The%20FAQ%20version%20omits%20%60cp%20.env.example%20.env%60%2C%20the%20API%20key%20note%2C%20%60uv%20sync%60%2C%20and%20%60uv%20run%20aegra%20dev%60%2C%20so%20a%20user%20following%20the%20FAQ%20steps%20will%20end%20up%20without%20a%20working%20%60.env%60%20and%20no%20running%20server.%20It%20also%20skips%20the%20important%20note%20about%20installing%20%60aegra-cli%60%20rather%20than%20the%20%60aegra%60%20meta-package%20%28line%2050%29.%0A%0A&repo=aegra%2Faegra&pr=397&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0AREADME.md%3A182-235%0A**FAQ%20duplicates%20most%20of%20the%20existing%20README%20content**%0A%0ANearly%20every%20subsection%20in%20the%20new%20FAQ%20repeats%20content%20that%20already%20exists%20higher%20up%20in%20the%20document%3A%20%22What%20is%20Aegra%3F%22%20mirrors%20line%2027%2C%20%22Key%20Features%22%20duplicates%20the%20%E2%9C%A8%20Features%20section%20%28lines%2097%E2%80%93108%29%2C%20%22How%20to%20Install%22%20mirrors%20the%20%F0%9F%9A%80%20Quick%20Start%20%28lines%2032%E2%80%9361%29%2C%20%22Works%20With%22%20mirrors%20line%2029%2C%20%22Requirements%22%20mirrors%20the%20Prerequisites%20note%2C%20%22Why%20Aegra%20vs%20LangSmith%3F%22%20mirrors%20the%20%F0%9F%94%A5%20comparison%20table%20%28lines%2083%E2%80%9396%29%2C%20%22License%22%20mirrors%20the%20%F0%9F%93%84%20License%20section%2C%20and%20%22Help%20Resources%22%20mirrors%20the%20%F0%9F%92%AC%20Community%20%26%20Support%20section.%20A%20FAQ%20section%20is%20most%20useful%20when%20it%20answers%20questions%20not%20already%20covered%20inline%20%E2%80%94%20as%20written%2C%20this%20section%20adds%20significant%20length%20with%20no%20new%20information%20for%20the%20reader.%0A%0A%23%23%23%20Issue%202%20of%204%0AREADME.md%3A182%0A**FAQ%20section%20placed%20after%20the%20document's%20visual%20closing%20element**%0A%0AThe%20FAQ%20is%20appended%20after%20the%20closing%20%60%3C%2Fa%3E%60%20of%20the%20star%20history%20chart%2C%20which%20was%20the%20intended%20final%20flourish%20of%20the%20document.%20Inserting%20substantial%20text%20after%20it%20breaks%20the%20reading%20flow%20and%20will%20appear%20after%20the%20chart%20image%20in%20rendered%20Markdown.%20It%20should%20be%20placed%20before%20the%20star%20history%20section%2C%20or%20at%20the%20very%20least%20before%20the%20%60---%60%20separator%20on%20line%20168.%0A%0A%23%23%23%20Issue%203%20of%204%0AREADME.md%3A209-214%0A**%22Works%20With%22%20links%20are%20plain%20text%20paths%2C%20not%20hyperlinks**%0A%0AThe%20existing%20README%20%28line%2029%29%20already%20links%20these%20platforms%20with%20full%20GitHub%20URLs%20%28%60https%3A%2F%2Fgithub.com%2Flangchain-ai%2Fagent-chat-ui%60%2C%20etc.%29%2C%20but%20the%20FAQ%20table%20shows%20bare%20paths%20like%20%60langchain-ai%2Fagent-chat-ui%60%20as%20unlinked%20text.%20Readers%20clicking%20on%20them%20will%20get%20nothing.%20The%20table%20either%20needs%20proper%20Markdown%20links%20or%20should%20be%20dropped%20in%20favour%20of%20the%20already-linked%20line%2029.%0A%0A%23%23%23%20Issue%204%20of%204%0AREADME.md%3A197-207%0A**Installation%20instructions%20are%20incomplete%20compared%20to%20the%20Quick%20Start**%0A%0AThe%20existing%20Quick%20Start%20%28lines%2034%E2%80%9348%29%20shows%20the%20full%20CLI%20flow%3A%20%60pip%20install%20aegra-cli%60%2C%20%60aegra%20init%60%2C%20%60cd%20%3Cproject%3E%60%2C%20%60cp%20.env.example%20.env%60%20%28with%20a%20note%20to%20add%20%60OPENAI_API_KEY%60%29%2C%20%60uv%20sync%60%2C%20and%20%60uv%20run%20aegra%20dev%60.%20The%20FAQ%20version%20omits%20%60cp%20.env.example%20.env%60%2C%20the%20API%20key%20note%2C%20%60uv%20sync%60%2C%20and%20%60uv%20run%20aegra%20dev%60%2C%20so%20a%20user%20following%20the%20FAQ%20steps%20will%20end%20up%20without%20a%20working%20%60.env%60%20and%20no%20running%20server.%20It%20also%20skips%20the%20important%20note%20about%20installing%20%60aegra-cli%60%20rather%20than%20the%20%60aegra%60%20meta-package%20%28line%2050%29.%0A%0A&pr=397&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22docs%2Fadd-faq-section%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fadd-faq-section%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0AREADME.md%3A182-235%0A**FAQ%20duplicates%20most%20of%20the%20existing%20README%20content**%0A%0ANearly%20every%20subsection%20in%20the%20new%20FAQ%20repeats%20content%20that%20already%20exists%20higher%20up%20in%20the%20document%3A%20%22What%20is%20Aegra%3F%22%20mirrors%20line%2027%2C%20%22Key%20Features%22%20duplicates%20the%20%E2%9C%A8%20Features%20section%20%28lines%2097%E2%80%93108%29%2C%20%22How%20to%20Install%22%20mirrors%20the%20%F0%9F%9A%80%20Quick%20Start%20%28lines%2032%E2%80%9361%29%2C%20%22Works%20With%22%20mirrors%20line%2029%2C%20%22Requirements%22%20mirrors%20the%20Prerequisites%20note%2C%20%22Why%20Aegra%20vs%20LangSmith%3F%22%20mirrors%20the%20%F0%9F%94%A5%20comparison%20table%20%28lines%2083%E2%80%9396%29%2C%20%22License%22%20mirrors%20the%20%F0%9F%93%84%20License%20section%2C%20and%20%22Help%20Resources%22%20mirrors%20the%20%F0%9F%92%AC%20Community%20%26%20Support%20section.%20A%20FAQ%20section%20is%20most%20useful%20when%20it%20answers%20questions%20not%20already%20covered%20inline%20%E2%80%94%20as%20written%2C%20this%20section%20adds%20significant%20length%20with%20no%20new%20information%20for%20the%20reader.%0A%0A%23%23%23%20Issue%202%20of%204%0AREADME.md%3A182%0A**FAQ%20section%20placed%20after%20the%20document's%20visual%20closing%20element**%0A%0AThe%20FAQ%20is%20appended%20after%20the%20closing%20%60%3C%2Fa%3E%60%20of%20the%20star%20history%20chart%2C%20which%20was%20the%20intended%20final%20flourish%20of%20the%20document.%20Inserting%20substantial%20text%20after%20it%20breaks%20the%20reading%20flow%20and%20will%20appear%20after%20the%20chart%20image%20in%20rendered%20Markdown.%20It%20should%20be%20placed%20before%20the%20star%20history%20section%2C%20or%20at%20the%20very%20least%20before%20the%20%60---%60%20separator%20on%20line%20168.%0A%0A%23%23%23%20Issue%203%20of%204%0AREADME.md%3A209-214%0A**%22Works%20With%22%20links%20are%20plain%20text%20paths%2C%20not%20hyperlinks**%0A%0AThe%20existing%20README%20%28line%2029%29%20already%20links%20these%20platforms%20with%20full%20GitHub%20URLs%20%28%60https%3A%2F%2Fgithub.com%2Flangchain-ai%2Fagent-chat-ui%60%2C%20etc.%29%2C%20but%20the%20FAQ%20table%20shows%20bare%20paths%20like%20%60langchain-ai%2Fagent-chat-ui%60%20as%20unlinked%20text.%20Readers%20clicking%20on%20them%20will%20get%20nothing.%20The%20table%20either%20needs%20proper%20Markdown%20links%20or%20should%20be%20dropped%20in%20favour%20of%20the%20already-linked%20line%2029.%0A%0A%23%23%23%20Issue%204%20of%204%0AREADME.md%3A197-207%0A**Installation%20instructions%20are%20incomplete%20compared%20to%20the%20Quick%20Start**%0A%0AThe%20existing%20Quick%20Start%20%28lines%2034%E2%80%9348%29%20shows%20the%20full%20CLI%20flow%3A%20%60pip%20install%20aegra-cli%60%2C%20%60aegra%20init%60%2C%20%60cd%20%3Cproject%3E%60%2C%20%60cp%20.env.example%20.env%60%20%28with%20a%20note%20to%20add%20%60OPENAI_API_KEY%60%29%2C%20%60uv%20sync%60%2C%20and%20%60uv%20run%20aegra%20dev%60.%20The%20FAQ%20version%20omits%20%60cp%20.env.example%20.env%60%2C%20the%20API%20key%20note%2C%20%60uv%20sync%60%2C%20and%20%60uv%20run%20aegra%20dev%60%2C%20so%20a%20user%20following%20the%20FAQ%20steps%20will%20end%20up%20without%20a%20working%20%60.env%60%20and%20no%20running%20server.%20It%20also%20skips%20the%20important%20note%20about%20installing%20%60aegra-cli%60%20rather%20than%20the%20%60aegra%60%20meta-package%20%28line%2050%29.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: Add FAQ section for common questio..."](https://github.com/aegra/aegra/commit/bea63f527ba7086d2bef38777a58db3c6610f420) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34385228)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->