### PR TITLE
feat(observability): enable Langfuse v4 direct-write with immutable spans

### DIFF
--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -2,8 +2,9 @@
 
 Sets Langfuse-compatible span attributes (``langfuse.user.id``,
 ``langfuse.session.id``, ``langfuse.trace.name``) from per-request
-context variables on the **root span only**, enabling trace enrichment
-without requiring changes to graph code.
+context variables on **every span** in the trace, enabling the Langfuse
+v4 immutable observations model where each observation must carry its
+own context (no server-side join from trace to children).
 
 Also sets Phoenix/OpenInference-compatible aliases (``user.id``,
 ``session.id``) so that the same code works when ``OTEL_TARGETS``
@@ -17,7 +18,7 @@ Usage::
         session_id=thread_id,
         trace_name=graph_id,
     )
-    # The root OTEL span created in this task will carry the attributes.
+    # All OTEL spans created in this task will carry the attributes.
 """
 
 import contextvars
@@ -43,15 +44,13 @@ _trace_attrs: contextvars.ContextVar[dict[str, str | int | float | bool] | None]
 
 
 class SpanEnrichmentProcessor(SpanProcessor):
-    """Injects per-request trace attributes onto the root span of each trace.
+    """Injects per-request trace attributes onto every span in the trace.
 
     Reads from the ``aegra_otel_trace_attrs`` context variable and sets
-    each key/value pair as a span attribute on the **root span** only.
-    A span is considered a root if it has no parent OR if its parent is a
-    remote span (i.e. arrived via W3C ``traceparent`` from an upstream
-    service).  Langfuse reads trace-level properties (userId, sessionId,
-    name) exclusively from the root span, so enriching local child spans
-    is unnecessary and produces noise in per-observation metadata.
+    each key/value pair as a span attribute on **all spans** (root, child,
+    and grandchild).  The Langfuse v4 immutable observations model requires
+    each observation to carry its own userId, sessionId, and traceName — there
+    is no server-side join from trace to children.
 
     Call :func:`set_trace_context` inside the asyncio Task that runs
     graph execution to populate the context variable before any spans
@@ -59,10 +58,6 @@ class SpanEnrichmentProcessor(SpanProcessor):
     """
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
-        if span.parent is not None and span.parent.is_valid and not span.parent.is_remote:
-            # Skip local child spans only — spans whose parent arrived via
-            # a remote traceparent header are still local roots and must be enriched.
-            return
         attrs = _trace_attrs.get()
         if not attrs:
             return

--- a/libs/aegra-api/src/aegra_api/observability/targets/langfuse.py
+++ b/libs/aegra-api/src/aegra_api/observability/targets/langfuse.py
@@ -30,4 +30,10 @@ class LangfuseTarget(BaseOtelTarget):
         auth_str = f"{pk}:{sk}"
         auth_b64 = base64.b64encode(auth_str.encode()).decode()
 
-        return OTLPSpanExporter(endpoint=endpoint, headers={"Authorization": f"Basic {auth_b64}"})
+        return OTLPSpanExporter(
+            endpoint=endpoint,
+            headers={
+                "Authorization": f"Basic {auth_b64}",
+                "x-langfuse-ingestion-version": "4",
+            },
+        )

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -137,8 +137,8 @@ class TestSpanEnrichmentProcessor:
         assert calls["session.id"] == "s1"
         assert calls["langfuse.trace.name"] == "graph_x"
 
-    def test_on_start_skips_local_child_spans(self) -> None:
-        """on_start() does NOT enrich local child spans (valid, non-remote parent)."""
+    def test_on_start_enriches_local_child_spans(self) -> None:
+        """on_start() enriches local child spans for Langfuse v4 immutable model."""
         set_trace_context(user_id="u1", session_id="s1", trace_name="graph_x")
         processor = SpanEnrichmentProcessor()
         mock_span = MagicMock()
@@ -148,7 +148,10 @@ class TestSpanEnrichmentProcessor:
 
         processor.on_start(mock_span)
 
-        mock_span.set_attribute.assert_not_called()
+        calls = {call.args[0]: call.args[1] for call in mock_span.set_attribute.call_args_list}
+        assert calls["langfuse.user.id"] == "u1"
+        assert calls["langfuse.session.id"] == "s1"
+        assert calls["langfuse.trace.name"] == "graph_x"
 
     def test_on_start_enriches_span_with_remote_parent(self) -> None:
         """on_start() enriches spans whose parent arrived via W3C traceparent.
@@ -504,3 +507,34 @@ class TestSpanEnrichmentEndToEnd:
         attrs = dict(self.exporter.get_finished_spans()[0].attributes or {})
         assert attrs["langfuse.trace.metadata.tenant"] == "acme"
         assert "langfuse.trace.metadata.nested" not in attrs
+
+    def test_child_spans_receive_same_attributes_as_root(self) -> None:
+        """Child spans receive the same langfuse.* attributes as the root span.
+
+        Required for Langfuse v4 immutable model where each observation must
+        carry its own context — no server-side join from trace to children.
+        """
+        ctx = make_run_trace_context(
+            run_id="run-1",
+            thread_id="thread-1",
+            graph_id="my_graph",
+            user_identity="user-1",
+        )
+
+        def _create_parent_and_child() -> None:
+            with self.tracer.start_as_current_span("root_span"):  # noqa: SIM117
+                with self.tracer.start_as_current_span("child_span"):
+                    with self.tracer.start_as_current_span("grandchild_span"):
+                        pass
+
+        ctx.run(_create_parent_and_child)
+
+        spans = self.exporter.get_finished_spans()
+        assert len(spans) == 3
+
+        for span in spans:
+            attrs = dict(span.attributes or {})
+            assert attrs["langfuse.user.id"] == "user-1"
+            assert attrs["langfuse.session.id"] == "thread-1"
+            assert attrs["langfuse.trace.name"] == "my_graph"
+            assert attrs["langfuse.trace.metadata.run_id"] == "run-1"

--- a/libs/aegra-api/tests/unit/test_observability/test_targets/test_langfuse.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_targets/test_langfuse.py
@@ -70,3 +70,19 @@ class TestLangfuseTarget:
 
             # Should not have double slash //api...
             assert exporter._endpoint == "https://custom.langfuse.host/api/public/otel/v1/traces"
+
+    def test_ingestion_version_header_set(self):
+        """Test that x-langfuse-ingestion-version: 4 header is passed to OTLPSpanExporter."""
+        with (
+            patch("aegra_api.observability.targets.langfuse.settings") as mock_settings,
+            patch("aegra_api.observability.targets.langfuse.OTLPSpanExporter") as mock_exporter_cls,
+        ):
+            mock_settings.observability.LANGFUSE_PUBLIC_KEY = "pk-test"
+            mock_settings.observability.LANGFUSE_SECRET_KEY = "sk-test"
+            mock_settings.observability.LANGFUSE_BASE_URL = "https://us.cloud.langfuse.com"
+
+            target = LangfuseTarget()
+            target.get_exporter()
+
+            call_kwargs = mock_exporter_cls.call_args[1]
+            assert call_kwargs["headers"]["x-langfuse-ingestion-version"] == "4"


### PR DESCRIPTION
Adds `x-langfuse-ingestion-version: 4` header to the Langfuse OTLP exporter and propagates trace attributes to all child spans (not just root). This enables near-real-time data availability on Langfuse Cloud by routing spans to the immutable observations table. Backward-compatible — header is ignored on older Langfuse servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Child and grandchild spans now receive the same trace context attributes (user ID, session ID, trace name, run ID metadata) as the root span.
  * Langfuse integration explicitly includes an ingestion-version header for improved compatibility.

* **Tests**
  * Added unit and end-to-end tests verifying span enrichment on child spans and the ingestion-version header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables Langfuse v4's immutable observations model by (1) propagating trace context attributes to every span instead of only the root, and (2) adding the `x-langfuse-ingestion-version: 4` header to the OTLP exporter. Both changes are backward-compatible with older Langfuse deployments.

- **`span_enrichment.py`**: Removes the local-child-span guard in `SpanEnrichmentProcessor.on_start`, so `langfuse.user.id`, `langfuse.session.id`, `langfuse.trace.name`, and metadata keys are now written to root, child, and grandchild spans equally.
- **`targets/langfuse.py`**: Adds `x-langfuse-ingestion-version: 4` header to the `OTLPSpanExporter` constructor, routing spans to Langfuse Cloud's near-real-time ingestion path.
- Tests are updated and extended with an E2E case that verifies all three span depths carry the expected attributes.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change removes a four-line guard and adds one HTTP header — both well-tested and backward-compatible with older Langfuse deployments.

The core logic change is a simple guard removal with comprehensive unit and E2E coverage. The new header is ignored by Langfuse servers that don't understand it. No data-loss, auth, or correctness risk is introduced by these changes.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/observability/span_enrichment.py | Removes the root-span guard in `on_start`, so all spans now receive trace context attributes. Logic is straightforward; one function-level docstring still says "root OTEL span" where it should say "all OTEL spans". |
| libs/aegra-api/src/aegra_api/observability/targets/langfuse.py | Adds `x-langfuse-ingestion-version: 4` header to the OTLP exporter. Clean and well-scoped change. |
| libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py | Updates the child-span unit test to assert enrichment (was asserting skip), and adds a thorough E2E test covering root, child, and grandchild spans all receiving langfuse.* attributes. |
| libs/aegra-api/tests/unit/test_observability/test_targets/test_langfuse.py | Adds `test_ingestion_version_header_set` which mocks `OTLPSpanExporter` and verifies the new header is passed via `call_args[1]`. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Task as asyncio Task
    participant SEP as SpanEnrichmentProcessor
    participant TP as TracerProvider
    participant LF as Langfuse OTLP Exporter

    Task->>Task: set_trace_context(user_id, session_id, trace_name)
    Task->>TP: start_as_current_span("root_span")
    TP->>SEP: on_start(root_span)
    SEP->>root_span: set_attribute(langfuse.user.id, ...)
    Note over SEP,root_span: All attrs injected (was: root only)
    TP->>TP: start_as_current_span("child_span")
    TP->>SEP: on_start(child_span)
    SEP->>child_span: set_attribute(langfuse.user.id, ...)
    Note over SEP,child_span: NEW: child also enriched
    TP->>TP: start_as_current_span("grandchild_span")
    TP->>SEP: on_start(grandchild_span)
    SEP->>grandchild_span: set_attribute(langfuse.user.id, ...)
    Note over SEP,grandchild_span: NEW: grandchild also enriched
    TP->>LF: export([root, child, grandchild])
    Note over LF: Header: x-langfuse-ingestion-version: 4
    LF->>LF: Route to immutable observations table
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `libs/aegra-api/src/aegra_api/observability/span_enrichment.py`, line 45-59 ([link](https://github.com/aegra/aegra/blob/8d683198aabcc4da52521918243197d9cde17361/libs/aegra-api/src/aegra_api/observability/span_enrichment.py#L45-L59)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale module and class docstrings contradict the new behavior**

   Both the module-level docstring (line 5: "on the **root span only**") and the `SpanEnrichmentProcessor` class docstring (lines 46–54) still describe the old root-span-only policy. The class docstring explicitly states that enriching local child spans "is unnecessary and produces noise in per-observation metadata" — the exact opposite of the intention here. A developer reading this in the future may revert or work around the child-span enrichment believing it to be a bug. Both docstrings should be updated to reflect the v4 immutable model rationale.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%0ALine%3A%2045-59%0A%0AComment%3A%0A**Stale%20module%20and%20class%20docstrings%20contradict%20the%20new%20behavior**%0A%0ABoth%20the%20module-level%20docstring%20%28line%205%3A%20%22on%20the%20**root%20span%20only**%22%29%20and%20the%20%60SpanEnrichmentProcessor%60%20class%20docstring%20%28lines%2046%E2%80%9354%29%20still%20describe%20the%20old%20root-span-only%20policy.%20The%20class%20docstring%20explicitly%20states%20that%20enriching%20local%20child%20spans%20%22is%20unnecessary%20and%20produces%20noise%20in%20per-observation%20metadata%22%20%E2%80%94%20the%20exact%20opposite%20of%20the%20intention%20here.%20A%20developer%20reading%20this%20in%20the%20future%20may%20revert%20or%20work%20around%20the%20child-span%20enrichment%20believing%20it%20to%20be%20a%20bug.%20Both%20docstrings%20should%20be%20updated%20to%20reflect%20the%20v4%20immutable%20model%20rationale.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=416&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%0ALine%3A%2045-59%0A%0AComment%3A%0A**Stale%20module%20and%20class%20docstrings%20contradict%20the%20new%20behavior**%0A%0ABoth%20the%20module-level%20docstring%20%28line%205%3A%20%22on%20the%20**root%20span%20only**%22%29%20and%20the%20%60SpanEnrichmentProcessor%60%20class%20docstring%20%28lines%2046%E2%80%9354%29%20still%20describe%20the%20old%20root-span-only%20policy.%20The%20class%20docstring%20explicitly%20states%20that%20enriching%20local%20child%20spans%20%22is%20unnecessary%20and%20produces%20noise%20in%20per-observation%20metadata%22%20%E2%80%94%20the%20exact%20opposite%20of%20the%20intention%20here.%20A%20developer%20reading%20this%20in%20the%20future%20may%20revert%20or%20work%20around%20the%20child-span%20enrichment%20believing%20it%20to%20be%20a%20bug.%20Both%20docstrings%20should%20be%20updated%20to%20reflect%20the%20v4%20immutable%20model%20rationale.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=416&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Flangfuse-v4-immutable-direct-write%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Flangfuse-v4-immutable-direct-write%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%0ALine%3A%2045-59%0A%0AComment%3A%0A**Stale%20module%20and%20class%20docstrings%20contradict%20the%20new%20behavior**%0A%0ABoth%20the%20module-level%20docstring%20%28line%205%3A%20%22on%20the%20**root%20span%20only**%22%29%20and%20the%20%60SpanEnrichmentProcessor%60%20class%20docstring%20%28lines%2046%E2%80%9354%29%20still%20describe%20the%20old%20root-span-only%20policy.%20The%20class%20docstring%20explicitly%20states%20that%20enriching%20local%20child%20spans%20%22is%20unnecessary%20and%20produces%20noise%20in%20per-observation%20metadata%22%20%E2%80%94%20the%20exact%20opposite%20of%20the%20intention%20here.%20A%20developer%20reading%20this%20in%20the%20future%20may%20revert%20or%20work%20around%20the%20child-span%20enrichment%20believing%20it%20to%20be%20a%20bug.%20Both%20docstrings%20should%20be%20updated%20to%20reflect%20the%20v4%20immutable%20model%20rationale.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=416&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A86-88%0AThe%20%60set_trace_context%60%20function%20docstring%20still%20says%20%22The%20root%20OTEL%20span%20created%20in%20this%20task%20will%20have%20the%20specified%20attributes%20injected%22%2C%20which%20is%20now%20inaccurate.%20After%20the%20behavior%20change%20in%20this%20PR%2C%20every%20span%20in%20the%20trace%20receives%20the%20injected%20attributes%2C%20not%20just%20the%20root.%20A%20developer%20reading%20only%20this%20function's%20docstring%20could%20be%20misled%20into%20thinking%20child-span%20enrichment%20is%20unintended%20and%20revert%20%60on_start%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20Must%20be%20called%20inside%20the%20asyncio%20Task%20that%20will%20run%20graph%20execution.%0A%20%20%20%20All%20OTEL%20spans%20created%20in%20this%20task%20will%20have%20the%20specified%0A%20%20%20%20attributes%20injected%20by%20%3Aclass%3A%60SpanEnrichmentProcessor%60.%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=416&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A86-88%0AThe%20%60set_trace_context%60%20function%20docstring%20still%20says%20%22The%20root%20OTEL%20span%20created%20in%20this%20task%20will%20have%20the%20specified%20attributes%20injected%22%2C%20which%20is%20now%20inaccurate.%20After%20the%20behavior%20change%20in%20this%20PR%2C%20every%20span%20in%20the%20trace%20receives%20the%20injected%20attributes%2C%20not%20just%20the%20root.%20A%20developer%20reading%20only%20this%20function's%20docstring%20could%20be%20misled%20into%20thinking%20child-span%20enrichment%20is%20unintended%20and%20revert%20%60on_start%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20Must%20be%20called%20inside%20the%20asyncio%20Task%20that%20will%20run%20graph%20execution.%0A%20%20%20%20All%20OTEL%20spans%20created%20in%20this%20task%20will%20have%20the%20specified%0A%20%20%20%20attributes%20injected%20by%20%3Aclass%3A%60SpanEnrichmentProcessor%60.%0A%60%60%60%0A%0A&pr=416&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Flangfuse-v4-immutable-direct-write%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Flangfuse-v4-immutable-direct-write%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fobservability%2Fspan_enrichment.py%3A86-88%0AThe%20%60set_trace_context%60%20function%20docstring%20still%20says%20%22The%20root%20OTEL%20span%20created%20in%20this%20task%20will%20have%20the%20specified%20attributes%20injected%22%2C%20which%20is%20now%20inaccurate.%20After%20the%20behavior%20change%20in%20this%20PR%2C%20every%20span%20in%20the%20trace%20receives%20the%20injected%20attributes%2C%20not%20just%20the%20root.%20A%20developer%20reading%20only%20this%20function's%20docstring%20could%20be%20misled%20into%20thinking%20child-span%20enrichment%20is%20unintended%20and%20revert%20%60on_start%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20Must%20be%20called%20inside%20the%20asyncio%20Task%20that%20will%20run%20graph%20execution.%0A%20%20%20%20All%20OTEL%20spans%20created%20in%20this%20task%20will%20have%20the%20specified%0A%20%20%20%20attributes%20injected%20by%20%3Aclass%3A%60SpanEnrichmentProcessor%60.%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=416&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["feat(observability): enable Langfuse v4 ..."](https://github.com/aegra/aegra/commit/a8cb1083ce995fb979b3bfa6cf983ad5653c5ce9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36450267)</sub>

<!-- /greptile_comment -->