### PR TITLE
test(cron): make update_cron end_time test date relative

### DIFF
--- a/libs/aegra-api/tests/unit/test_services/test_cron_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_cron_service.py
@@ -795,7 +795,7 @@ class TestUpdateCronExtended:
         cron_service: CronService,
         mock_session: AsyncMock,
     ) -> None:
-        end = datetime(2026, 6, 1, tzinfo=UTC)
+        end = datetime.now(UTC) + timedelta(days=365)
         updated = _make_cron_orm(end_time=end)
         mock_session.scalar.side_effect = [_make_cron_orm(), updated]
 


### PR DESCRIPTION
## Description

  The unit test `TestUpdateCronExtended::test_updates_end_time` hardcoded `end_time = datetime(2026, 6, 1, tzinfo=UTC)`. The `CronUpdate` model validator requires `end_time` to be in the future, so the test passed in CI until 2026-06-01 and started failing on a clean tree from 2026-06-02 onward — a time-bomb unrelated to any code change.

  The fix makes the date relative (`datetime.now(UTC) + timedelta(days=365)`), matching the sibling test `test_sets_end_time` in the same file. No production code changes.

  ## Type of Change

  - [ ] `feat`: New feature
  - [ ] `fix`: Bug fix
  - [ ] `docs`: Documentation changes
  - [ ] `style`: Code style/formatting
  - [ ] `refactor`: Code refactoring
  - [ ] `perf`: Performance improvement
  - [x] `test`: Tests added/updated
  - [ ] `chore`: Maintenance (dependencies, build, etc.)
  - [ ] `ci`: CI/CD changes

  ## Related Issues

  N/A

  ## Changes Made

  - Replace the hardcoded `datetime(2026, 6, 1)` `end_time` in `test_updates_end_time` with a relative `datetime.now(UTC) + timedelta(days=365)`, so the future-`end_time` validator on `CronUpdate` no longer rejects the value once the wall clock passes the literal date.

  ## Testing

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] E2E tests added/updated
  - [ ] Manual testing performed

  Ran unit + integration suites: `1538 passed`. The previously failing test now passes. `ruff check` and `ruff format --check` both clean.

  ## Checklist

  - [x] Code follows project style (Ruff formatting)
  - [x] All linting checks pass (`make lint`)
  - [ ] Type checking passes (`make type-check`)
  - [x] All tests pass (`make test`)
  - [ ] Documentation updated (if needed)
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] PR title follows Conventional Commits format

  ## Screenshots (if applicable)

  N/A

  ## Additional Notes

  Test-only change; no version bump. `make test` shows the relevant levels passing (1538 unit + integration).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a unit test to use dynamic time computation instead of fixed values for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a time-bomb in `test_updates_end_time` where a hardcoded `end_time` of `datetime(2026, 6, 1)` caused the test to fail as soon as the wall clock passed that date, since the `CronUpdate` model validator rejects `end_time` values in the past.

- Replaces the hardcoded date with `datetime.now(UTC) + timedelta(days=365)`, consistent with the sibling test `test_sets_end_time` in the same file.
- `timedelta` was already imported; no production code is touched.

<h3>Confidence Score: 5/5</h3>

Single-line test fix with no production code changes; the relative date formula is correct and already follows the pattern used by the sibling test.

The change is isolated to one line in a test file, replaces a literal date that had already expired with a future-relative expression, and reuses an import already present in the file. The logic matches the adjacent test, and there are no production-code modifications.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/tests/unit/test_services/test_cron_service.py | Replaces hardcoded `datetime(2026, 6, 1)` with `datetime.now(UTC) + timedelta(days=365)` in `test_updates_end_time`; `timedelta` was already imported, so no other changes are needed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["test_updates_end_time runs"] --> B{"end_time > now?"}
    B -- "Before fix: hardcoded 2026-06-01\n(fails after that date)" --> C["CronUpdate validator rejects\nend_time → ValidationError → test fails"]
    B -- "After fix: now(UTC) + 365 days\n(always in the future)" --> D["CronUpdate validator accepts\nend_time → test passes"]
```

<sub>Reviews (1): Last reviewed commit: ["test(cron): make update\_cron end\_time te..."](https://github.com/aegra/aegra/commit/1407372db5da1f7238d086d9325db51b0da4065c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35328253)</sub>

<!-- /greptile_comment -->