### PR TITLE
chore(release): bump version to 0.9.21

### DIFF
--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.20"
+version = "0.9.21"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.20"
+version = "0.9.21"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.20"
+version = "0.9.21"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.20"
+version = "0.9.21"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
Release bump for the Langfuse v4 direct-write feature (#416).

- per-span context enrichment (user/session/trace on every observation)
- x-langfuse-ingestion-version: 4 header for real-time ingestion

Verified live against Langfuse cloud before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions to 0.9.21 for API and CLI libraries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Version bump from `0.9.20` to `0.9.21` for `aegra-api` and `aegra-cli`, along with the corresponding `uv.lock` update. This is a release chore commit packaging the Langfuse v4 direct-write feature landed in #416.

- Both `pyproject.toml` files are bumped consistently to `0.9.21`; no dependency versions or other metadata changed.
- The `uv.lock` entries for both packages are updated to match, with no transitive dependency changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only version strings are updated, no logic or dependency changes.

All three changed files contain only version string updates (0.9.20 → 0.9.21). Both pyproject.toml files are bumped in lockstep and the uv.lock is consistent. There is nothing here that could introduce a regression.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/pyproject.toml | Version bumped from 0.9.20 to 0.9.21; no other changes. |
| libs/aegra-cli/pyproject.toml | Version bumped from 0.9.20 to 0.9.21; no other changes. |
| uv.lock | Lock file updated to reflect new 0.9.21 versions for both aegra-api and aegra-cli; no dependency changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PR #417 - Release bump 0.9.20 → 0.9.21"] --> B["libs/aegra-api/pyproject.toml\nversion = '0.9.21'"]
    A --> C["libs/aegra-cli/pyproject.toml\nversion = '0.9.21'"]
    B --> D["uv.lock\naegra-api 0.9.21"]
    C --> E["uv.lock\naegra-cli 0.9.21"]
```

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump version to 0.9.21"](https://github.com/aegra/aegra/commit/7620831985bfbd6dffd2d516cc500b2c93ff0cad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36487374)</sub>

<!-- /greptile_comment -->