### PR TITLE
fix(db): asyncpg crash on DATABASE_URL with sslmode query param

### DIFF
--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.18"
+version = "0.9.19"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -11,16 +11,17 @@ from aegra_api.constants import MULTIHOST_URL_RE
 
 _logger = logging.getLogger(__name__)
 
-# libpq sslmode → asyncpg ssl query param. asyncpg has no analog for
-# "allow"/"prefer" (try-then-fallback) — both map to off, matching the
-# safer-of-the-two interpretation for an application server.
+# libpq sslmode → asyncpg ssl query param. asyncpg's ssl param validates
+# via SSLMode.parse(), which accepts libpq spellings only — "true"/"false"
+# raise ClientConfigurationError. asyncpg has no "allow"; map it to "prefer"
+# (the closest try-TLS-then-fallback mode).
 _SSLMODE_TO_ASYNCPG: dict[str, str] = {
-    "disable": "false",
-    "allow": "false",
-    "prefer": "false",
-    "require": "true",
-    "verify-ca": "true",
-    "verify-full": "true",
+    "disable": "disable",
+    "allow": "prefer",
+    "prefer": "prefer",
+    "require": "require",
+    "verify-ca": "verify-ca",
+    "verify-full": "verify-full",
 }
 
 # libpq params that asyncpg rejects as unknown kwargs. We strip these from

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -151,10 +151,10 @@ class TestDatabaseURLSupport:
         assert "connect_timeout=10" in db.database_url_sync
         assert db.database_url_sync.startswith("postgresql://")
 
-    def test_async_url_translates_sslmode_require_to_ssl_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """asyncpg rejects ``sslmode`` as an unknown kwarg. We translate it
-        to ``ssl=true`` so the async engine starts cleanly when users paste
-        a libpq-style URL (the common shape from RDS/Azure/GCP consoles)."""
+    def test_async_url_translates_sslmode_require_to_ssl_require(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """asyncpg rejects ``sslmode`` as an unknown kwarg. We rename it to
+        ``ssl`` so the async engine starts cleanly when users paste a
+        libpq-style URL (the common shape from RDS/Azure/GCP consoles)."""
         monkeypatch.setenv(
             "DATABASE_URL",
             "postgresql://user:pass@host:5432/db?sslmode=require",
@@ -163,18 +163,18 @@ class TestDatabaseURLSupport:
         db = DatabaseSettings(_env_file=None)
 
         assert "sslmode" not in db.database_url
-        assert "ssl=true" in db.database_url
+        assert "ssl=require" in db.database_url
         assert db.database_url.startswith("postgresql+asyncpg://")
 
     @pytest.mark.parametrize(
         ("sslmode", "expected_ssl"),
         [
-            ("disable", "false"),
-            ("allow", "false"),
-            ("prefer", "false"),
-            ("require", "true"),
-            ("verify-ca", "true"),
-            ("verify-full", "true"),
+            ("disable", "disable"),
+            ("allow", "prefer"),
+            ("prefer", "prefer"),
+            ("require", "require"),
+            ("verify-ca", "verify-ca"),
+            ("verify-full", "verify-full"),
         ],
     )
     def test_async_url_translates_all_sslmode_values(
@@ -186,6 +186,21 @@ class TestDatabaseURLSupport:
 
         assert f"ssl={expected_ssl}" in db.database_url
         assert "sslmode" not in db.database_url
+
+    @pytest.mark.parametrize("sslmode", ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"])
+    def test_translated_ssl_value_is_accepted_by_asyncpg(self, monkeypatch: pytest.MonkeyPatch, sslmode: str) -> None:
+        """The emitted ``ssl`` value must parse via asyncpg's SSLMode — the
+        previous ``true``/``false`` spellings raised ClientConfigurationError
+        at engine startup (GH #404)."""
+        from urllib.parse import parse_qs, urlsplit
+
+        from asyncpg.connect_utils import SSLMode
+
+        monkeypatch.setenv("DATABASE_URL", f"postgresql://u:p@h:5432/db?sslmode={sslmode}")
+        db = DatabaseSettings(_env_file=None)
+
+        ssl_value = parse_qs(urlsplit(db.database_url).query)["ssl"][0]
+        SSLMode.parse(ssl_value)  # raises if asyncpg would reject it
 
     def test_async_url_strips_other_libpq_only_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``channel_binding`` / ``sslcert`` etc. also crash asyncpg as unknown
@@ -395,7 +410,7 @@ class TestMultiHostDatabaseURL:
         assert url.startswith("postgresql+asyncpg://user:pass@/db?")
         assert "host=h1,h2" in url
         assert "port=5432,5432" in url
-        assert "ssl=true" in url
+        assert "ssl=require" in url
         # libpq-only kwargs that asyncpg would reject are stripped.
         assert "target_session_attrs" not in url
         assert "sslmode" not in url

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -194,13 +194,18 @@ class TestDatabaseURLSupport:
         at engine startup (GH #404)."""
         from urllib.parse import parse_qs, urlsplit
 
-        from asyncpg.connect_utils import SSLMode
+        # SSLMode lives in a private asyncpg module; skip loudly (not silently)
+        # if a future asyncpg moves it, rather than masking a real regression.
+        connect_utils = pytest.importorskip("asyncpg.connect_utils")
+        ssl_mode = getattr(connect_utils, "SSLMode", None)
+        if ssl_mode is None:
+            pytest.skip("asyncpg.connect_utils.SSLMode not found in this asyncpg version")
 
         monkeypatch.setenv("DATABASE_URL", f"postgresql://u:p@h:5432/db?sslmode={sslmode}")
         db = DatabaseSettings(_env_file=None)
 
         ssl_value = parse_qs(urlsplit(db.database_url).query)["ssl"][0]
-        SSLMode.parse(ssl_value)  # raises if asyncpg would reject it
+        ssl_mode.parse(ssl_value)  # raises if asyncpg would reject it
 
     def test_async_url_strips_other_libpq_only_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``channel_binding`` / ``sslcert`` etc. also crash asyncpg as unknown

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.18"
+version = "0.9.19"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Problem

Any `DATABASE_URL` carrying a `?sslmode=<x>` query param crashes the async engine at startup:

```
asyncpg.exceptions._base.ClientConfigurationError: `sslmode` parameter must be one of: disable, allow, prefer, require, verify-ca, verify-full
```

The sslmode translation map emitted `ssl=true` / `ssl=false`. asyncpg validates the `ssl` query param via `SSLMode.parse()`, which accepts only libpq spellings — `"true"`/`"false"` raise the (misleadingly worded) error above. SQLAlchemy's asyncpg dialect forwards the query string verbatim and does not coerce a string `ssl` value to a bool.

This hit **every** connection string copied from a managed-Postgres console (RDS, Cloud SQL, Azure, Supabase, Heroku, Neon), all of which ship `?sslmode=require`.

## Fix

Map each `sslmode` to its asyncpg-accepted spelling instead of `true`/`false`:

| sslmode | before | after |
|---------|--------|-------|
| disable | `ssl=false` (broken) | `ssl=disable` |
| allow | `ssl=false` (broken) | `ssl=prefer` |
| prefer | `ssl=false` (broken) | `ssl=prefer` |
| require | `ssl=true` (broken) | `ssl=require` |
| verify-ca | `ssl=true` (broken) | `ssl=verify-ca` |
| verify-full | `ssl=true` (broken) | `ssl=verify-full` |

`allow` has no asyncpg analog, so it maps to `prefer` (closest try-TLS-then-fallback mode).

The sync (psycopg) URL is unaffected — psycopg speaks libpq natively and keeps `sslmode=...`.

## Tests

- Updated existing translation tests to assert the new spellings.
- Added a regression test that feeds the emitted `ssl` value through asyncpg `SSLMode.parse()` — guaranteeing the value can never again be one asyncpg rejects at startup.
- All settings unit tests pass; ruff + ty clean.

Fixes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database SSL-mode translation now emits asyncpg-style string values (e.g., "require", "verify-*", "disable"/"prefer") so connection URLs reflect correct SSL semantics.

* **Tests**
  * Updated unit tests and added validation to ensure generated SSL values are accepted by asyncpg's SSL-mode parser.

* **Chores**
  * Bumped package versions for aegra-api and aegra-cli to 0.9.19.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a startup crash that occurred whenever `DATABASE_URL` contained a `?sslmode=<x>` query param. The old mapping emitted `ssl=true` / `ssl=false`, which asyncpg's `SSLMode.parse()` rejects at engine startup; the fix maps each libpq `sslmode` to its proper asyncpg-accepted spelling (e.g. `require` → `ssl=require`, `disable` → `ssl=disable`).

- **Core fix** in `settings.py`: `_SSLMODE_TO_ASYNCPG` now uses asyncpg-valid spellings for all six libpq `sslmode` values; `allow` (no asyncpg analog) maps to `prefer` as the closest equivalent.
- **Tests** updated to assert new spellings, and a new parametrized regression test feeds each emitted value directly through `asyncpg.connect_utils.SSLMode.parse()`, guarded with `pytest.importorskip` so it skips loudly rather than hard-failing if the private module ever moves.
- **One pre-existing concern remains unaddressed**: the warning emitted for `verify-ca`/`verify-full` on lines 184–190 of `settings.py` still says _"asyncpg will negotiate TLS but skip the verify-* check"_ — now factually incorrect since those modes are passed through verbatim and asyncpg will attempt certificate verification.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the connection-crash fix itself; one pre-existing warning message for verify-ca/verify-full remains factually wrong and was flagged in the previous review round without being corrected in this PR.

The sslmode-to-asyncpg translation is now correct and the regression test anchors it against asyncpg's own parser. The unresolved stale warning (lines 184–190 of settings.py) still tells users that asyncpg will skip certificate verification for verify-ca/verify-full, when the new mapping causes asyncpg to actually attempt it — a user following that advice will hold a wrong mental model and may misdiagnose TLS handshake failures as something else.

libs/aegra-api/src/aegra_api/settings.py — the warning block inside _translate_libpq_params_for_asyncpg for verify-ca/verify-full (lines 184–190) needs its message updated to reflect that asyncpg now performs certificate verification with these modes.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/settings.py | Core mapping fix is correct; stale warning text for verify-ca/verify-full (lines 184–190, unchanged) still claims asyncpg skips cert verification when it no longer does — flagged in previous review, unresolved here. |
| libs/aegra-api/tests/unit/test_settings.py | Tests updated to assert new ssl spellings; regression test validates each mapped value against asyncpg's SSLMode.parse() with proper importorskip guard addressing the previous thread concern. |
| libs/aegra-api/pyproject.toml | Patch version bump 0.9.18 → 0.9.19, no issues. |
| libs/aegra-cli/pyproject.toml | Patch version bump 0.9.18 → 0.9.19 to keep aegra-cli in sync, no issues. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[DATABASE_URL with ?sslmode=X] --> B{_translate_libpq_params_for_asyncpg}
    B --> C{key == sslmode?}
    C -- yes --> D[_SSLMODE_TO_ASYNCPG.get value]
    D --> E{mapped value found?}
    E -- no --> F[log warning, drop param]
    E -- yes --> G{value in verify-ca / verify-full?}
    G -- yes --> H[log warning stale text]
    G -- no --> I[append ssl=mapped to rewritten]
    H --> I
    C -- no --> J{key in _LIBPQ_ONLY_PARAMS?}
    J -- yes --> K[add to dropped list]
    J -- no --> L[keep as-is in rewritten]
    K --> M{dropped not empty?}
    M -- yes --> N[log warning about stripped params]
    I --> O[urlencode rewritten params]
    L --> O
    N --> O
    O --> P[postgresql+asyncpg://... ?ssl=require etc.]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `libs/aegra-api/src/aegra_api/settings.py`, line 184-190 ([link](https://github.com/aegra/aegra/blob/4036c4fd99da072857e6c887e1308e60552a7bb4/libs/aegra-api/src/aegra_api/settings.py#L184-L190)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale warning message after sslmode remapping**

   The warning says _"asyncpg will negotiate TLS but skip the verify-* check"_, but that was true only when `verify-ca`/`verify-full` mapped to `ssl=true` (plain TLS, no cert validation). With the new mapping they now pass `ssl=verify-ca` / `ssl=verify-full` directly to asyncpg, which means asyncpg **will** attempt certificate verification — using whatever CA bundle it finds (usually the system default). A user who reads this warning and assumes verification is silently bypassed will be holding a false mental model; worse, if their CA bundle is absent the connection will fail at TLS handshake rather than at startup, with an opaque error that the warning misdirects them away from.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%0ALine%3A%20184-190%0A%0AComment%3A%0A**Stale%20warning%20message%20after%20sslmode%20remapping**%0A%0AThe%20warning%20says%20_%22asyncpg%20will%20negotiate%20TLS%20but%20skip%20the%20verify-*%20check%22_%2C%20but%20that%20was%20true%20only%20when%20%60verify-ca%60%2F%60verify-full%60%20mapped%20to%20%60ssl%3Dtrue%60%20%28plain%20TLS%2C%20no%20cert%20validation%29.%20With%20the%20new%20mapping%20they%20now%20pass%20%60ssl%3Dverify-ca%60%20%2F%20%60ssl%3Dverify-full%60%20directly%20to%20asyncpg%2C%20which%20means%20asyncpg%20**will**%20attempt%20certificate%20verification%20%E2%80%94%20using%20whatever%20CA%20bundle%20it%20finds%20%28usually%20the%20system%20default%29.%20A%20user%20who%20reads%20this%20warning%20and%20assumes%20verification%20is%20silently%20bypassed%20will%20be%20holding%20a%20false%20mental%20model%3B%20worse%2C%20if%20their%20CA%20bundle%20is%20absent%20the%20connection%20will%20fail%20at%20TLS%20handshake%20rather%20than%20at%20startup%2C%20with%20an%20opaque%20error%20that%20the%20warning%20misdirects%20them%20away%20from.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=409&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%0ALine%3A%20184-190%0A%0AComment%3A%0A**Stale%20warning%20message%20after%20sslmode%20remapping**%0A%0AThe%20warning%20says%20_%22asyncpg%20will%20negotiate%20TLS%20but%20skip%20the%20verify-*%20check%22_%2C%20but%20that%20was%20true%20only%20when%20%60verify-ca%60%2F%60verify-full%60%20mapped%20to%20%60ssl%3Dtrue%60%20%28plain%20TLS%2C%20no%20cert%20validation%29.%20With%20the%20new%20mapping%20they%20now%20pass%20%60ssl%3Dverify-ca%60%20%2F%20%60ssl%3Dverify-full%60%20directly%20to%20asyncpg%2C%20which%20means%20asyncpg%20**will**%20attempt%20certificate%20verification%20%E2%80%94%20using%20whatever%20CA%20bundle%20it%20finds%20%28usually%20the%20system%20default%29.%20A%20user%20who%20reads%20this%20warning%20and%20assumes%20verification%20is%20silently%20bypassed%20will%20be%20holding%20a%20false%20mental%20model%3B%20worse%2C%20if%20their%20CA%20bundle%20is%20absent%20the%20connection%20will%20fail%20at%20TLS%20handshake%20rather%20than%20at%20startup%2C%20with%20an%20opaque%20error%20that%20the%20warning%20misdirects%20them%20away%20from.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=409&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fsslmode-asyncpg-translation%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsslmode-asyncpg-translation%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fsettings.py%0ALine%3A%20184-190%0A%0AComment%3A%0A**Stale%20warning%20message%20after%20sslmode%20remapping**%0A%0AThe%20warning%20says%20_%22asyncpg%20will%20negotiate%20TLS%20but%20skip%20the%20verify-*%20check%22_%2C%20but%20that%20was%20true%20only%20when%20%60verify-ca%60%2F%60verify-full%60%20mapped%20to%20%60ssl%3Dtrue%60%20%28plain%20TLS%2C%20no%20cert%20validation%29.%20With%20the%20new%20mapping%20they%20now%20pass%20%60ssl%3Dverify-ca%60%20%2F%20%60ssl%3Dverify-full%60%20directly%20to%20asyncpg%2C%20which%20means%20asyncpg%20**will**%20attempt%20certificate%20verification%20%E2%80%94%20using%20whatever%20CA%20bundle%20it%20finds%20%28usually%20the%20system%20default%29.%20A%20user%20who%20reads%20this%20warning%20and%20assumes%20verification%20is%20silently%20bypassed%20will%20be%20holding%20a%20false%20mental%20model%3B%20worse%2C%20if%20their%20CA%20bundle%20is%20absent%20the%20connection%20will%20fail%20at%20TLS%20handshake%20rather%20than%20at%20startup%2C%20with%20an%20opaque%20error%20that%20the%20warning%20misdirects%20them%20away%20from.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=409&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["chore(release): bump version to 0.9.19"](https://github.com/aegra/aegra/commit/dba950cec4abadbc0dda50c497ba82f5b28f5e92) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36010684)</sub>

<!-- /greptile_comment -->