### PR TITLE
fix(worker): treat idle BLPOP timeout as empty queue, not Redis failure

### DIFF
--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -19,6 +19,7 @@ from datetime import UTC, datetime, timedelta
 import structlog
 from asgi_correlation_id import correlation_id
 from redis import RedisError
+from redis import TimeoutError as RedisTimeoutError
 from sqlalchemy import select, update
 
 from aegra_api.core.active_runs import active_runs
@@ -253,7 +254,11 @@ class WorkerExecutor(BaseExecutor):
             result = await client.blpop(settings.worker.WORKER_QUEUE_KEY, timeout=5)  # type: ignore[arg-type]
             if result is None:
                 return None
-            return result[1]  # type: ignore[return-value]
+            return result[1]
+        except RedisTimeoutError:
+            # Idle expiry: a blocking BLPOP hit the socket timeout with no jobs.
+            # Normal when the queue is empty, not a connectivity failure — re-loop.
+            return None
         except RedisError as exc:
             logger.warning("Redis BLPOP failed, falling back to Postgres poll", error=str(exc))
             await asyncio.sleep(settings.worker.POSTGRES_POLL_INTERVAL_SECONDS)

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -4,6 +4,8 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from redis import ConnectionError as RedisConnectionError
+from redis import TimeoutError as RedisTimeoutError
 
 from aegra_api.core.active_runs import active_runs
 from aegra_api.models.auth import User
@@ -669,3 +671,72 @@ class TestExecuteWithLease:
             await task  # Completes normally (CancelledError is handled internally)
 
         assert job_task_was_cancelled, "job_task must be cancelled when _execute_with_lease is cancelled"
+
+
+class TestDequeue:
+    """Tests for WorkerExecutor._dequeue BLPOP handling."""
+
+    def _make_executor_with_blpop(self, blpop: AsyncMock) -> WorkerExecutor:
+        executor = WorkerExecutor()
+        executor._poll_postgres = AsyncMock(return_value="from-postgres")  # type: ignore[method-assign]
+        self._client = MagicMock()
+        self._client.blpop = blpop
+        return executor
+
+    @pytest.mark.asyncio
+    async def test_returns_run_id_on_queue_hit(self) -> None:
+        blpop = AsyncMock(return_value=("aegra:worker:queue", "run-123"))
+        executor = self._make_executor_with_blpop(blpop)
+
+        with patch(f"{MODULE}.redis_manager.get_client", return_value=self._client):
+            result = await executor._dequeue()
+
+        assert result == "run-123"
+        executor._poll_postgres.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_blpop_returns_none(self) -> None:
+        blpop = AsyncMock(return_value=None)
+        executor = self._make_executor_with_blpop(blpop)
+
+        with patch(f"{MODULE}.redis_manager.get_client", return_value=self._client):
+            result = await executor._dequeue()
+
+        assert result is None
+        executor._poll_postgres.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_idle_socket_timeout_returns_none_without_fallback(self) -> None:
+        """A blocking BLPOP that hits the socket timeout raises redis TimeoutError
+        (a RedisError subclass). That is a normal idle expiry, not a connectivity
+        failure: it must return None silently, never poll Postgres (GH #bug)."""
+        blpop = AsyncMock(side_effect=RedisTimeoutError("Timeout reading from redis:6379"))
+        executor = self._make_executor_with_blpop(blpop)
+
+        with (
+            patch(f"{MODULE}.redis_manager.get_client", return_value=self._client),
+            patch(f"{MODULE}.logger.warning") as mock_warning,
+        ):
+            result = await executor._dequeue()
+
+        assert result is None
+        executor._poll_postgres.assert_not_awaited()
+        mock_warning.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_connection_error_falls_back_to_postgres(self) -> None:
+        """A genuine Redis failure (connection lost) must still warn and fall
+        back to the Postgres poll so jobs are not stranded."""
+        blpop = AsyncMock(side_effect=RedisConnectionError("Connection refused"))
+        executor = self._make_executor_with_blpop(blpop)
+
+        with (
+            patch(f"{MODULE}.redis_manager.get_client", return_value=self._client),
+            patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock),
+            patch(f"{MODULE}.logger.warning") as mock_warning,
+        ):
+            result = await executor._dequeue()
+
+        assert result == "from-postgres"
+        executor._poll_postgres.assert_awaited_once()
+        mock_warning.assert_called_once()


### PR DESCRIPTION
## Problem

When the job queue is empty, `WorkerExecutor._dequeue()` logs a spurious warning and falls back to a Postgres poll on **every** idle cycle:

```
[warning] Redis BLPOP failed, falling back to Postgres poll
  error='Timeout reading from redis:6379' func_name=_dequeue
```

Redis is fully healthy (PING → PONG, 0 blocked clients). The warning fires roughly every ~10s per worker (5s BLPOP timeout + 5s `POSTGRES_POLL_INTERVAL_SECONDS`), producing dozens of false warnings per minute at idle and an unnecessary Postgres `SELECT` each time.

Reported by Soufiene.

## Root cause

`except RedisError` is too broad. `redis.exceptions.TimeoutError` is a **subclass of `RedisError`**:

```
RedisError
├── ConnectionError
└── TimeoutError   ← raised by a blocking BLPOP when the socket read times out
```

A blocking `BLPOP timeout=5` races the connection's client-side `socket_timeout` against the server-side timeout. When `socket_timeout <= 5s`, redis-py raises `TimeoutError` **instead of returning `None`** — and the handler classified that benign idle expiry as a connectivity failure, warning + falling back to Postgres.

## Fix

Catch `redis.TimeoutError` separately and return `None` — a timed-out blocking read with no jobs is normal idle behavior, so the worker just re-enters the loop. Genuine failures (`ConnectionError`, auth, etc.) still warn and fall back to the Postgres poll.

```python
except RedisTimeoutError:
    # Idle expiry: a blocking BLPOP hit the socket timeout with no jobs.
    return None
except RedisError as exc:
    logger.warning("Redis BLPOP failed, falling back to Postgres poll", error=str(exc))
    ...
```

Also removes a now-unused `# type: ignore[return-value]` on the same line (flagged by `ty`).

## Tests

New `TestDequeue` in `test_worker_executor.py`:
- **`test_idle_socket_timeout_returns_none_without_fallback`** — the regression: `BLPOP` raising `redis.TimeoutError` returns `None`, logs no warning, never polls Postgres. Fails on old code, passes on the fix.
- `test_connection_error_falls_back_to_postgres` — a real `ConnectionError` still warns + falls back.
- `test_returns_run_id_on_queue_hit` / `test_returns_none_when_blpop_returns_none` — happy paths.

Full unit suite (1213) passes; ruff + ty clean.

## Impact

Severity low (cosmetic + minor DB load). No correctness/data-loss change — the fallback was harmless, just noisy and wasteful at idle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved queue timeout handling to gracefully manage idle conditions without triggering unnecessary fallback operations.
  * Enhanced error distinction to properly differentiate between temporary timeouts and actual connection failures.

* **Tests**
  * Added comprehensive test coverage for queue operations, including timeout and connection error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a spurious warning emitted on every idle cycle by `WorkerExecutor._dequeue()` when `redis-py` raises `TimeoutError` (a `RedisError` subclass) on a `BLPOP` with no jobs — instead of returning `None` as callers expect. The fix adds a targeted `except RedisTimeoutError` clause before the broad `except RedisError` to return `None` silently on idle expiry, while genuine connectivity failures still warn and fall back to the Postgres poll.

- Adds `from redis import TimeoutError as RedisTimeoutError` to disambiguate from Python's built-in `TimeoutError`, and inserts the new `except` handler in the correct sub-class-first order.
- Removes the now-unnecessary `# type: ignore[return-value]` on the `return result[1]` line.
- Adds four focused unit tests in `TestDequeue` covering the regression case, genuine connection failures, and both BLPOP happy paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-targeted exception-handler fix with no correctness or data-loss risk.

The fix is a single-concern change: add one except clause above an existing broader one, in the correct exception-hierarchy order. The import alias avoids any shadowing of the Python built-in. All existing behavior for real Redis failures is preserved, and the four new tests directly cover the regression plus the fallback path. No data path, lease, or schema is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Adds `except RedisTimeoutError` before the broad `except RedisError` to return `None` on idle BLPOP expiry; removes stale `# type: ignore[return-value]`. Logic and ordering are correct. |
| libs/aegra-api/tests/unit/test_services/test_worker_executor.py | Four new tests in `TestDequeue` cover the regression (`TimeoutError` → `None`, no warning, no Postgres call), real `ConnectionError` fallback, and both BLPOP happy paths. Tests are well-scoped and correctly patched. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_dequeue called] --> B[redis_manager.get_client]
    B --> C["client.blpop(WORKER_QUEUE_KEY, timeout=5)"]
    C --> D{Result?}
    D -- "None (server-side timeout)" --> E[return None\nre-enter loop]
    D -- "('queue', 'run-id')" --> F[return run_id]
    C -- RedisTimeoutError\n(socket_timeout le 5s) --> G["return None\nno warning, no Postgres\n NEW"]
    C -- "ConnectionError / other RedisError" --> H[logger.warning\nasyncio.sleep\n_poll_postgres]
    H --> I[return run_id from Postgres\nor None]
```

<sub>Reviews (1): Last reviewed commit: ["fix(worker): treat idle BLPOP timeout as..."](https://github.com/aegra/aegra/commit/7b89a790ab81b0d9fe3ce991ddeb1f9cd1425d73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36282336)</sub>

<!-- /greptile_comment -->