### PR TITLE
feat(database): add DATABASE_ENABLED flag for optional persistence mode

### DIFF
--- a/libs/aegra-api/src/aegra_api/core/database.py
+++ b/libs/aegra-api/src/aegra_api/core/database.py
@@ -21,6 +21,27 @@ if TYPE_CHECKING:
 logger = structlog.get_logger(__name__)
 
 
+class _NoOpStore:
+    """Stub store that raises on any operation when running in memory mode.
+
+    Returned by ``get_store()`` in memory mode so callers always receive an
+    object (avoiding ``AttributeError`` on ``None``), but get a descriptive
+    error if they attempt store operations that require PostgreSQL.
+    """
+
+    async def aget(self, *args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("Store is disabled in memory mode (DATABASE_ENABLED=false)")
+
+    async def aput(self, *args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("Store is disabled in memory mode (DATABASE_ENABLED=false)")
+
+    async def adelete(self, *args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("Store is disabled in memory mode (DATABASE_ENABLED=false)")
+
+    async def alist_namespaces(self, *args: Any, **kwargs: Any) -> list:
+        raise RuntimeError("Store is disabled in memory mode (DATABASE_ENABLED=false)")
+
+
 class DatabaseManager:
     """Manages database connections and LangGraph persistence components.
 
@@ -45,9 +66,11 @@ class DatabaseManager:
         Use when DATABASE_ENABLED=false. State is ephemeral and lost on restart,
         but the application starts without requiring any external database.
         """
+        if self._memory_mode and self._checkpointer is not None:
+            return
         self._memory_mode = True
         self._checkpointer = MemorySaver()
-        self._store = None  # No persistent store in memory mode
+        self._store = _NoOpStore()
         logger.info("✅ In-memory checkpointing initialized (no PostgreSQL)")
 
     async def initialize(self) -> None:
@@ -137,10 +160,15 @@ class DatabaseManager:
             raise RuntimeError("Database not initialized — call initialize() or initialize_memory_mode() first")
         return self._checkpointer
 
-    def get_store(self) -> AsyncPostgresStore | None:
-        """Return the store backend, or None if running in memory mode."""
+    def get_store(self) -> "AsyncPostgresStore | _NoOpStore":
+        """Return the store backend.
+
+        In memory mode, returns a ``_NoOpStore`` stub that raises a descriptive
+        ``RuntimeError`` on any operation, preventing silent ``AttributeError``
+        crashes in downstream callers.
+        """
         if self._memory_mode:
-            return None
+            return self._store  # type: ignore[return-value]  # _NoOpStore
         if self._store is None:
             raise RuntimeError("Database not initialized")
         return self._store

--- a/libs/aegra-api/src/aegra_api/core/database.py
+++ b/libs/aegra-api/src/aegra_api/core/database.py
@@ -69,6 +69,11 @@ class DatabaseManager:
         Use when DATABASE_ENABLED=false. State is ephemeral and lost on restart,
         but the application starts without requiring any external database.
         """
+        if self.engine is not None or self.lg_pool is not None:
+            raise RuntimeError(
+                "Cannot switch to memory mode after PostgreSQL initialization. "
+                "Call close() first."
+            )
         if self._memory_mode and self._checkpointer is not None:
             return
         self._memory_mode = True
@@ -78,6 +83,11 @@ class DatabaseManager:
 
     async def initialize(self) -> None:
         """Initialize database connections and LangGraph components"""
+        if self._memory_mode:
+            raise RuntimeError(
+                "Cannot switch to PostgreSQL mode after memory initialization. "
+                "Call close() first."
+            )
         # Idempotency check: if already initialized, do nothing
         if self.engine:
             return
@@ -137,9 +147,11 @@ class DatabaseManager:
         logger.info("✅ Database and LangGraph components initialized")
 
     async def close(self) -> None:
-        """Close database connections (no-op in memory mode)."""
+        """Close database connections and reset state."""
         if self._memory_mode:
             self._checkpointer = None
+            self._store = None
+            self._memory_mode = False
             logger.info("✅ In-memory checkpointer released")
             return
 

--- a/libs/aegra-api/src/aegra_api/core/database.py
+++ b/libs/aegra-api/src/aegra_api/core/database.py
@@ -70,10 +70,7 @@ class DatabaseManager:
         but the application starts without requiring any external database.
         """
         if self.engine is not None or self.lg_pool is not None:
-            raise RuntimeError(
-                "Cannot switch to memory mode after PostgreSQL initialization. "
-                "Call close() first."
-            )
+            raise RuntimeError("Cannot switch to memory mode after PostgreSQL initialization. Call close() first.")
         if self._memory_mode and self._checkpointer is not None:
             return
         self._memory_mode = True
@@ -84,10 +81,7 @@ class DatabaseManager:
     async def initialize(self) -> None:
         """Initialize database connections and LangGraph components"""
         if self._memory_mode:
-            raise RuntimeError(
-                "Cannot switch to PostgreSQL mode after memory initialization. "
-                "Call close() first."
-            )
+            raise RuntimeError("Cannot switch to PostgreSQL mode after memory initialization. Call close() first.")
         # Idempotency check: if already initialized, do nothing
         if self.engine:
             return

--- a/libs/aegra-api/src/aegra_api/core/database.py
+++ b/libs/aegra-api/src/aegra_api/core/database.py
@@ -1,6 +1,11 @@
 """Database manager with LangGraph integration"""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import structlog
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langgraph.store.postgres.aio import AsyncPostgresStore
 from psycopg.rows import dict_row
@@ -10,20 +15,40 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from aegra_api.config import load_store_config
 from aegra_api.settings import settings
 
+if TYPE_CHECKING:
+    from langgraph.checkpoint.base import BaseCheckpointSaver
+
 logger = structlog.get_logger(__name__)
 
 
 class DatabaseManager:
-    """Manages database connections and LangGraph persistence components"""
+    """Manages database connections and LangGraph persistence components.
+
+    Supports two modes controlled by ``settings.db.DATABASE_ENABLED``:
+      - **postgres** (default): full PostgreSQL-backed checkpointing and store.
+      - **memory**: lightweight in-process MemorySaver — no external DB required.
+    """
 
     def __init__(self) -> None:
         self.engine: AsyncEngine | None = None
+        self._memory_mode: bool = False
 
         # Shared pool for LangGraph components (Checkpointer + Store)
         self.lg_pool: AsyncConnectionPool | None = None
-        self._checkpointer: AsyncPostgresSaver | None = None
-        self._store: AsyncPostgresStore | None = None
+        self._checkpointer: BaseCheckpointSaver | None = None
+        self._store: AsyncPostgresStore | Any | None = None
         self._database_url = settings.db.database_url
+
+    async def initialize_memory_mode(self) -> None:
+        """Initialize with in-memory checkpointing (no database required).
+
+        Use when DATABASE_ENABLED=false. State is ephemeral and lost on restart,
+        but the application starts without requiring any external database.
+        """
+        self._memory_mode = True
+        self._checkpointer = MemorySaver()
+        self._store = None  # No persistent store in memory mode
+        logger.info("✅ In-memory checkpointing initialized (no PostgreSQL)")
 
     async def initialize(self) -> None:
         """Initialize database connections and LangGraph components"""
@@ -86,7 +111,12 @@ class DatabaseManager:
         logger.info("✅ Database and LangGraph components initialized")
 
     async def close(self) -> None:
-        """Close database connections"""
+        """Close database connections (no-op in memory mode)."""
+        if self._memory_mode:
+            self._checkpointer = None
+            logger.info("✅ In-memory checkpointer released")
+            return
+
         # Close SQLAlchemy engine
         if self.engine:
             await self.engine.dispose()
@@ -101,14 +131,16 @@ class DatabaseManager:
 
         logger.info("✅ Database connections closed")
 
-    def get_checkpointer(self) -> AsyncPostgresSaver:
-        """Return the live AsyncPostgresSaver instance."""
+    def get_checkpointer(self) -> BaseCheckpointSaver:
+        """Return the checkpointer (Postgres or MemorySaver depending on mode)."""
         if self._checkpointer is None:
-            raise RuntimeError("Database not initialized")
+            raise RuntimeError("Database not initialized — call initialize() or initialize_memory_mode() first")
         return self._checkpointer
 
-    def get_store(self) -> AsyncPostgresStore:
-        """Return the live AsyncPostgresStore instance."""
+    def get_store(self) -> AsyncPostgresStore | None:
+        """Return the store backend, or None if running in memory mode."""
+        if self._memory_mode:
+            return None
         if self._store is None:
             raise RuntimeError("Database not initialized")
         return self._store
@@ -118,6 +150,11 @@ class DatabaseManager:
         if not self.engine:
             raise RuntimeError("Database not initialized")
         return self.engine
+
+    @property
+    def is_memory_mode(self) -> bool:
+        """Whether the manager is running in memory-only mode (no PostgreSQL)."""
+        return self._memory_mode
 
 
 # Global database manager instance

--- a/libs/aegra-api/src/aegra_api/core/database.py
+++ b/libs/aegra-api/src/aegra_api/core/database.py
@@ -38,6 +38,9 @@ class _NoOpStore:
     async def adelete(self, *args: Any, **kwargs: Any) -> None:
         raise RuntimeError("Store is disabled in memory mode (DATABASE_ENABLED=false)")
 
+    async def asearch(self, *args: Any, **kwargs: Any) -> list:
+        raise RuntimeError("Store is disabled in memory mode (DATABASE_ENABLED=false)")
+
     async def alist_namespaces(self, *args: Any, **kwargs: Any) -> list:
         raise RuntimeError("Store is disabled in memory mode (DATABASE_ENABLED=false)")
 

--- a/libs/aegra-api/src/aegra_api/core/health.py
+++ b/libs/aegra-api/src/aegra_api/core/health.py
@@ -55,6 +55,9 @@ async def health_check(_request: Request) -> HealthResponse:
 
     Verifies connectivity to PostgreSQL, the checkpoint backend, and the
     store backend. Returns 503 if any component is unhealthy.
+
+    When DATABASE_ENABLED=false, database and store are reported as
+    "disabled" (healthy) and only the in-memory checkpointer is probed.
     """
     health_status = {
         "status": "healthy",
@@ -63,39 +66,51 @@ async def health_check(_request: Request) -> HealthResponse:
         "langgraph_store": "unknown",
     }
 
-    # Database connectivity
-    try:
-        if db_manager.engine:
-            async with db_manager.engine.begin() as conn:
-                await conn.execute(text("SELECT 1"))
-            health_status["database"] = "connected"
-        else:
-            health_status["database"] = "not_initialized"
+    if db_manager.is_memory_mode:
+        health_status["database"] = "disabled"
+        health_status["langgraph_store"] = "disabled"
+        # Verify in-memory checkpointer is reachable
+        try:
+            checkpointer = db_manager.get_checkpointer()
+            with contextlib.suppress(Exception):
+                await checkpointer.aget_tuple({"configurable": {"thread_id": "health-check"}})
+            health_status["langgraph_checkpointer"] = "connected (memory)"
+        except Exception as e:
+            health_status["langgraph_checkpointer"] = f"error: {str(e)}"
             health_status["status"] = "unhealthy"
-    except Exception as e:
-        health_status["database"] = f"error: {str(e)}"
-        health_status["status"] = "unhealthy"
+    else:
+        # Database connectivity
+        try:
+            if db_manager.engine:
+                async with db_manager.engine.begin() as conn:
+                    await conn.execute(text("SELECT 1"))
+                health_status["database"] = "connected"
+            else:
+                health_status["database"] = "not_initialized"
+                health_status["status"] = "unhealthy"
+        except Exception as e:
+            health_status["database"] = f"error: {str(e)}"
+            health_status["status"] = "unhealthy"
 
-    # LangGraph checkpointer (lazy-init)
-    try:
-        checkpointer = db_manager.get_checkpointer()
-        # probe - will raise if connection is bad; tuple may not exist which is fine
-        with contextlib.suppress(Exception):
-            await checkpointer.aget_tuple({"configurable": {"thread_id": "health-check"}})
-        health_status["langgraph_checkpointer"] = "connected"
-    except Exception as e:
-        health_status["langgraph_checkpointer"] = f"error: {str(e)}"
-        health_status["status"] = "unhealthy"
+        # LangGraph checkpointer (lazy-init)
+        try:
+            checkpointer = db_manager.get_checkpointer()
+            with contextlib.suppress(Exception):
+                await checkpointer.aget_tuple({"configurable": {"thread_id": "health-check"}})
+            health_status["langgraph_checkpointer"] = "connected"
+        except Exception as e:
+            health_status["langgraph_checkpointer"] = f"error: {str(e)}"
+            health_status["status"] = "unhealthy"
 
-    # LangGraph store (lazy-init)
-    try:
-        store = db_manager.get_store()
-        with contextlib.suppress(Exception):
-            await store.aget(("health",), "check")
-        health_status["langgraph_store"] = "connected"
-    except Exception as e:
-        health_status["langgraph_store"] = f"error: {str(e)}"
-        health_status["status"] = "unhealthy"
+        # LangGraph store (lazy-init)
+        try:
+            store = db_manager.get_store()
+            with contextlib.suppress(Exception):
+                await store.aget(("health",), "check")
+            health_status["langgraph_store"] = "connected"
+        except Exception as e:
+            health_status["langgraph_store"] = f"error: {str(e)}"
+            health_status["status"] = "unhealthy"
 
     if health_status["status"] == "unhealthy":
         raise HTTPException(status_code=503, detail="Service unhealthy")
@@ -109,7 +124,19 @@ async def readiness_check(_request: Request) -> dict[str, str]:
 
     Returns 200 when the server can accept traffic (database and graph
     backends are initialized). Returns 503 otherwise.
+
+    In memory mode, only verifies the in-memory checkpointer is available.
     """
+    if db_manager.is_memory_mode:
+        try:
+            db_manager.get_checkpointer()
+        except RuntimeError as e:
+            raise HTTPException(
+                status_code=503,
+                detail=f"Service not ready - checkpointer unavailable: {str(e)}",
+            ) from e
+        return {"status": "ready"}
+
     # Engine must exist and respond to a trivial query
     if not db_manager.engine:
         raise HTTPException(

--- a/libs/aegra-api/src/aegra_api/core/health.py
+++ b/libs/aegra-api/src/aegra_api/core/health.py
@@ -72,8 +72,7 @@ async def health_check(_request: Request) -> HealthResponse:
         # Verify in-memory checkpointer is reachable
         try:
             checkpointer = db_manager.get_checkpointer()
-            with contextlib.suppress(Exception):
-                await checkpointer.aget_tuple({"configurable": {"thread_id": "health-check"}})
+            await checkpointer.aget_tuple({"configurable": {"thread_id": "health-check"}})
             health_status["langgraph_checkpointer"] = "connected (memory)"
         except Exception as e:
             health_status["langgraph_checkpointer"] = f"error: {str(e)}"

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -77,23 +77,30 @@ def _log_connection_help(error: Exception) -> None:
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """FastAPI lifespan context manager for startup/shutdown"""
-    # Multi-pod K8s: set RUN_MIGRATIONS_ON_STARTUP=false + run `aegra db upgrade`
-    # out-of-band. See docs/guides/deployment.mdx.
-    if settings.app.RUN_MIGRATIONS_ON_STARTUP:
+    if settings.db.DATABASE_ENABLED:
+        # Multi-pod K8s: set RUN_MIGRATIONS_ON_STARTUP=false + run `aegra db upgrade`
+        # out-of-band. See docs/guides/deployment.mdx.
+        if settings.app.RUN_MIGRATIONS_ON_STARTUP:
+            try:
+                await run_migrations_async()
+            except (ConnectionRefusedError, OSError) as e:
+                _log_connection_help(e)
+                raise
+        else:
+            logger.info("skipping startup migrations (RUN_MIGRATIONS_ON_STARTUP=false)")
+
+        # Startup: Initialize database and LangGraph components
         try:
-            await run_migrations_async()
+            await db_manager.initialize()
         except (ConnectionRefusedError, OSError) as e:
             _log_connection_help(e)
             raise
     else:
-        logger.info("skipping startup migrations (RUN_MIGRATIONS_ON_STARTUP=false)")
-
-    # Startup: Initialize database and LangGraph components
-    try:
-        await db_manager.initialize()
-    except (ConnectionRefusedError, OSError) as e:
-        _log_connection_help(e)
-        raise
+        logger.info(
+            "Running without PostgreSQL (DATABASE_ENABLED=false). "
+            "Using in-memory checkpointing — state is lost on restart."
+        )
+        await db_manager.initialize_memory_mode()
 
     # Observability
     setup_observability()
@@ -150,7 +157,8 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     if settings.redis.REDIS_BROKER_ENABLED:
         await redis_manager.close()
 
-    await db_manager.close()
+    if settings.db.DATABASE_ENABLED:
+        await db_manager.close()
 
 
 # Define core exception handlers

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -157,8 +157,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     if settings.redis.REDIS_BROKER_ENABLED:
         await redis_manager.close()
 
-    if settings.db.DATABASE_ENABLED:
-        await db_manager.close()
+    await db_manager.close()
 
 
 # Define core exception handlers

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -133,8 +133,13 @@ class DatabaseSettings(EnvBase):
     Supports two configuration modes:
     1. DATABASE_URL (standard for containerized deployments) — parsed into individual fields
     2. Individual POSTGRES_* vars — used when DATABASE_URL is not set
+
+    Set DATABASE_ENABLED=false to run without PostgreSQL entirely.
+    The server will use in-memory checkpointing (MemorySaver) and skip
+    all database initialization, migrations, and health probes.
     """
 
+    DATABASE_ENABLED: bool = True
     DATABASE_URL: str | None = None
 
     POSTGRES_USER: str = "postgres"


### PR DESCRIPTION
## Summary

Allow `aegra_api` to run **without PostgreSQL** by setting a single environment variable:

```bash
DATABASE_ENABLED=false
```

When disabled, the server uses LangGraph's `MemorySaver` for in-memory checkpointing and skips all database initialization, migrations, and health probes. This enables lightweight deployments (development, CI, stateless workers) that don't need durable persistence.

## Changes

| File | What |
|------|------|
| `settings.py` | Add `DATABASE_ENABLED: bool = True` to `DatabaseSettings` |
| `main.py` | Guard DB init/migrations and shutdown behind the flag |
| `core/database.py` | Add `initialize_memory_mode()`, `is_memory_mode` property, conditional `close()` |
| `core/health.py` | `/health` and `/ready` report database as `"disabled"` in memory mode instead of returning 503 |

## Motivation

- **Issue #406**: Server crashes on startup when no PostgreSQL is available — the lifespan unconditionally calls `db_manager.initialize()` and `run_migrations_async()`.
- **Issue #407**: Health/readiness probes hard-depend on database connectivity, causing Kubernetes to kill pods even when the application itself is functional in stateless mode.

## Design Decisions

- **Backward compatible**: `DATABASE_ENABLED` defaults to `True` — no behavior change for existing deployments.
- **Follows existing patterns**: Mirrors the `REDIS_BROKER_ENABLED` / `CRON_ENABLED` guards already in `main.py`.
- **Minimal surface area**: Single setting controls all DB-related behavior (init, migrations, health probes, shutdown).
- **`MemorySaver` fallback**: Provides a working checkpointer for development and testing without external dependencies.

## Test Plan

- [ ] `DATABASE_ENABLED=true` (default): verify existing behavior unchanged — DB connects, migrations run, health probes check DB
- [ ] `DATABASE_ENABLED=false`: verify startup without PostgreSQL, `/health` returns `{"database": "disabled", ...}`, `/ready` returns `{"status": "ready"}`
- [ ] Kill PostgreSQL mid-session with `DATABASE_ENABLED=true`: verify health probes return 503
- [ ] Verify `MemorySaver` persists thread state within a single process lifecycle

Closes #406
Closes #407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit “memory mode” to run without PostgreSQL using in-memory checkpointing.
  * Introduced `DATABASE_ENABLED` to disable PostgreSQL (default: enabled).
  * Startup now automatically selects database-backed mode or memory mode, skipping DB init/migrations when disabled.
* **Bug Fixes**
  * Health and readiness checks now correctly reflect database vs memory mode; readiness fails clearly when the in-memory checkpointer is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an optional no-database mode for the API. The main changes are:

- `DATABASE_ENABLED` now controls whether PostgreSQL is initialized.
- Memory mode uses LangGraph `MemorySaver` for checkpointing.
- Startup and shutdown now branch between database and memory mode.
- Health and readiness checks report database-backed and memory-only states differently.

<h3>Confidence Score: 4/5</h3>

This is close, but the cron startup path should be fixed before merging.

- `DATABASE_ENABLED=false` can still start the cron scheduler by default.
- Cron uses the database session factory on its first tick.
- The server can look healthy while scheduled jobs never run.

libs/aegra-api/src/aegra_api/main.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/database.py | Adds memory-mode setup, no-op store behavior, mode guards, and shutdown cleanup. |
| libs/aegra-api/src/aegra_api/core/health.py | Updates health and readiness checks for PostgreSQL-backed and memory-only modes. |
| libs/aegra-api/src/aegra_api/main.py | Adds memory-mode startup while cron startup still follows the existing cron flag. |
| libs/aegra-api/src/aegra_api/settings.py | Adds the `DATABASE_ENABLED` setting with the existing database-backed behavior as the default. |


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `libs/aegra-api/src/aegra_api/main.py`, line 143-144 ([link](https://github.com/aegra/aegra/blob/fc4a2ce859b0115f3c4667b209b769e8fefb3c75/libs/aegra-api/src/aegra_api/main.py#L143-L144)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cron scheduler will crash at first tick in memory mode**

   `cron_scheduler` uses SQLAlchemy sessions (`_get_session_maker`) and ORM queries against the `crons` table. With `DATABASE_ENABLED=false`, `db_manager.engine` is `None`, so any session factory call or SQLAlchemy query during the first poll tick raises a `RuntimeError`. Since `CRON_ENABLED` defaults to `True`, memory-mode deployments will fail silently after startup.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmain.py%0ALine%3A%20143-144%0A%0AComment%3A%0A**Cron%20scheduler%20will%20crash%20at%20first%20tick%20in%20memory%20mode**%0A%0A%60cron_scheduler%60%20uses%20SQLAlchemy%20sessions%20%28%60_get_session_maker%60%29%20and%20ORM%20queries%20against%20the%20%60crons%60%20table.%20With%20%60DATABASE_ENABLED%3Dfalse%60%2C%20%60db_manager.engine%60%20is%20%60None%60%2C%20so%20any%20session%20factory%20call%20or%20SQLAlchemy%20query%20during%20the%20first%20poll%20tick%20raises%20a%20%60RuntimeError%60.%20Since%20%60CRON_ENABLED%60%20defaults%20to%20%60True%60%2C%20memory-mode%20deployments%20will%20fail%20silently%20after%20startup.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=408&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmain.py%0ALine%3A%20143-144%0A%0AComment%3A%0A**Cron%20scheduler%20will%20crash%20at%20first%20tick%20in%20memory%20mode**%0A%0A%60cron_scheduler%60%20uses%20SQLAlchemy%20sessions%20%28%60_get_session_maker%60%29%20and%20ORM%20queries%20against%20the%20%60crons%60%20table.%20With%20%60DATABASE_ENABLED%3Dfalse%60%2C%20%60db_manager.engine%60%20is%20%60None%60%2C%20so%20any%20session%20factory%20call%20or%20SQLAlchemy%20query%20during%20the%20first%20poll%20tick%20raises%20a%20%60RuntimeError%60.%20Since%20%60CRON_ENABLED%60%20defaults%20to%20%60True%60%2C%20memory-mode%20deployments%20will%20fail%20silently%20after%20startup.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=408&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Foptional-persistence-mode%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Foptional-persistence-mode%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmain.py%0ALine%3A%20143-144%0A%0AComment%3A%0A**Cron%20scheduler%20will%20crash%20at%20first%20tick%20in%20memory%20mode**%0A%0A%60cron_scheduler%60%20uses%20SQLAlchemy%20sessions%20%28%60_get_session_maker%60%29%20and%20ORM%20queries%20against%20the%20%60crons%60%20table.%20With%20%60DATABASE_ENABLED%3Dfalse%60%2C%20%60db_manager.engine%60%20is%20%60None%60%2C%20so%20any%20session%20factory%20call%20or%20SQLAlchemy%20query%20during%20the%20first%20poll%20tick%20raises%20a%20%60RuntimeError%60.%20Since%20%60CRON_ENABLED%60%20defaults%20to%20%60True%60%2C%20memory-mode%20deployments%20will%20fail%20silently%20after%20startup.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `libs/aegra-api/src/aegra_api/main.py`, line 143-144 ([link](https://github.com/aegra/aegra/blob/a8fe4567ea6a69988334e5ea734e32639d0329d9/libs/aegra-api/src/aegra_api/main.py#L143-L144)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cron still needs Postgres**

   When `DATABASE_ENABLED=false`, startup leaves `db_manager.engine` unset but this branch still starts cron whenever `CRON_ENABLED` is true, which is the default. The scheduler's first tick calls `_get_session_maker()`, which calls `db_manager.get_engine()` and raises `RuntimeError("Database not initialized")` on every poll. The loop catches and logs the error, so the server can stay healthy while scheduled jobs never run and `/info` still reports crons as enabled.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmain.py%0ALine%3A%20143-144%0A%0AComment%3A%0A**Cron%20still%20needs%20Postgres**%0A%0AWhen%20%60DATABASE_ENABLED%3Dfalse%60%2C%20startup%20leaves%20%60db_manager.engine%60%20unset%20but%20this%20branch%20still%20starts%20cron%20whenever%20%60CRON_ENABLED%60%20is%20true%2C%20which%20is%20the%20default.%20The%20scheduler's%20first%20tick%20calls%20%60_get_session_maker%28%29%60%2C%20which%20calls%20%60db_manager.get_engine%28%29%60%20and%20raises%20%60RuntimeError%28%22Database%20not%20initialized%22%29%60%20on%20every%20poll.%20The%20loop%20catches%20and%20logs%20the%20error%2C%20so%20the%20server%20can%20stay%20healthy%20while%20scheduled%20jobs%20never%20run%20and%20%60%2Finfo%60%20still%20reports%20crons%20as%20enabled.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20settings.cron.CRON_ENABLED%20and%20settings.db.DATABASE_ENABLED%3A%0A%20%20%20%20%20%20%20%20await%20cron_scheduler.start%28%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=408&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmain.py%0ALine%3A%20143-144%0A%0AComment%3A%0A**Cron%20still%20needs%20Postgres**%0A%0AWhen%20%60DATABASE_ENABLED%3Dfalse%60%2C%20startup%20leaves%20%60db_manager.engine%60%20unset%20but%20this%20branch%20still%20starts%20cron%20whenever%20%60CRON_ENABLED%60%20is%20true%2C%20which%20is%20the%20default.%20The%20scheduler's%20first%20tick%20calls%20%60_get_session_maker%28%29%60%2C%20which%20calls%20%60db_manager.get_engine%28%29%60%20and%20raises%20%60RuntimeError%28%22Database%20not%20initialized%22%29%60%20on%20every%20poll.%20The%20loop%20catches%20and%20logs%20the%20error%2C%20so%20the%20server%20can%20stay%20healthy%20while%20scheduled%20jobs%20never%20run%20and%20%60%2Finfo%60%20still%20reports%20crons%20as%20enabled.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20settings.cron.CRON_ENABLED%20and%20settings.db.DATABASE_ENABLED%3A%0A%20%20%20%20%20%20%20%20await%20cron_scheduler.start%28%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=408&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Foptional-persistence-mode%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Foptional-persistence-mode%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fmain.py%0ALine%3A%20143-144%0A%0AComment%3A%0A**Cron%20still%20needs%20Postgres**%0A%0AWhen%20%60DATABASE_ENABLED%3Dfalse%60%2C%20startup%20leaves%20%60db_manager.engine%60%20unset%20but%20this%20branch%20still%20starts%20cron%20whenever%20%60CRON_ENABLED%60%20is%20true%2C%20which%20is%20the%20default.%20The%20scheduler's%20first%20tick%20calls%20%60_get_session_maker%28%29%60%2C%20which%20calls%20%60db_manager.get_engine%28%29%60%20and%20raises%20%60RuntimeError%28%22Database%20not%20initialized%22%29%60%20on%20every%20poll.%20The%20loop%20catches%20and%20logs%20the%20error%2C%20so%20the%20server%20can%20stay%20healthy%20while%20scheduled%20jobs%20never%20run%20and%20%60%2Finfo%60%20still%20reports%20crons%20as%20enabled.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20settings.cron.CRON_ENABLED%20and%20settings.db.DATABASE_ENABLED%3A%0A%20%20%20%20%20%20%20%20await%20cron_scheduler.start%28%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=408&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmain.py%3A143-144%0A**Cron%20still%20needs%20Postgres**%0A%0AWhen%20%60DATABASE_ENABLED%3Dfalse%60%2C%20startup%20leaves%20%60db_manager.engine%60%20unset%20but%20this%20branch%20still%20starts%20cron%20whenever%20%60CRON_ENABLED%60%20is%20true%2C%20which%20is%20the%20default.%20The%20scheduler's%20first%20tick%20calls%20%60_get_session_maker%28%29%60%2C%20which%20calls%20%60db_manager.get_engine%28%29%60%20and%20raises%20%60RuntimeError%28%22Database%20not%20initialized%22%29%60%20on%20every%20poll.%20The%20loop%20catches%20and%20logs%20the%20error%2C%20so%20the%20server%20can%20stay%20healthy%20while%20scheduled%20jobs%20never%20run%20and%20%60%2Finfo%60%20still%20reports%20crons%20as%20enabled.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20settings.cron.CRON_ENABLED%20and%20settings.db.DATABASE_ENABLED%3A%0A%20%20%20%20%20%20%20%20await%20cron_scheduler.start%28%29%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=408&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmain.py%3A143-144%0A**Cron%20still%20needs%20Postgres**%0A%0AWhen%20%60DATABASE_ENABLED%3Dfalse%60%2C%20startup%20leaves%20%60db_manager.engine%60%20unset%20but%20this%20branch%20still%20starts%20cron%20whenever%20%60CRON_ENABLED%60%20is%20true%2C%20which%20is%20the%20default.%20The%20scheduler's%20first%20tick%20calls%20%60_get_session_maker%28%29%60%2C%20which%20calls%20%60db_manager.get_engine%28%29%60%20and%20raises%20%60RuntimeError%28%22Database%20not%20initialized%22%29%60%20on%20every%20poll.%20The%20loop%20catches%20and%20logs%20the%20error%2C%20so%20the%20server%20can%20stay%20healthy%20while%20scheduled%20jobs%20never%20run%20and%20%60%2Finfo%60%20still%20reports%20crons%20as%20enabled.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20settings.cron.CRON_ENABLED%20and%20settings.db.DATABASE_ENABLED%3A%0A%20%20%20%20%20%20%20%20await%20cron_scheduler.start%28%29%0A%60%60%60%0A%0A&pr=408&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Foptional-persistence-mode%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Foptional-persistence-mode%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmain.py%3A143-144%0A**Cron%20still%20needs%20Postgres**%0A%0AWhen%20%60DATABASE_ENABLED%3Dfalse%60%2C%20startup%20leaves%20%60db_manager.engine%60%20unset%20but%20this%20branch%20still%20starts%20cron%20whenever%20%60CRON_ENABLED%60%20is%20true%2C%20which%20is%20the%20default.%20The%20scheduler's%20first%20tick%20calls%20%60_get_session_maker%28%29%60%2C%20which%20calls%20%60db_manager.get_engine%28%29%60%20and%20raises%20%60RuntimeError%28%22Database%20not%20initialized%22%29%60%20on%20every%20poll.%20The%20loop%20catches%20and%20logs%20the%20error%2C%20so%20the%20server%20can%20stay%20healthy%20while%20scheduled%20jobs%20never%20run%20and%20%60%2Finfo%60%20still%20reports%20crons%20as%20enabled.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20settings.cron.CRON_ENABLED%20and%20settings.db.DATABASE_ENABLED%3A%0A%20%20%20%20%20%20%20%20await%20cron_scheduler.start%28%29%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=408&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["style(database): fix ruff format violati..."](https://github.com/aegra/aegra/commit/a8fe4567ea6a69988334e5ea734e32639d0329d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35807887)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=1640ab19-5310-4fc5-aaf6-3760087c66e8))
- Context used - AGENTS.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=15e5c4fa-b823-4fae-b564-d5a58cb22ed4))

<!-- /greptile_comment -->