### PR TITLE
fix(settings): translate sslmode using libpq spellings asyncpg accepts

### DIFF
--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -11,17 +11,11 @@ from aegra_api.constants import MULTIHOST_URL_RE
 
 _logger = logging.getLogger(__name__)
 
-# libpq sslmode → asyncpg ssl query param. asyncpg has no analog for
-# "allow"/"prefer" (try-then-fallback) — both map to off, matching the
-# safer-of-the-two interpretation for an application server.
-_SSLMODE_TO_ASYNCPG: dict[str, str] = {
-    "disable": "false",
-    "allow": "false",
-    "prefer": "false",
-    "require": "true",
-    "verify-ca": "true",
-    "verify-full": "true",
-}
+# Valid libpq sslmode values. asyncpg's `ssl` kwarg, when given a string,
+# parses it via SSLMode.parse() and only accepts these spellings. Boolean
+# strings like "true"/"false" raise ClientConfigurationError. We rename
+# `sslmode=X` → `ssl=X` and pass the value through verbatim.
+_VALID_SSLMODES: frozenset[str] = frozenset({"disable", "allow", "prefer", "require", "verify-ca", "verify-full"})
 
 # libpq params that asyncpg rejects as unknown kwargs. We strip these from
 # the async URL — users who need them must use PG* env vars or a custom
@@ -176,18 +170,19 @@ class DatabaseSettings(EnvBase):
 
         for key, value in parse_qsl(query, keep_blank_values=True):
             if key == "sslmode":
-                mapped = _SSLMODE_TO_ASYNCPG.get(value.lower())
-                if mapped is None:
+                normalized = value.lower()
+                if normalized not in _VALID_SSLMODES:
                     _logger.warning("Unknown sslmode=%r in DATABASE_URL; ignoring", value)
                     continue
-                if value.lower() in ("verify-ca", "verify-full"):
+                if normalized in ("verify-ca", "verify-full"):
                     _logger.warning(
-                        "DATABASE_URL sslmode=%s requires an SSLContext for cert verification; "
-                        "asyncpg will negotiate TLS but skip the verify-* check. "
-                        "Use PGSSLMODE + PGSSLROOTCERT env vars for full verification.",
+                        "DATABASE_URL sslmode=%s — asyncpg will verify the server cert "
+                        "against PGSSLROOTCERT or ~/.postgresql/root.crt and fail to "
+                        "connect if neither is available. Set PGSSLROOTCERT to a CA bundle "
+                        "(or use an SSLContext via connect_args) if startup fails.",
                         value,
                     )
-                rewritten.append(("ssl", mapped))
+                rewritten.append(("ssl", normalized))
             elif key in _LIBPQ_ONLY_PARAMS:
                 dropped.append(key)
             else:

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -1,8 +1,9 @@
 """Tests for AppSettings, DatabaseSettings, and WorkerSettings."""
 
-from urllib.parse import quote_plus
+from urllib.parse import parse_qs, quote_plus, urlsplit
 
 import pytest
+from asyncpg.connect_utils import SSLMode  # type: ignore[import-untyped]
 from pydantic import ValidationError
 from sqlalchemy.engine import make_url
 
@@ -151,10 +152,11 @@ class TestDatabaseURLSupport:
         assert "connect_timeout=10" in db.database_url_sync
         assert db.database_url_sync.startswith("postgresql://")
 
-    def test_async_url_translates_sslmode_require_to_ssl_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """asyncpg rejects ``sslmode`` as an unknown kwarg. We translate it
-        to ``ssl=true`` so the async engine starts cleanly when users paste
-        a libpq-style URL (the common shape from RDS/Azure/GCP consoles)."""
+    def test_async_url_translates_sslmode_require_to_ssl_require(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """asyncpg rejects ``sslmode`` as an unknown kwarg, but accepts ``ssl``
+        with libpq sslmode spellings (``ssl=require``). We rename the param
+        and keep the value so the async engine starts cleanly when users
+        paste a libpq-style URL (the common shape from RDS/Azure/GCP consoles)."""
         monkeypatch.setenv(
             "DATABASE_URL",
             "postgresql://user:pass@host:5432/db?sslmode=require",
@@ -163,29 +165,35 @@ class TestDatabaseURLSupport:
         db = DatabaseSettings(_env_file=None)
 
         assert "sslmode" not in db.database_url
-        assert "ssl=true" in db.database_url
+        assert "ssl=require" in db.database_url
         assert db.database_url.startswith("postgresql+asyncpg://")
 
     @pytest.mark.parametrize(
-        ("sslmode", "expected_ssl"),
-        [
-            ("disable", "false"),
-            ("allow", "false"),
-            ("prefer", "false"),
-            ("require", "true"),
-            ("verify-ca", "true"),
-            ("verify-full", "true"),
-        ],
+        "sslmode",
+        ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"],
     )
-    def test_async_url_translates_all_sslmode_values(
-        self, monkeypatch: pytest.MonkeyPatch, sslmode: str, expected_ssl: str
-    ) -> None:
+    def test_async_url_translates_all_sslmode_values(self, monkeypatch: pytest.MonkeyPatch, sslmode: str) -> None:
         monkeypatch.setenv("DATABASE_URL", f"postgresql://u:p@h:5432/db?sslmode={sslmode}")
 
         db = DatabaseSettings(_env_file=None)
 
-        assert f"ssl={expected_ssl}" in db.database_url
+        assert f"ssl={sslmode}" in db.database_url
         assert "sslmode" not in db.database_url
+
+    @pytest.mark.parametrize(
+        "sslmode",
+        ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"],
+    )
+    def test_translated_ssl_value_accepted_by_asyncpg(self, sslmode: str) -> None:
+        """Regression: the value we put after ``ssl=`` must parse via
+        ``asyncpg.connect_utils.SSLMode.parse``. asyncpg >= 0.28 raises
+        ClientConfigurationError for unknown values (e.g. ``"true"``/``"false"``)."""
+        mapped = DatabaseSettings._translate_libpq_params_for_asyncpg(
+            f"postgresql+asyncpg://u:p@h/db?sslmode={sslmode}&connect_timeout=10"
+        )
+        ssl_value = parse_qs(urlsplit(mapped).query)["ssl"][0]
+        # Must not raise — SSLMode.parse() is what asyncpg runs internally.
+        SSLMode.parse(ssl_value)
 
     def test_async_url_strips_other_libpq_only_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``channel_binding`` / ``sslcert`` etc. also crash asyncpg as unknown
@@ -395,7 +403,7 @@ class TestMultiHostDatabaseURL:
         assert url.startswith("postgresql+asyncpg://user:pass@/db?")
         assert "host=h1,h2" in url
         assert "port=5432,5432" in url
-        assert "ssl=true" in url
+        assert "ssl=require" in url
         # libpq-only kwargs that asyncpg would reject are stripped.
         assert "target_session_attrs" not in url
         assert "sslmode" not in url


### PR DESCRIPTION
## Description

  Fixes a startup crash when `DATABASE_URL` contains any `?sslmode=` query param. The translation introduced in #390 rewrote `sslmode=X` to `ssl=true` / `ssl=false`, but asyncpg ≥ 0.28 strict-validates string `ssl` kwargs via `SSLMode.parse()`, which only accepts libpq sslmode
  spellings (`disable`/`allow`/`prefer`/`require`/`verify-ca`/`verify-full`). `"true"` and `"false"` both raise `ClientConfigurationError`, so every aegra install that uses `?sslmode=` in the URL — the standard shape copied from RDS / Cloud SQL / Azure / Heroku consoles —
  crashes at startup.

  The fix renames `sslmode=X` → `ssl=X` and passes the value through verbatim. asyncpg's string `ssl` kwarg, when given a libpq sslmode value, runs `SSLMode.parse()` and behaves identically to libpq.

  ## Type of Change

  - [x] `fix`: Bug fix

  ## Related Issues

 Closes #404 

  ## Changes Made

  - `libs/aegra-api/src/aegra_api/settings.py`: replace `_SSLMODE_TO_ASYNCPG` dict (mapped to `"true"`/`"false"`) with a `_VALID_SSLMODES` frozenset; pass the original sslmode value through as `ssl=<value>` after lowercasing.
  - `libs/aegra-api/src/aegra_api/settings.py`: update the `verify-ca`/`verify-full` warning — with the corrected translation, asyncpg *does* perform certificate verification against `PGSSLROOTCERT` / `~/.postgresql/root.crt`; the old text claiming "TLS but skip the verify-* 
  check" is no longer accurate.
  - `libs/aegra-api/tests/unit/test_settings.py`: add `test_translated_ssl_value_accepted_by_asyncpg` regression test that actually calls `asyncpg.connect_utils.SSLMode.parse()` on the produced value — closing the gap left by existing tests that only assert string composition.
  - `libs/aegra-api/tests/unit/test_settings.py`: update existing `test_async_url_translates_*` assertions to match the new `ssl=<sslmode>` shape.


  ## Testing

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] E2E tests added/updated
  - [x] Manual testing performed

  Manual verification (`asyncpg 0.31.0`, `sqlalchemy 2.0.46`):

  1. **Reproduce on `main`** — `SSLMode.parse("false")` raises `AttributeError` → asyncpg re-raises as `ClientConfigurationError` with the misleading "sslmode parameter must be one of..." message.
  2. **Confirm fix** — translated URL becomes `postgresql+asyncpg://...?ssl=disable`; `SSLMode.parse("disable") == SSLMode.disable` ✓.
  3. **End-to-end against a real Postgres**:
     - `sslmode=disable` against a plain Postgres → connects ✓
     - `sslmode=require` against a Postgres with `ssl=on` + `hostssl`-only `pg_hba.conf` → connects via SSL ✓
     - `sslmode=allow` against the same SSL-required Postgres → asyncpg correctly retries with SSL after non-SSL is rejected (`pg_stat_ssl.ssl = true`) ✓
  4. **Negative case** — unknown sslmode values (`?sslmode=bogus`) still log a warning and drop the param.

  ## Checklist

  - [x] Code follows project style (Ruff formatting) 
  - [x] All linting checks pass (`make lint`)
  - [x] Type checking passes (`make type-check`)
  - [x] All tests pass (`make test`)
  - [x] Documentation updated (if needed) — *N/A: no public docs reference the internal `ssl=true`/`ssl=false` translation; user-facing recommendation (`PGSSLMODE` env var) is unchanged.*
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] PR title follows Conventional Commits format

  ## Screenshots (if applicable)

  N/A

  ## Additional Notes

  - Root cause is upstream tightening: asyncpg 0.28+ routes string `ssl` kwargs through `SSLMode.parse()` (`connect_utils.py:680-687`), and SQLAlchemy's asyncpg dialect (`create_connect_args`) forwards URL query params verbatim without coercing `ssl` from str to bool. The
  previous test suite only asserted URL string composition — it never instantiated a connection — which is why the bug shipped and CI never flagged it. The new regression test (`test_translated_ssl_value_accepted_by_asyncpg`) calls `SSLMode.parse()` directly to catch this class
   of issue.
  - `database_url_sync` (psycopg / LangGraph checkpointer + store) is unaffected: psycopg speaks libpq natively and accepts `sslmode=` as-is.
  - Ironic side note for future readers: *not* specifying `sslmode` at all also works around the bug — asyncpg's default with no `ssl` kwarg is `SSLMode.disable` (`connect_utils.py:815`), unlike libpq's default `prefer`. So this bug specifically punishes users who explicitly
  set `sslmode=`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter handling of database SSL/TLS modes: unknown modes are warned and omitted; certificate-verification modes emit clearer warnings about expected root CA placement.
  * SSL parameter conversion now preserves the mode value (e.g., ssl=require) in converted async database URLs instead of mapping to boolean.

* **Tests**
  * Updated tests to assert preserved SSL mode in converted URLs and to validate accepted parsed SSL values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a startup crash in `DatabaseSettings` when `DATABASE_URL` contains an `?sslmode=` query param: asyncpg ≥ 0.28 validates string `ssl` kwargs via `SSLMode.parse()`, which rejects `"true"`/`"false"` with `ClientConfigurationError`. The fix replaces the `_SSLMODE_TO_ASYNCPG` dict with a `_VALID_SSLMODES` frozenset and passes the libpq sslmode value through verbatim as `ssl=<value>`.

- **`settings.py`**: `_SSLMODE_TO_ASYNCPG` removed; `sslmode` is now translated inline to `ssl=<normalized-value>` and dropped from `_LIBPQ_ONLY_PARAMS`. The `allow`→`prefer` remapping is also dropped (asyncpg supports `allow` natively). The verify-ca/verify-full warning is updated to reflect that asyncpg will now actually perform cert verification.
- **`test_settings.py`**: Parametrized assertions updated to expect `ssl=<sslmode>` (e.g. `ssl=allow` instead of `ssl=prefer`). A new regression test (`test_translated_ssl_value_accepted_by_asyncpg`) calls `SSLMode.parse()` directly on the emitted value, closing the gap that let the original bug ship undetected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core sslmode translation logic is correct, well-tested, and manually verified against a real Postgres instance.

The fix is narrowly scoped to sslmode param translation in a single static method. The new regression test calls SSLMode.parse() directly, closing the validation gap that allowed the original bug to ship. The allow→allow passthrough (dropping the old allow→prefer remap) is validated by the same test. No data path, auth boundary, or migration is touched.

The top-level import of asyncpg.connect_utils.SSLMode in the test file is the only thing worth a second look — see inline comment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/settings.py | Replaces the _SSLMODE_TO_ASYNCPG dict (which incorrectly mapped allow→prefer and emitted true/false) with a _VALID_SSLMODES frozenset; sslmode values are now passed through verbatim as ssl=<value>. Removes sslmode from _LIBPQ_ONLY_PARAMS (it is handled inline). Warning message for verify-ca/verify-full updated to reflect correct cert-verification behavior. Logic is correct. |
| libs/aegra-api/tests/unit/test_settings.py | Updates translation assertions to match new ssl=<sslmode> shape; adds test_translated_ssl_value_accepted_by_asyncpg that calls SSLMode.parse() directly. Main concern: SSLMode is now imported at module level from a private asyncpg internal, so any future relocation of the symbol would cause all tests in the file to fail at collection time. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DATABASE_URL with ?sslmode=X"] --> B["_translate_libpq_params_for_asyncpg()"]
    B --> C{key == 'sslmode'?}
    C -- yes --> D["normalized = value.lower()"]
    D --> E{normalized in _VALID_SSLMODES?}
    E -- no --> F["warn + drop param"]
    E -- yes --> G{normalized in verify-ca / verify-full?}
    G -- yes --> H["emit cert-verification warning"]
    G -- no --> I["append ('ssl', normalized)"]
    H --> I
    C -- no --> J{key in _LIBPQ_ONLY_PARAMS?}
    J -- yes --> K["warn + drop param"]
    J -- no --> L["append (key, value) verbatim"]
    I --> M["async URL: ...?ssl=require"]
    L --> M
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Ftests%2Funit%2Ftest_settings.py%3A6%0A**Hard%20top-level%20import%20of%20private%20asyncpg%20symbol**%0A%0A%60asyncpg.connect_utils%60%20is%20an%20internal%2C%20undocumented%20module.%20Importing%20%60SSLMode%60%20at%20module%20level%20means%20that%20if%20a%20future%20asyncpg%20release%20moves%20or%20renames%20the%20symbol%2C%20every%20test%20in%20this%20file%20will%20fail%20to%20collect%20%E2%80%94%20not%20just%20the%20SSLMode%20regression%20test.%20The%20previous%20approach%20%28%60pytest.importorskip%60%20%2B%20%60getattr%28...%2C%20None%29%60%29%20degraded%20gracefully%20with%20a%20loud%20skip%3B%20this%20approach%20breaks%20the%20entire%20suite%20silently.%0A%0AConsider%20guarding%20this%20with%20a%20try%2Fexcept%20and%20marking%20the%20test%20class%20with%20a%20module-level%20%60skipif%60%2C%20or%20restoring%20the%20%60importorskip%60%20pattern%20inside%20the%20regression%20test.%20The%20%60%23%20type%3A%20ignore%5Bimport-untyped%5D%60%20already%20signals%20awareness%20that%20this%20is%20a%20private%20import.%0A%0A&repo=aegra%2Faegra&pr=405&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Ftests%2Funit%2Ftest_settings.py%3A6%0A**Hard%20top-level%20import%20of%20private%20asyncpg%20symbol**%0A%0A%60asyncpg.connect_utils%60%20is%20an%20internal%2C%20undocumented%20module.%20Importing%20%60SSLMode%60%20at%20module%20level%20means%20that%20if%20a%20future%20asyncpg%20release%20moves%20or%20renames%20the%20symbol%2C%20every%20test%20in%20this%20file%20will%20fail%20to%20collect%20%E2%80%94%20not%20just%20the%20SSLMode%20regression%20test.%20The%20previous%20approach%20%28%60pytest.importorskip%60%20%2B%20%60getattr%28...%2C%20None%29%60%29%20degraded%20gracefully%20with%20a%20loud%20skip%3B%20this%20approach%20breaks%20the%20entire%20suite%20silently.%0A%0AConsider%20guarding%20this%20with%20a%20try%2Fexcept%20and%20marking%20the%20test%20class%20with%20a%20module-level%20%60skipif%60%2C%20or%20restoring%20the%20%60importorskip%60%20pattern%20inside%20the%20regression%20test.%20The%20%60%23%20type%3A%20ignore%5Bimport-untyped%5D%60%20already%20signals%20awareness%20that%20this%20is%20a%20private%20import.%0A%0A&pr=405&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fsslmode-asyncpg-strict%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsslmode-asyncpg-strict%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Ftests%2Funit%2Ftest_settings.py%3A6%0A**Hard%20top-level%20import%20of%20private%20asyncpg%20symbol**%0A%0A%60asyncpg.connect_utils%60%20is%20an%20internal%2C%20undocumented%20module.%20Importing%20%60SSLMode%60%20at%20module%20level%20means%20that%20if%20a%20future%20asyncpg%20release%20moves%20or%20renames%20the%20symbol%2C%20every%20test%20in%20this%20file%20will%20fail%20to%20collect%20%E2%80%94%20not%20just%20the%20SSLMode%20regression%20test.%20The%20previous%20approach%20%28%60pytest.importorskip%60%20%2B%20%60getattr%28...%2C%20None%29%60%29%20degraded%20gracefully%20with%20a%20loud%20skip%3B%20this%20approach%20breaks%20the%20entire%20suite%20silently.%0A%0AConsider%20guarding%20this%20with%20a%20try%2Fexcept%20and%20marking%20the%20test%20class%20with%20a%20module-level%20%60skipif%60%2C%20or%20restoring%20the%20%60importorskip%60%20pattern%20inside%20the%20regression%20test.%20The%20%60%23%20type%3A%20ignore%5Bimport-untyped%5D%60%20already%20signals%20awareness%20that%20this%20is%20a%20private%20import.%0A%0A&repo=aegra%2Faegra&pr=405&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/sslmode-asy..."](https://github.com/aegra/aegra/commit/c38193576167ab8cad6cdc258f63e6a3bbd4b34b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35571077)</sub>

<!-- /greptile_comment -->