### PR TITLE
test(runs): settle run via join before asserting interrupt status

### DIFF
--- a/libs/aegra-api/tests/e2e/test_runs/test_runs.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_runs.py
@@ -293,6 +293,12 @@ async def test_runs_wait_with_interrupts_e2e():
 
         check_and_skip_if_geo_blocked(last_run)
 
+        # The wait response can return before the run row leaves "running"
+        # (the status write races the HTTP response). Join blocks until the
+        # run reaches a terminal state, then re-read to get the settled status.
+        await client.runs.join(thread_id, last_run["run_id"])
+        last_run = (await client.runs.list(thread_id))[0]
+
         # Status can be interrupted or success depending on graph structure
         assert last_run["status"] in ("interrupted", "success"), (
             f"Expected interrupted or success status, got {last_run['status']}"


### PR DESCRIPTION
## Problem

`test_runs_wait_with_interrupts_e2e` flaked in CI:

```
AssertionError: Expected interrupted or success status, got running
assert 'running' in ('interrupted', 'success')
```

The `/runs/wait` endpoint can return `200` before the run row transitions out of `running` — the status write races the HTTP response. The test listed the run immediately after the wait returned, so it sometimes read the still-transient `running` status and failed the terminal-status assert.

This is a test-only race; the endpoint behaves correctly. Nothing in the run lifecycle changed.

## Fix

Join the run before asserting. `client.runs.join(thread_id, run_id)` blocks until the run reaches a terminal state, then re-read the settled status. Same join primitive already used elsewhere in this suite.

```python
await client.runs.join(thread_id, last_run["run_id"])
last_run = (await client.runs.list(thread_id))[0]
assert last_run["status"] in ("interrupted", "success")
```

## Verification

Ran the test against a live server **3× in a row → 3 passes** (2.4–4.6s each). Previously flaked on the status read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of run wait endpoint testing to ensure consistent results in asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CI flake in `test_runs_wait_with_interrupts_e2e` where the test read the run status immediately after `/runs/wait` returned, sometimes catching the still-transient `running` value before the server committed the terminal status. The fix inserts `await client.runs.join(thread_id, last_run["run_id"])` — already used elsewhere in the suite — to block until the run row is settled, then re-fetches the list to assert on the finalized status.

- Adds two lines to the test: a `join` call to wait for terminal state, and a re-read of `runs.list` to get the settled status.
- No production code is changed; the fix is entirely within the E2E test.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change touches only a single E2E test and correctly applies the same join pattern already established in the same file.

The fix is a two-line addition to a test: a blocking join that waits for terminal state, followed by a re-fetch of the run list. The same client.runs.join primitive is used at line 55 of the same file, so the approach is consistent with existing practice. No production paths are touched, and the race it closes is clearly described and reproducible.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/tests/e2e/test_runs/test_runs.py | Inserts a client.runs.join call before the terminal-status assertion in test_runs_wait_with_interrupts_e2e to eliminate the race between the HTTP response and the status-column write. No logic changes outside this test. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant T as Test
    participant S as Server (/runs/wait)
    participant DB as Database

    T->>S: "POST /threads/{id}/runs/wait (interrupt_before=agent)"
    S-->>T: 200 OK (HTTP response)
    Note over S,DB: Status write may still be in-flight
    T->>S: runs.join(thread_id, run_id) — BLOCKS
    S->>DB: poll / await terminal status
    DB-->>S: "status = interrupted | success"
    S-->>T: join resolves
    T->>S: runs.list(thread_id)
    S-->>T: run with settled status
    T->>T: assert status in (interrupted, success) ✓
```

<sub>Reviews (1): Last reviewed commit: ["test(runs): settle run via join before a..."](https://github.com/aegra/aegra/commit/eebe1742cd8005e90eba09a1485a8b8c6aedc325) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36030862)</sub>

<!-- /greptile_comment -->