### PR TITLE
docs: add cron feature mention to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ async for chunk in client.runs.stream(
 
 - **[Agent Protocol](https://github.com/langchain-ai/agent-protocol) compliant** - Works with Agent Chat UI, LangGraph Studio, CopilotKit
 - **[Worker architecture](https://docs.aegra.dev/guides/worker-architecture)** - Redis job queue with 30 concurrent runs per instance, lease-based crash recovery, and horizontal scaling across multiple instances
+- **[Scheduled cron jobs](https://docs.aegra.dev/guides/cron)** - Trigger runs on a schedule with standard 5-field or seconds-level 6-field expressions, IANA timezone support, and multi-instance safe `SKIP LOCKED` claim
 - **[Human-in-the-loop](https://docs.aegra.dev/guides/human-in-the-loop)** - Approval gates and user intervention points
 - **[Streaming](https://docs.aegra.dev/guides/streaming)** - Real-time SSE streaming with cross-instance pub/sub and automatic reconnection with event replay
 - **[Persistent state](https://docs.aegra.dev/guides/threads-and-state)** - PostgreSQL checkpoints via LangGraph

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ async for chunk in client.runs.stream(
 |:--|:--|:--|
 | **Deploy agents** | Local dev only (Free), paid cloud (Plus) | Free, unlimited |
 | **Custom auth** | Not available (Free), available (Plus) | Python handlers (JWT/OAuth/Firebase) |
+| **Scheduled cron jobs** | Not available (Free), available (Plus) | Built-in, free |
 | **Self-hosted** | Enterprise only (license key required) | Always (Apache 2.0) |
 | **Own database** | Managed only (Free/Plus), bring your own (Enterprise) | Bring your own Postgres |
 | **Tracing** | LangSmith only | Any OTLP backend (Langfuse, Phoenix, etc.) |
@@ -131,6 +132,7 @@ aegra version           # Show version info
 | [Configuration](https://docs.aegra.dev/reference/configuration) | aegra.json format and all options |
 | [Authentication](https://docs.aegra.dev/guides/authentication) | JWT, OAuth, Firebase, or custom auth handlers |
 | [Worker Architecture](https://docs.aegra.dev/guides/worker-architecture) | Redis job queue, crash recovery, horizontal scaling |
+| [Scheduled cron jobs](https://docs.aegra.dev/guides/cron) | Trigger runs on a schedule with timezone support and multi-instance safe claim |
 | [Streaming](https://docs.aegra.dev/guides/streaming) | 8 SSE stream modes with reconnection |
 | [Store](https://docs.aegra.dev/guides/store) | Key-value and semantic search storage |
 | [Observability](https://docs.aegra.dev/guides/observability) | Fan-out tracing to Langfuse, Phoenix, or any OTLP backend |

--- a/docs/why-aegra.mdx
+++ b/docs/why-aegra.mdx
@@ -32,6 +32,7 @@ These are reasonable trade-offs for prototyping. They become problems at product
 |:--|:--|:--|
 | **Deploy agents** | Local dev only (Free), paid cloud (Plus) | Free, unlimited |
 | **Custom auth** | Not available (Free), available (Plus) | Python handlers (JWT/OAuth/Firebase) |
+| **Scheduled cron jobs** | Not available (Free), available (Plus) | Built-in, free |
 | **Self-hosted** | Enterprise only (license key required) | Always (Apache 2.0) |
 | **Own database** | Managed only (Free/Plus), bring your own (Enterprise) | Bring your own Postgres |
 | **Tracing** | LangSmith only | Any OTLP backend (Langfuse, Phoenix, etc.) |
@@ -54,6 +55,9 @@ See the full breakdown on the [feature support](/feature-support) page.
   </Card>
   <Card title="Human-in-the-loop" icon="hand" href="/guides/human-in-the-loop">
     Approval gates and user intervention points.
+  </Card>
+  <Card title="Scheduled cron jobs" icon="clock" href="/guides/cron">
+    Trigger runs on a schedule with timezone support and multi-instance safe claim.
   </Card>
   <Card title="Authentication" icon="lock" href="/guides/authentication">
     JWT, OAuth, Firebase, or custom auth handlers.

--- a/libs/aegra-api/README.md
+++ b/libs/aegra-api/README.md
@@ -11,6 +11,7 @@ Aegra is an open-source, self-hosted alternative to LangSmith Deployments. This 
 - **Self-Hosted**: Run on your own PostgreSQL database
 - **Streaming Support**: Real-time streaming of agent responses
 - **Human-in-the-Loop**: Built-in support for human approval workflows
+- **Scheduled Cron Jobs**: Trigger runs on a schedule with timezone support and multi-instance safe claim
 - **Vector Store**: Semantic search capabilities with PostgreSQL
 
 ## Installation
@@ -117,6 +118,11 @@ OTEL_TARGETS=LANGFUSE,PHOENIX
 | `/threads/{thread_id}/runs` | POST | Execute graph (background) |
 | `/threads/{thread_id}/runs/stream` | POST | Execute graph (streaming) |
 | `/threads/{thread_id}/runs/{run_id}/cancel` | POST | Cancel a run |
+| `/runs/crons` | POST | Create a stateless cron job |
+| `/threads/{thread_id}/runs/crons` | POST | Create a thread-bound cron job |
+| `/runs/crons/{cron_id}` | PATCH/DELETE | Update or delete a cron job |
+| `/runs/crons/search` | POST | Search cron jobs |
+| `/runs/crons/count` | POST | Count cron jobs |
 | `/store/items` | PUT | Save to vector store |
 | `/store/items/search` | POST | Semantic search |
 | `/store/namespaces` | POST | List store namespaces |


### PR DESCRIPTION
## Summary
- Add scheduled cron jobs bullet to root README features list (links to cron guide)
- Add cron feature mention + six cron endpoints to `libs/aegra-api/README.md`

Follow-up to #395 to make the cron feature discoverable from the READMEs alongside other documented features. Docs-only, no code change.

## Test plan
- [x] Render check (markdown), all links target existing docs paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in scheduled cron jobs with flexible 5- and 6-field expressions, IANA timezone support, and multi-instance safe job claiming.

* **Documentation**
  * Added API documentation for cron management (create, update, delete, search/count).
  * Updated product docs and README to surface built-in cron scheduling and link to the cron guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a docs-only follow-up to #395 that makes the cron scheduling feature discoverable from the root README and the `aegra-api` package README. All added links resolve to the existing `docs/guides/cron.mdx` guide, and the six endpoint rows in `libs/aegra-api/README.md` match the actual routes declared in `crons.py`.

- **README.md**: Adds cron to the LangSmith comparison table, the features list (with a full-detail bullet), and the documentation index table.
- **docs/why-aegra.mdx**: Adds cron to the comparison table and inserts a new `<Card>` in the "What we support today" section; the supporting prose sentence on that same section omits cron, leaving a minor consistency gap.
- **libs/aegra-api/README.md**: Adds cron to the features bullet list and inserts all six cron endpoints into the API table; the package structure diagram (unchanged by this PR) still omits `crons.py`, as noted in a prior review comment.

<h3>Confidence Score: 5/5</h3>

Docs-only change; all added links point to an existing guide and all endpoint paths match the live router implementation.

Every link resolves to a real file, every documented endpoint exists in crons.py, and no code is modified. The only gap is a one-line prose omission in why-aegra.mdx that a reader could find misleading, but it doesn't break anything.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Adds cron to comparison table, features list (with accurate link to existing docs/guides/cron.mdx), and docs table — all entries are accurate. |
| docs/why-aegra.mdx | Adds cron to comparison table and adds a new Card; the "What we support today" prose on line 48 still omits cron from its feature list despite the new card directly below it. |
| libs/aegra-api/README.md | Adds cron to features list and six endpoint rows; endpoints match the actual crons.py router; package structure diagram still omits crons.py (noted in prior review comment). |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Root README.md] -->|links to| C[docs/guides/cron.mdx]
    B[docs/why-aegra.mdx] -->|Card href| C
    D[libs/aegra-api/README.md] -->|endpoint table| E[crons.py router]
    E --> E1[POST /runs/crons]
    E --> E2[POST /threads/id/runs/crons]
    E --> E3[PATCH /runs/crons/id]
    E --> E4[DELETE /runs/crons/id]
    E --> E5[POST /runs/crons/search]
    E --> E6[POST /runs/crons/count]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `libs/aegra-api/README.md`, line 185-188 ([link](https://github.com/aegra/aegra/blob/07449308130da6a240a1c9eb98aa53db770477ea/libs/aegra-api/README.md#L185-L188)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The package structure diagram lists only four files under `api/` but `crons.py` exists and is the implementation backing all six cron endpoints just added to the endpoint table. A reader exploring the package layout won't find any indication that a cron module exists.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2FREADME.md%0ALine%3A%20185-188%0A%0AComment%3A%0AThe%20package%20structure%20diagram%20lists%20only%20four%20files%20under%20%60api%2F%60%20but%20%60crons.py%60%20exists%20and%20is%20the%20implementation%20backing%20all%20six%20cron%20endpoints%20just%20added%20to%20the%20endpoint%20table.%20A%20reader%20exploring%20the%20package%20layout%20won't%20find%20any%20indication%20that%20a%20cron%20module%20exists.%0A%0A%60%60%60suggestion%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20assistants.py%20%23%20%2Fassistants%20CRUD%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20threads.py%20%20%20%20%23%20%2Fthreads%20and%20state%20management%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20runs.py%20%20%20%20%20%20%20%23%20%2Fruns%20execution%20and%20streaming%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20crons.py%20%20%20%20%20%20%23%20%2Fruns%2Fcrons%20scheduling%20endpoints%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%94%E2%94%80%E2%94%80%20store.py%20%20%20%20%20%20%23%20%2Fstore%20vector%20storage%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=400&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2FREADME.md%0ALine%3A%20185-188%0A%0AComment%3A%0AThe%20package%20structure%20diagram%20lists%20only%20four%20files%20under%20%60api%2F%60%20but%20%60crons.py%60%20exists%20and%20is%20the%20implementation%20backing%20all%20six%20cron%20endpoints%20just%20added%20to%20the%20endpoint%20table.%20A%20reader%20exploring%20the%20package%20layout%20won't%20find%20any%20indication%20that%20a%20cron%20module%20exists.%0A%0A%60%60%60suggestion%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20assistants.py%20%23%20%2Fassistants%20CRUD%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20threads.py%20%20%20%20%23%20%2Fthreads%20and%20state%20management%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20runs.py%20%20%20%20%20%20%20%23%20%2Fruns%20execution%20and%20streaming%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20crons.py%20%20%20%20%20%20%23%20%2Fruns%2Fcrons%20scheduling%20endpoints%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%94%E2%94%80%E2%94%80%20store.py%20%20%20%20%20%20%23%20%2Fstore%20vector%20storage%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=400&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22docs%2Fcron-readme-update%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fcron-readme-update%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2FREADME.md%0ALine%3A%20185-188%0A%0AComment%3A%0AThe%20package%20structure%20diagram%20lists%20only%20four%20files%20under%20%60api%2F%60%20but%20%60crons.py%60%20exists%20and%20is%20the%20implementation%20backing%20all%20six%20cron%20endpoints%20just%20added%20to%20the%20endpoint%20table.%20A%20reader%20exploring%20the%20package%20layout%20won't%20find%20any%20indication%20that%20a%20cron%20module%20exists.%0A%0A%60%60%60suggestion%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20assistants.py%20%23%20%2Fassistants%20CRUD%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20threads.py%20%20%20%20%23%20%2Fthreads%20and%20state%20management%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20runs.py%20%20%20%20%20%20%20%23%20%2Fruns%20execution%20and%20streaming%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%9C%E2%94%80%E2%94%80%20crons.py%20%20%20%20%20%20%23%20%2Fruns%2Fcrons%20scheduling%20endpoints%0A%E2%94%82%20%20%20%E2%94%82%20%20%20%E2%94%94%E2%94%80%E2%94%80%20store.py%20%20%20%20%20%20%23%20%2Fstore%20vector%20storage%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fwhy-aegra.mdx%3A48%0AThe%20%22What%20we%20support%20today%22%20prose%20lists%20supported%20capabilities%20but%20doesn't%20mention%20scheduled%20cron%20jobs%2C%20even%20though%20cron%20is%20now%20called%20out%20in%20the%20comparison%20table%20and%20the%20new%20Card%20directly%20below.%20A%20reader%20skimming%20the%20prose%20introduction%20would%20miss%20it.%0A%0A%60%60%60suggestion%0AAegra%20covers%20the%20core%20capabilities%20needed%20for%20production%20agent%20deployments%3A%20assistants%2C%20threads%2C%20streaming%2C%20human-in-the-loop%2C%20persistent%20state%2C%20key-value%20and%20semantic%20storage%2C%20auth%2C%20observability%2C%20scheduled%20cron%20jobs%2C%20and%20deployment%20to%20Docker%2C%20PaaS%2C%20or%20Kubernetes.%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=400&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fwhy-aegra.mdx%3A48%0AThe%20%22What%20we%20support%20today%22%20prose%20lists%20supported%20capabilities%20but%20doesn't%20mention%20scheduled%20cron%20jobs%2C%20even%20though%20cron%20is%20now%20called%20out%20in%20the%20comparison%20table%20and%20the%20new%20Card%20directly%20below.%20A%20reader%20skimming%20the%20prose%20introduction%20would%20miss%20it.%0A%0A%60%60%60suggestion%0AAegra%20covers%20the%20core%20capabilities%20needed%20for%20production%20agent%20deployments%3A%20assistants%2C%20threads%2C%20streaming%2C%20human-in-the-loop%2C%20persistent%20state%2C%20key-value%20and%20semantic%20storage%2C%20auth%2C%20observability%2C%20scheduled%20cron%20jobs%2C%20and%20deployment%20to%20Docker%2C%20PaaS%2C%20or%20Kubernetes.%0A%60%60%60%0A%0A&pr=400&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22docs%2Fcron-readme-update%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Fcron-readme-update%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fwhy-aegra.mdx%3A48%0AThe%20%22What%20we%20support%20today%22%20prose%20lists%20supported%20capabilities%20but%20doesn't%20mention%20scheduled%20cron%20jobs%2C%20even%20though%20cron%20is%20now%20called%20out%20in%20the%20comparison%20table%20and%20the%20new%20Card%20directly%20below.%20A%20reader%20skimming%20the%20prose%20introduction%20would%20miss%20it.%0A%0A%60%60%60suggestion%0AAegra%20covers%20the%20core%20capabilities%20needed%20for%20production%20agent%20deployments%3A%20assistants%2C%20threads%2C%20streaming%2C%20human-in-the-loop%2C%20persistent%20state%2C%20key-value%20and%20semantic%20storage%2C%20auth%2C%20observability%2C%20scheduled%20cron%20jobs%2C%20and%20deployment%20to%20Docker%2C%20PaaS%2C%20or%20Kubernetes.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["docs: add cron to root README comparison..."](https://github.com/aegra/aegra/commit/505fd03b7e9dc60f839d7b1139c4deb956755fa3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34709738)</sub>

<!-- /greptile_comment -->