### PR TITLE
test(hitl): raise interrupt-poll timeout from 10s to 30s

### DIFF
--- a/libs/aegra-api/tests/e2e/test_human_in_loop/test_human_in_loop.py
+++ b/libs/aegra-api/tests/e2e/test_human_in_loop/test_human_in_loop.py
@@ -79,7 +79,7 @@ async def test_human_in_loop_interrupt_resume_e2e():
     # Wait for interrupt
     import asyncio
 
-    max_wait = 10
+    max_wait = 30
     wait_interval = 0.5
     waited = 0
 
@@ -198,7 +198,7 @@ async def test_human_in_loop_text_response_e2e():
     # Wait for interrupt
     import asyncio
 
-    max_wait = 10
+    max_wait = 30
     wait_interval = 0.5
     waited = 0
 
@@ -340,7 +340,7 @@ async def test_human_in_loop_ignore_tool_call_e2e():
     # Wait for interrupt
     import asyncio
 
-    max_wait = 10
+    max_wait = 30
     wait_interval = 0.5
     waited = 0
 
@@ -611,7 +611,7 @@ async def test_human_in_loop_mark_as_resolved_e2e():
     # Wait for interrupt
     import asyncio
 
-    max_wait = 10
+    max_wait = 30
     wait_interval = 0.5
     waited = 0
 


### PR DESCRIPTION
## Problem

`test_human_in_loop_interrupt_resume_e2e` flaked in CI:

```
AssertionError: Expected interrupted, got running
assert 'running' == 'interrupted'
```

The four interrupt-detection loops in this file polled for at most 10s. The `agent_hitl` graph makes a real LLM call before reaching the interrupt node, and under CI load that round-trip can exceed 10s. When it does, the loop exits with the run still in `running` and the `Expected interrupted` assert fails.

Pre-existing flake (untouched since the repo restructure), unrelated to recent feature work.

## Fix

Raise the poll ceiling from 10s to 30s at all four sites to absorb LLM latency variance.

## Verification

Ran the failing test 3x in a row against a live server -> 3 passes. Full `test_human_in_loop.py` file: 5 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced stability of human-in-the-loop workflow tests by adjusting timeout configurations for interrupt-resume, text-response, and tool-call scenarios to reduce test flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises the interrupt-poll timeout in four places from 10 s to 30 s to stop `test_human_in_loop_interrupt_resume_e2e` from flaking when LLM latency exceeds 10 s under CI load.

- Three of the four changed loops are in active tests; the fourth is inside `test_human_in_loop_mark_as_resolved_e2e`, which is decorated with `@pytest.mark.skip` and never runs.
- The shared `wait_for_run_settle` helper (used by `test_human_in_loop_edit_tool_args_e2e` and `test_human_in_loop_streaming_interrupt_resume_e2e`) still defaults to 20 s, so those two tests remain exposed to the same latency-induced flake.

<h3>Confidence Score: 4/5</h3>

Safe to merge — only test polling timeouts are changed; no production code is touched.

The fix correctly addresses the root cause for three active tests, but the shared `wait_for_run_settle` helper (20 s default) leaves two other tests still exposed to the same latency-induced flake, and one of the four updated loops is inside a skipped test with no current runtime effect.

The `wait_for_run_settle` helper at the top of `test_human_in_loop.py` — its 20 s default was not updated to match the new 30 s limit.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/tests/e2e/test_human_in_loop/test_human_in_loop.py | Raises the interrupt-detection poll ceiling from 10 s to 30 s at four sites; one of those sites is inside a @pytest.mark.skip test, and the shared wait_for_run_settle helper (used by two other tests) still caps at 20 s. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as E2E Test
    participant API as Aegra API
    participant LLM as LLM (real call)
    participant Graph as agent_hitl graph

    Test->>API: runs.create(input)
    API->>LLM: "LLM call (may take >10 s under CI load)"
    LLM-->>Graph: response
    Graph-->>API: "status = interrupted"
    loop Poll every 0.5 s (max_wait was 10 s, now 30 s)
        Test->>API: runs.get(run_id)
        API-->>Test: status
    end
    Test->>API: "runs.create(command=resume)"
    API-->>Test: resumed run
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `libs/aegra-api/tests/e2e/test_human_in_loop/test_human_in_loop.py`, line 9 ([link](https://github.com/aegra/aegra/blob/14b90ac78fb26a059088516fcff34963978ea018/libs/aegra-api/tests/e2e/test_human_in_loop/test_human_in_loop.py#L9)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `wait_for_run_settle` helper used by `test_human_in_loop_edit_tool_args_e2e` (line 458) and `test_human_in_loop_streaming_interrupt_resume_e2e` (line 752) still defaults to 20 s. Under the same CI-load conditions that triggered this fix, both tests can reach the same "Expected interrupted, got running" failure because their poll ceiling is lower than the 30 s now applied to the four inline loops.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%0ALine%3A%209%0A%0AComment%3A%0AThe%20%60wait_for_run_settle%60%20helper%20used%20by%20%60test_human_in_loop_edit_tool_args_e2e%60%20%28line%20458%29%20and%20%60test_human_in_loop_streaming_interrupt_resume_e2e%60%20%28line%20752%29%20still%20defaults%20to%2020%20s.%20Under%20the%20same%20CI-load%20conditions%20that%20triggered%20this%20fix%2C%20both%20tests%20can%20reach%20the%20same%20%22Expected%20interrupted%2C%20got%20running%22%20failure%20because%20their%20poll%20ceiling%20is%20lower%20than%20the%2030%20s%20now%20applied%20to%20the%20four%20inline%20loops.%0A%0A%60%60%60suggestion%0Aasync%20def%20wait_for_run_settle%28client%2C%20thread_id%2C%20run_id%2C%20max_wait%3D30%29%3A%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%0ALine%3A%209%0A%0AComment%3A%0AThe%20%60wait_for_run_settle%60%20helper%20used%20by%20%60test_human_in_loop_edit_tool_args_e2e%60%20%28line%20458%29%20and%20%60test_human_in_loop_streaming_interrupt_resume_e2e%60%20%28line%20752%29%20still%20defaults%20to%2020%20s.%20Under%20the%20same%20CI-load%20conditions%20that%20triggered%20this%20fix%2C%20both%20tests%20can%20reach%20the%20same%20%22Expected%20interrupted%2C%20got%20running%22%20failure%20because%20their%20poll%20ceiling%20is%20lower%20than%20the%2030%20s%20now%20applied%20to%20the%20four%20inline%20loops.%0A%0A%60%60%60suggestion%0Aasync%20def%20wait_for_run_settle%28client%2C%20thread_id%2C%20run_id%2C%20max_wait%3D30%29%3A%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fflaky-hitl-interrupt-timeout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fflaky-hitl-interrupt-timeout%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%0ALine%3A%209%0A%0AComment%3A%0AThe%20%60wait_for_run_settle%60%20helper%20used%20by%20%60test_human_in_loop_edit_tool_args_e2e%60%20%28line%20458%29%20and%20%60test_human_in_loop_streaming_interrupt_resume_e2e%60%20%28line%20752%29%20still%20defaults%20to%2020%20s.%20Under%20the%20same%20CI-load%20conditions%20that%20triggered%20this%20fix%2C%20both%20tests%20can%20reach%20the%20same%20%22Expected%20interrupted%2C%20got%20running%22%20failure%20because%20their%20poll%20ceiling%20is%20lower%20than%20the%2030%20s%20now%20applied%20to%20the%20four%20inline%20loops.%0A%0A%60%60%60suggestion%0Aasync%20def%20wait_for_run_settle%28client%2C%20thread_id%2C%20run_id%2C%20max_wait%3D30%29%3A%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


2. `libs/aegra-api/tests/e2e/test_human_in_loop/test_human_in_loop.py`, line 611-631 ([link](https://github.com/aegra/aegra/blob/14b90ac78fb26a059088516fcff34963978ea018/libs/aegra-api/tests/e2e/test_human_in_loop/test_human_in_loop.py#L611-L631)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Timeout bump in a skipped test has no effect.** `test_human_in_loop_mark_as_resolved_e2e` is decorated with `@pytest.mark.skip` (line 575), so this polling loop never executes in CI. The change is harmless, but if the intent was to de-flake this test once the LangGraph bug is resolved and the skip is removed, the update is still correct for that future scenario — just worth calling out so reviewers don't count it as one of the "four active fixes" mentioned in the PR description.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%0ALine%3A%20611-631%0A%0AComment%3A%0A**Timeout%20bump%20in%20a%20skipped%20test%20has%20no%20effect.**%20%60test_human_in_loop_mark_as_resolved_e2e%60%20is%20decorated%20with%20%60%40pytest.mark.skip%60%20%28line%20575%29%2C%20so%20this%20polling%20loop%20never%20executes%20in%20CI.%20The%20change%20is%20harmless%2C%20but%20if%20the%20intent%20was%20to%20de-flake%20this%20test%20once%20the%20LangGraph%20bug%20is%20resolved%20and%20the%20skip%20is%20removed%2C%20the%20update%20is%20still%20correct%20for%20that%20future%20scenario%20%E2%80%94%20just%20worth%20calling%20out%20so%20reviewers%20don't%20count%20it%20as%20one%20of%20the%20%22four%20active%20fixes%22%20mentioned%20in%20the%20PR%20description.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%0ALine%3A%20611-631%0A%0AComment%3A%0A**Timeout%20bump%20in%20a%20skipped%20test%20has%20no%20effect.**%20%60test_human_in_loop_mark_as_resolved_e2e%60%20is%20decorated%20with%20%60%40pytest.mark.skip%60%20%28line%20575%29%2C%20so%20this%20polling%20loop%20never%20executes%20in%20CI.%20The%20change%20is%20harmless%2C%20but%20if%20the%20intent%20was%20to%20de-flake%20this%20test%20once%20the%20LangGraph%20bug%20is%20resolved%20and%20the%20skip%20is%20removed%2C%20the%20update%20is%20still%20correct%20for%20that%20future%20scenario%20%E2%80%94%20just%20worth%20calling%20out%20so%20reviewers%20don't%20count%20it%20as%20one%20of%20the%20%22four%20active%20fixes%22%20mentioned%20in%20the%20PR%20description.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fflaky-hitl-interrupt-timeout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fflaky-hitl-interrupt-timeout%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%0ALine%3A%20611-631%0A%0AComment%3A%0A**Timeout%20bump%20in%20a%20skipped%20test%20has%20no%20effect.**%20%60test_human_in_loop_mark_as_resolved_e2e%60%20is%20decorated%20with%20%60%40pytest.mark.skip%60%20%28line%20575%29%2C%20so%20this%20polling%20loop%20never%20executes%20in%20CI.%20The%20change%20is%20harmless%2C%20but%20if%20the%20intent%20was%20to%20de-flake%20this%20test%20once%20the%20LangGraph%20bug%20is%20resolved%20and%20the%20skip%20is%20removed%2C%20the%20update%20is%20still%20correct%20for%20that%20future%20scenario%20%E2%80%94%20just%20worth%20calling%20out%20so%20reviewers%20don't%20count%20it%20as%20one%20of%20the%20%22four%20active%20fixes%22%20mentioned%20in%20the%20PR%20description.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%3A9%0AThe%20%60wait_for_run_settle%60%20helper%20used%20by%20%60test_human_in_loop_edit_tool_args_e2e%60%20%28line%20458%29%20and%20%60test_human_in_loop_streaming_interrupt_resume_e2e%60%20%28line%20752%29%20still%20defaults%20to%2020%20s.%20Under%20the%20same%20CI-load%20conditions%20that%20triggered%20this%20fix%2C%20both%20tests%20can%20reach%20the%20same%20%22Expected%20interrupted%2C%20got%20running%22%20failure%20because%20their%20poll%20ceiling%20is%20lower%20than%20the%2030%20s%20now%20applied%20to%20the%20four%20inline%20loops.%0A%0A%60%60%60suggestion%0Aasync%20def%20wait_for_run_settle%28client%2C%20thread_id%2C%20run_id%2C%20max_wait%3D30%29%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%3A611-631%0A**Timeout%20bump%20in%20a%20skipped%20test%20has%20no%20effect.**%20%60test_human_in_loop_mark_as_resolved_e2e%60%20is%20decorated%20with%20%60%40pytest.mark.skip%60%20%28line%20575%29%2C%20so%20this%20polling%20loop%20never%20executes%20in%20CI.%20The%20change%20is%20harmless%2C%20but%20if%20the%20intent%20was%20to%20de-flake%20this%20test%20once%20the%20LangGraph%20bug%20is%20resolved%20and%20the%20skip%20is%20removed%2C%20the%20update%20is%20still%20correct%20for%20that%20future%20scenario%20%E2%80%94%20just%20worth%20calling%20out%20so%20reviewers%20don't%20count%20it%20as%20one%20of%20the%20%22four%20active%20fixes%22%20mentioned%20in%20the%20PR%20description.%0A%0A&repo=aegra%2Faegra&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%3A9%0AThe%20%60wait_for_run_settle%60%20helper%20used%20by%20%60test_human_in_loop_edit_tool_args_e2e%60%20%28line%20458%29%20and%20%60test_human_in_loop_streaming_interrupt_resume_e2e%60%20%28line%20752%29%20still%20defaults%20to%2020%20s.%20Under%20the%20same%20CI-load%20conditions%20that%20triggered%20this%20fix%2C%20both%20tests%20can%20reach%20the%20same%20%22Expected%20interrupted%2C%20got%20running%22%20failure%20because%20their%20poll%20ceiling%20is%20lower%20than%20the%2030%20s%20now%20applied%20to%20the%20four%20inline%20loops.%0A%0A%60%60%60suggestion%0Aasync%20def%20wait_for_run_settle%28client%2C%20thread_id%2C%20run_id%2C%20max_wait%3D30%29%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%3A611-631%0A**Timeout%20bump%20in%20a%20skipped%20test%20has%20no%20effect.**%20%60test_human_in_loop_mark_as_resolved_e2e%60%20is%20decorated%20with%20%60%40pytest.mark.skip%60%20%28line%20575%29%2C%20so%20this%20polling%20loop%20never%20executes%20in%20CI.%20The%20change%20is%20harmless%2C%20but%20if%20the%20intent%20was%20to%20de-flake%20this%20test%20once%20the%20LangGraph%20bug%20is%20resolved%20and%20the%20skip%20is%20removed%2C%20the%20update%20is%20still%20correct%20for%20that%20future%20scenario%20%E2%80%94%20just%20worth%20calling%20out%20so%20reviewers%20don't%20count%20it%20as%20one%20of%20the%20%22four%20active%20fixes%22%20mentioned%20in%20the%20PR%20description.%0A%0A&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fflaky-hitl-interrupt-timeout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fflaky-hitl-interrupt-timeout%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%3A9%0AThe%20%60wait_for_run_settle%60%20helper%20used%20by%20%60test_human_in_loop_edit_tool_args_e2e%60%20%28line%20458%29%20and%20%60test_human_in_loop_streaming_interrupt_resume_e2e%60%20%28line%20752%29%20still%20defaults%20to%2020%20s.%20Under%20the%20same%20CI-load%20conditions%20that%20triggered%20this%20fix%2C%20both%20tests%20can%20reach%20the%20same%20%22Expected%20interrupted%2C%20got%20running%22%20failure%20because%20their%20poll%20ceiling%20is%20lower%20than%20the%2030%20s%20now%20applied%20to%20the%20four%20inline%20loops.%0A%0A%60%60%60suggestion%0Aasync%20def%20wait_for_run_settle%28client%2C%20thread_id%2C%20run_id%2C%20max_wait%3D30%29%3A%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Ftests%2Fe2e%2Ftest_human_in_loop%2Ftest_human_in_loop.py%3A611-631%0A**Timeout%20bump%20in%20a%20skipped%20test%20has%20no%20effect.**%20%60test_human_in_loop_mark_as_resolved_e2e%60%20is%20decorated%20with%20%60%40pytest.mark.skip%60%20%28line%20575%29%2C%20so%20this%20polling%20loop%20never%20executes%20in%20CI.%20The%20change%20is%20harmless%2C%20but%20if%20the%20intent%20was%20to%20de-flake%20this%20test%20once%20the%20LangGraph%20bug%20is%20resolved%20and%20the%20skip%20is%20removed%2C%20the%20update%20is%20still%20correct%20for%20that%20future%20scenario%20%E2%80%94%20just%20worth%20calling%20out%20so%20reviewers%20don't%20count%20it%20as%20one%20of%20the%20%22four%20active%20fixes%22%20mentioned%20in%20the%20PR%20description.%0A%0A&repo=aegra%2Faegra&pr=418&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["test(hitl): raise interrupt-poll timeout..."](https://github.com/aegra/aegra/commit/14b90ac78fb26a059088516fcff34963978ea018) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36494564)</sub>

<!-- /greptile_comment -->