### PR TITLE
fix(db): resolve bundled alembic.ini, never a foreign one in CWD

### DIFF
--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.19"
+version = "0.9.20"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/core/migrations.py
+++ b/libs/aegra-api/src/aegra_api/core/migrations.py
@@ -1,6 +1,6 @@
 """Alembic migration helpers.
 
-Resolves alembic.ini from CWD or the installed package. Two entry points:
+Resolves the bundled alembic.ini from the installed package. Two entry points:
 - ``run_migrations()``: unconditional upgrade, takes advisory lock. Use for
   out-of-band runs (``aegra db upgrade``, init container, Helm Job).
 - ``run_migrations_if_needed()``: lock-free precheck, skips upgrade when
@@ -22,11 +22,17 @@ logger = structlog.get_logger(__name__)
 
 
 def find_alembic_ini() -> Path:
-    """Find alembic.ini file.
+    """Find the bundled alembic.ini, never a foreign one in CWD.
 
     Resolution order:
-    1. alembic.ini in CWD (repo development, Docker)
-    2. Bundled with aegra_api package (pip install)
+    1. Bundled with aegra_api package (pip install)
+    2. Development layout (repo/editable install)
+
+    Resolving CWD first would match a host project's own alembic.ini and
+    silently skip our migrations, so a fresh DB crashes with relation
+    "assistant" does not exist (GH #306). Both branches resolve relative to
+    this module, so CWD is irrelevant — including Docker, where the package
+    branch wins regardless of workdir.
 
     Returns:
         Absolute path to alembic.ini
@@ -34,19 +40,14 @@ def find_alembic_ini() -> Path:
     Raises:
         FileNotFoundError: If alembic.ini cannot be found
     """
-    # 1. CWD (works in repo dev and Docker)
-    cwd_ini = Path("alembic.ini")
-    if cwd_ini.exists():
-        return cwd_ini.resolve()
-
-    # 2. Package bundled (pip install aegra-api)
+    # 1. Package bundled (pip install aegra-api)
     # In installed package: site-packages/aegra_api/alembic.ini
     package_dir = Path(__file__).resolve().parent.parent  # aegra_api/
     package_ini = package_dir / "alembic.ini"
     if package_ini.exists():
         return package_ini
 
-    # 3. Development layout (src layout: libs/aegra-api/src/aegra_api/ → libs/aegra-api/)
+    # 2. Development layout (src layout: libs/aegra-api/src/aegra_api/ → libs/aegra-api/)
     dev_root = package_dir.parent.parent  # Up from src/aegra_api/ to libs/aegra-api/
     dev_ini = dev_root / "alembic.ini"
     if dev_ini.exists():

--- a/libs/aegra-api/tests/unit/test_migrations.py
+++ b/libs/aegra-api/tests/unit/test_migrations.py
@@ -5,20 +5,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from aegra_api.core import migrations as migrations_mod
 from aegra_api.core.migrations import find_alembic_ini, get_alembic_config
 
 
 class TestFindAlembicIni:
     """Tests for find_alembic_ini() resolution order."""
-
-    def test_finds_alembic_ini_in_cwd(self, tmp_path, monkeypatch):
-        """Should find alembic.ini when it exists in CWD."""
-        monkeypatch.chdir(tmp_path)
-        ini_file = tmp_path / "alembic.ini"
-        ini_file.write_text("[alembic]\nscript_location = alembic\n")
-
-        result = find_alembic_ini()
-        assert result == ini_file.resolve()
 
     def test_finds_alembic_ini_in_package(self, tmp_path, monkeypatch):
         """Should find alembic.ini bundled with the aegra_api package."""
@@ -32,15 +24,29 @@ class TestFindAlembicIni:
         assert result.name == "alembic.ini"
         assert result.exists()
 
-    def test_cwd_takes_priority_over_package(self, tmp_path, monkeypatch):
-        """CWD alembic.ini should be preferred over package-bundled one."""
+    def test_ignores_foreign_cwd_ini(self, tmp_path, monkeypatch):
+        """A host project's own alembic.ini in CWD must never shadow ours.
+
+        Resolving CWD first matched a foreign alembic.ini and skipped our
+        migrations, crashing a fresh DB with relation "assistant" does not
+        exist (GH #306). Discovery must be CWD-independent.
+        """
+        decoy = tmp_path / "alembic.ini"
+        decoy.write_text("[alembic]\nscript_location = not-ours\n")
         monkeypatch.chdir(tmp_path)
-        cwd_ini = tmp_path / "alembic.ini"
-        cwd_ini.write_text("[alembic]\nscript_location = alembic\n")
 
         result = find_alembic_ini()
-        # Should be the CWD file, not the package file
-        assert result == cwd_ini.resolve()
+
+        assert result.resolve() != decoy.resolve()
+        assert result.parent != tmp_path
+        assert result.exists()
+
+    def test_discovery_is_independent_of_cwd(self, tmp_path, monkeypatch):
+        """The resolved ini is identical regardless of process CWD."""
+        baseline = find_alembic_ini()
+
+        monkeypatch.chdir(tmp_path)
+        assert find_alembic_ini() == baseline
 
     def test_raises_when_not_found(self, tmp_path, monkeypatch):
         """Should raise FileNotFoundError when alembic.ini is nowhere."""
@@ -51,8 +57,6 @@ class TestFindAlembicIni:
         fake_core = tmp_path / "fake" / "pkg" / "core"
         fake_core.mkdir(parents=True)
         (fake_core / "migrations.py").touch()
-
-        import aegra_api.core.migrations as migrations_mod
 
         monkeypatch.setattr(
             migrations_mod,
@@ -69,45 +73,39 @@ class TestGetAlembicConfig:
 
     def test_returns_config_object(self, tmp_path, monkeypatch):
         """Should return a valid Alembic Config object."""
-        monkeypatch.chdir(tmp_path)
-
-        # Create a minimal alembic.ini
         ini_file = tmp_path / "alembic.ini"
         ini_file.write_text("[alembic]\nscript_location = alembic\n")
-
-        # Create the alembic directory
         alembic_dir = tmp_path / "alembic"
         alembic_dir.mkdir()
+        monkeypatch.setattr(migrations_mod, "find_alembic_ini", lambda: ini_file)
 
         cfg = get_alembic_config()
         assert cfg is not None
 
         # script_location should be resolved to absolute path
         script_loc = cfg.get_main_option("script_location")
+        assert script_loc is not None
         assert Path(script_loc).is_absolute()
         assert script_loc == str(alembic_dir.resolve())
 
     def test_resolves_relative_script_location(self, tmp_path, monkeypatch):
         """Should resolve relative script_location to absolute path."""
-        monkeypatch.chdir(tmp_path)
-
         ini_file = tmp_path / "alembic.ini"
         ini_file.write_text("[alembic]\nscript_location = alembic\n")
-
-        alembic_dir = tmp_path / "alembic"
-        alembic_dir.mkdir()
+        (tmp_path / "alembic").mkdir()
+        monkeypatch.setattr(migrations_mod, "find_alembic_ini", lambda: ini_file)
 
         cfg = get_alembic_config()
         script_loc = cfg.get_main_option("script_location")
+        assert script_loc is not None
         assert Path(script_loc).is_absolute()
 
     def test_preserves_absolute_script_location(self, tmp_path, monkeypatch):
         """Should not modify an already-absolute script_location."""
-        monkeypatch.chdir(tmp_path)
-
         abs_path = str(tmp_path / "my_alembic")
         ini_file = tmp_path / "alembic.ini"
         ini_file.write_text(f"[alembic]\nscript_location = {abs_path}\n")
+        monkeypatch.setattr(migrations_mod, "find_alembic_ini", lambda: ini_file)
 
         cfg = get_alembic_config()
         assert cfg.get_main_option("script_location") == abs_path

--- a/libs/aegra-api/tests/unit/test_migrations.py
+++ b/libs/aegra-api/tests/unit/test_migrations.py
@@ -53,7 +53,7 @@ class TestFindAlembicIni:
         monkeypatch.chdir(tmp_path)
 
         # Create a fake module location where no alembic.ini exists
-        # at any resolution level (CWD, package dir, or dev layout)
+        # at any resolution level (package dir or dev layout)
         fake_core = tmp_path / "fake" / "pkg" / "core"
         fake_core.mkdir(parents=True)
         (fake_core / "migrations.py").touch()
@@ -116,12 +116,10 @@ class TestRunMigrations:
 
     def test_run_migrations_calls_alembic_upgrade(self, tmp_path, monkeypatch):
         """Should call alembic command.upgrade with 'head'."""
-        monkeypatch.chdir(tmp_path)
-
         ini_file = tmp_path / "alembic.ini"
         ini_file.write_text("[alembic]\nscript_location = alembic\n")
-        alembic_dir = tmp_path / "alembic"
-        alembic_dir.mkdir()
+        (tmp_path / "alembic").mkdir()
+        monkeypatch.setattr(migrations_mod, "find_alembic_ini", lambda: ini_file)
 
         with patch("aegra_api.core.migrations.command") as mock_command:
             from aegra_api.core.migrations import run_migrations
@@ -148,9 +146,10 @@ class TestRunMigrationsIfNeeded:
     """Tests for the lock-free fast-path used at FastAPI startup."""
 
     def _setup_alembic_ini(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.chdir(tmp_path)
-        (tmp_path / "alembic.ini").write_text("[alembic]\nscript_location = alembic\n")
+        ini_file = tmp_path / "alembic.ini"
+        ini_file.write_text("[alembic]\nscript_location = alembic\n")
         (tmp_path / "alembic").mkdir()
+        monkeypatch.setattr(migrations_mod, "find_alembic_ini", lambda: ini_file)
 
     def test_skips_upgrade_when_database_at_head(self, tmp_path, monkeypatch):
         """When current revision matches head, no upgrade is invoked."""

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.19"
+version = "0.9.20"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.19"
+version = "0.9.20"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.19"
+version = "0.9.20"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Problem

`find_alembic_ini()` (`core/migrations.py`) checked the **current working directory first**. When a host project has its own `alembic.ini` in CWD, that foreign file was returned instead of our bundled one — so Aegra's schema migrations never ran and a fresh DB crashed at first query with:

```
relation "assistant" does not exist
```

Fixes #306.

## Root cause

The CWD-first branch was **redundant** and only did harm:

- **pip install** → resolves via the package branch (`aegra_api/alembic.ini`, force-included into the wheel — see `libs/aegra-api/pyproject.toml`).
- **repo / editable dev** → resolves via the dev-layout branch (`libs/aegra-api/alembic.ini`).

Both branches resolve **relative to the module** (`__file__`), so they are independent of CWD — Docker included, where the package branch wins regardless of workdir. The CWD branch could only ever *lose* to a foreign `alembic.ini`; it never covered a real case the other two didn't.

Verified both layouts still resolve to the bundled ini before/after the change, and that a decoy `alembic.ini` in CWD no longer hijacks resolution.

## Fix

Delete the CWD-first branch. Resolution order is now:

1. Package-bundled (pip install)
2. Development layout (repo/editable)

## Tests

- New `test_ignores_foreign_cwd_ini` — asserts the bundled ini wins when a decoy `alembic.ini` sits in CWD (fails on old code, passes on fix).
- New `test_discovery_is_independent_of_cwd` — resolution is identical regardless of process CWD.
- Updated `TestGetAlembicConfig` tests to inject the ini via `find_alembic_ini` instead of relying on the (now removed) CWD seam.
- Dropped the two tests that encoded the old CWD-priority behavior.
- Full unit suite (1209) passes; ruff + ty clean.

## Note on Docker

`docker-compose` runs from a workdir, but the package/dev branches resolve regardless of CWD, so removing the CWD branch does not change Docker behavior — called out explicitly since the original comment claimed the CWD branch was "for Docker".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration discovery now consistently uses the bundled migration config so host project configs in the current working directory cannot interfere.

* **Tests**
  * Migration tests improved for CWD-independence and stronger assertions around config resolution.

* **Chores**
  * Version bumped to 0.9.20 for aegra-api and aegra-cli.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent misconfiguration bug where `find_alembic_ini()` picked up a host project's `alembic.ini` from CWD before the bundled one, causing fresh databases to crash with `relation "assistant" does not exist`. The fix removes the CWD-first branch entirely, since both remaining branches (package-bundled and dev layout) resolve relative to `__file__` and are CWD-independent.

- **`core/migrations.py`**: `find_alembic_ini()` now only checks the package-bundled path (`aegra_api/alembic.ini` relative to `__file__`) and the dev-layout path (`libs/aegra-api/alembic.ini`); the docstring and inline comments are updated to explain why CWD is excluded.
- **`test_migrations.py`**: Removes the two tests encoding old CWD-priority behavior, adds `test_ignores_foreign_cwd_ini` and `test_discovery_is_independent_of_cwd`, and converts all `TestGetAlembicConfig` / `TestRunMigrations` / `TestRunMigrationsIfNeeded` helpers to inject `find_alembic_ini` via `monkeypatch.setattr` rather than relying on a CWD-placed file.
- **`pyproject.toml` / `uv.lock`**: Version bumped to `0.9.20` for both `aegra-api` and `aegra-cli`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes a purely harmful CWD lookup that could never win against the two module-relative branches, and all tests are properly isolated via monkeypatching.

The change is a straight deletion of a buggy code path. Both remaining resolution branches in find_alembic_ini() resolve relative to __file__, are CWD-independent, and match the actual deployment layouts (pip-installed package and editable dev src layout). The test suite is now better isolated: every test that exercises get_alembic_config or the migration runners injects find_alembic_ini via monkeypatch.setattr, removing fragile implicit CWD dependencies. The previously flagged stale-comment and stale-CWD-setup issues from earlier review rounds are both resolved.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/migrations.py | Removes the CWD-first resolution branch; both remaining branches resolve relative to __file__ and are correct for pip-install and dev-layout environments. |
| libs/aegra-api/tests/unit/test_migrations.py | Tests properly updated: CWD-priority tests removed, new CWD-independence tests added, and all helpers now inject find_alembic_ini via monkeypatch instead of relying on CWD state. Previously flagged stale-comment and stale-setup issues are resolved. |
| libs/aegra-api/pyproject.toml | Routine version bump from 0.9.19 to 0.9.20; no logic changes. |
| libs/aegra-cli/pyproject.toml | Routine version bump from 0.9.19 to 0.9.20; no logic changes. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[find_alembic_ini called] --> B["Compute package_dir = Path(__file__).resolve().parent.parent (aegra_api/)"]
    B --> C{package_ini exists? aegra_api/alembic.ini}
    C -- Yes --> D[Return package_ini pip-install layout]
    C -- No --> E["Compute dev_root = package_dir.parent.parent (libs/aegra-api/)"]
    E --> F{dev_ini exists? libs/aegra-api/alembic.ini}
    F -- Yes --> G[Return dev_ini dev/editable layout]
    F -- No --> H[Raise FileNotFoundError]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `libs/aegra-api/tests/unit/test_migrations.py`, line 117-154 ([link](https://github.com/aegra/aegra/blob/68aa11884eb3296d3f08a6288ad571ccf45f16f4/libs/aegra-api/tests/unit/test_migrations.py#L117-L154)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale CWD setup in untouched test helpers**

   `test_run_migrations_calls_alembic_upgrade` (line 117-132) and `_setup_alembic_ini` (lines 150-153) still create a CWD `alembic.ini` and `alembic/` directory that `find_alembic_ini()` no longer consults. Both tests now rely silently on the real bundled ini being present on the filesystem, rather than an isolated fixture. If the dev ini is ever absent or misconfigured, these tests will fail at `get_alembic_config()` with a `FileNotFoundError` instead of the assertion they intend to test. The `TestGetAlembicConfig` tests in this same PR show the right pattern: inject via `monkeypatch.setattr(migrations_mod, "find_alembic_ini", lambda: ini_file)`.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Funit%2Ftest_migrations.py%0ALine%3A%20117-154%0A%0AComment%3A%0A**Stale%20CWD%20setup%20in%20untouched%20test%20helpers**%0A%0A%60test_run_migrations_calls_alembic_upgrade%60%20%28line%20117-132%29%20and%20%60_setup_alembic_ini%60%20%28lines%20150-153%29%20still%20create%20a%20CWD%20%60alembic.ini%60%20and%20%60alembic%2F%60%20directory%20that%20%60find_alembic_ini%28%29%60%20no%20longer%20consults.%20Both%20tests%20now%20rely%20silently%20on%20the%20real%20bundled%20ini%20being%20present%20on%20the%20filesystem%2C%20rather%20than%20an%20isolated%20fixture.%20If%20the%20dev%20ini%20is%20ever%20absent%20or%20misconfigured%2C%20these%20tests%20will%20fail%20at%20%60get_alembic_config%28%29%60%20with%20a%20%60FileNotFoundError%60%20instead%20of%20the%20assertion%20they%20intend%20to%20test.%20The%20%60TestGetAlembicConfig%60%20tests%20in%20this%20same%20PR%20show%20the%20right%20pattern%3A%20inject%20via%20%60monkeypatch.setattr%28migrations_mod%2C%20%22find_alembic_ini%22%2C%20lambda%3A%20ini_file%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Funit%2Ftest_migrations.py%0ALine%3A%20117-154%0A%0AComment%3A%0A**Stale%20CWD%20setup%20in%20untouched%20test%20helpers**%0A%0A%60test_run_migrations_calls_alembic_upgrade%60%20%28line%20117-132%29%20and%20%60_setup_alembic_ini%60%20%28lines%20150-153%29%20still%20create%20a%20CWD%20%60alembic.ini%60%20and%20%60alembic%2F%60%20directory%20that%20%60find_alembic_ini%28%29%60%20no%20longer%20consults.%20Both%20tests%20now%20rely%20silently%20on%20the%20real%20bundled%20ini%20being%20present%20on%20the%20filesystem%2C%20rather%20than%20an%20isolated%20fixture.%20If%20the%20dev%20ini%20is%20ever%20absent%20or%20misconfigured%2C%20these%20tests%20will%20fail%20at%20%60get_alembic_config%28%29%60%20with%20a%20%60FileNotFoundError%60%20instead%20of%20the%20assertion%20they%20intend%20to%20test.%20The%20%60TestGetAlembicConfig%60%20tests%20in%20this%20same%20PR%20show%20the%20right%20pattern%3A%20inject%20via%20%60monkeypatch.setattr%28migrations_mod%2C%20%22find_alembic_ini%22%2C%20lambda%3A%20ini_file%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Falembic-ini-discovery%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Falembic-ini-discovery%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Funit%2Ftest_migrations.py%0ALine%3A%20117-154%0A%0AComment%3A%0A**Stale%20CWD%20setup%20in%20untouched%20test%20helpers**%0A%0A%60test_run_migrations_calls_alembic_upgrade%60%20%28line%20117-132%29%20and%20%60_setup_alembic_ini%60%20%28lines%20150-153%29%20still%20create%20a%20CWD%20%60alembic.ini%60%20and%20%60alembic%2F%60%20directory%20that%20%60find_alembic_ini%28%29%60%20no%20longer%20consults.%20Both%20tests%20now%20rely%20silently%20on%20the%20real%20bundled%20ini%20being%20present%20on%20the%20filesystem%2C%20rather%20than%20an%20isolated%20fixture.%20If%20the%20dev%20ini%20is%20ever%20absent%20or%20misconfigured%2C%20these%20tests%20will%20fail%20at%20%60get_alembic_config%28%29%60%20with%20a%20%60FileNotFoundError%60%20instead%20of%20the%20assertion%20they%20intend%20to%20test.%20The%20%60TestGetAlembicConfig%60%20tests%20in%20this%20same%20PR%20show%20the%20right%20pattern%3A%20inject%20via%20%60monkeypatch.setattr%28migrations_mod%2C%20%22find_alembic_ini%22%2C%20lambda%3A%20ini_file%29%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `libs/aegra-api/tests/unit/test_migrations.py`, line 55-56 ([link](https://github.com/aegra/aegra/blob/68aa11884eb3296d3f08a6288ad571ccf45f16f4/libs/aegra-api/tests/unit/test_migrations.py#L55-L56)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The comment still lists "CWD" as a resolution level, but CWD is no longer checked by `find_alembic_ini()`. A future reader may be misled into thinking CWD is still in the search order.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Funit%2Ftest_migrations.py%0ALine%3A%2055-56%0A%0AComment%3A%0AThe%20comment%20still%20lists%20%22CWD%22%20as%20a%20resolution%20level%2C%20but%20CWD%20is%20no%20longer%20checked%20by%20%60find_alembic_ini%28%29%60.%20A%20future%20reader%20may%20be%20misled%20into%20thinking%20CWD%20is%20still%20in%20the%20search%20order.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20Create%20a%20fake%20module%20location%20where%20no%20alembic.ini%20exists%0A%20%20%20%20%20%20%20%20%23%20at%20any%20resolution%20level%20%28package%20dir%20or%20dev%20layout%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Funit%2Ftest_migrations.py%0ALine%3A%2055-56%0A%0AComment%3A%0AThe%20comment%20still%20lists%20%22CWD%22%20as%20a%20resolution%20level%2C%20but%20CWD%20is%20no%20longer%20checked%20by%20%60find_alembic_ini%28%29%60.%20A%20future%20reader%20may%20be%20misled%20into%20thinking%20CWD%20is%20still%20in%20the%20search%20order.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20Create%20a%20fake%20module%20location%20where%20no%20alembic.ini%20exists%0A%20%20%20%20%20%20%20%20%23%20at%20any%20resolution%20level%20%28package%20dir%20or%20dev%20layout%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Falembic-ini-discovery%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Falembic-ini-discovery%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Funit%2Ftest_migrations.py%0ALine%3A%2055-56%0A%0AComment%3A%0AThe%20comment%20still%20lists%20%22CWD%22%20as%20a%20resolution%20level%2C%20but%20CWD%20is%20no%20longer%20checked%20by%20%60find_alembic_ini%28%29%60.%20A%20future%20reader%20may%20be%20misled%20into%20thinking%20CWD%20is%20still%20in%20the%20search%20order.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20Create%20a%20fake%20module%20location%20where%20no%20alembic.ini%20exists%0A%20%20%20%20%20%20%20%20%23%20at%20any%20resolution%20level%20%28package%20dir%20or%20dev%20layout%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test(migrations): inject find\_alembic\_in..."](https://github.com/aegra/aegra/commit/263c5e5adf53fdd5151e0e3c58514300b4f9a619) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36084212)</sub>

<!-- /greptile_comment -->