### PR TITLE
fix: replace config btree index with md5 expression index to support large assistant configs

### DIFF
--- a/libs/aegra-api/alembic/versions/20260612000000_hash_assistant_config_index.py
+++ b/libs/aegra-api/alembic/versions/20260612000000_hash_assistant_config_index.py
@@ -36,15 +36,15 @@ database that already contains a row whose ``config::text`` exceeds
 migration as **forward-only** on production databases that have been used
 with large agent configs.
 
-Revision ID: a1b2c3d4e5f6
-Revises: f1a2b3c4d5e6
+Revision ID: b88bb61be638
+Revises: c7d1f2a4b6e8
 Create Date: 2026-06-12 00:00:00.000000
 """
 
 from alembic import op
 
-revision = "a1b2c3d4e5f6"
-down_revision = "f1a2b3c4d5e6"
+revision = "b88bb61be638"
+down_revision = "c7d1f2a4b6e8"
 branch_labels = None
 depends_on = None
 

--- a/libs/aegra-api/alembic/versions/20260612000000_hash_assistant_config_index.py
+++ b/libs/aegra-api/alembic/versions/20260612000000_hash_assistant_config_index.py
@@ -1,0 +1,74 @@
+"""Replace verbatim-config btree index with md5 expression index.
+
+The unique btree index ``idx_assistant_user_graph_config`` was introduced in
+revision ``76dfdbe90d2b`` (add_version_table) as::
+
+    CREATE UNIQUE INDEX idx_assistant_user_graph_config
+        ON assistant (user_id, graph_id, config);
+
+PostgreSQL btree index entries are capped at roughly **2 704 bytes** (one
+third of an 8 KB page). The ``config`` column is a JSONB object whose
+``configurable`` sub-key holds agent configuration — including a system
+prompt that routinely exceeds 2 704 bytes. Every ``INSERT`` or ``UPDATE``
+whose serialised ``config`` is larger than that limit fails with::
+
+    index row size NNNN exceeds btree version 4 maximum 2704 for index
+    "idx_assistant_user_graph_config"
+
+This migration replaces the verbatim-column btree with a fixed-width
+**expression index** over ``md5(config::text)``::
+
+    CREATE UNIQUE INDEX idx_assistant_user_graph_config
+        ON assistant (user_id, graph_id, md5(config::text));
+
+``md5(config::text)`` is always 32 bytes, so the index entry never exceeds
+the btree limit regardless of payload size.  The uniqueness guarantee is
+preserved: PostgreSQL stores JSONB in canonical form (normalised key order,
+no insignificant whitespace), so ``config::text`` is deterministic for
+logically-equal configs.  ``md5`` is a PostgreSQL built-in — no
+``pgcrypto`` extension is required.
+
+Downgrade note
+--------------
+The downgrade re-creates the original btree index.  This will fail on any
+database that already contains a row whose ``config::text`` exceeds
+~2 704 bytes (i.e. the exact problem this migration fixes).  Treat this
+migration as **forward-only** on production databases that have been used
+with large agent configs.
+
+Revision ID: a1b2c3d4e5f6
+Revises: f1a2b3c4d5e6
+Create Date: 2026-06-12 00:00:00.000000
+"""
+
+from alembic import op
+
+revision = "a1b2c3d4e5f6"
+down_revision = "f1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("idx_assistant_user_graph_config", table_name="assistant")
+    # CREATE INDEX cannot use CONCURRENTLY inside a transaction, and Alembic
+    # migrations run inside a transaction by default.  The brief ShareLock on
+    # the assistant table during the index build is acceptable: the table is
+    # small and this migration runs once at deployment time.
+    op.execute(
+        "CREATE UNIQUE INDEX idx_assistant_user_graph_config"
+        " ON assistant (user_id, graph_id, md5(config::text))"
+    )
+
+
+def downgrade() -> None:
+    # WARNING: re-creating the verbatim-config btree will fail if any row's
+    # config::text already exceeds ~2 704 bytes.  Only safe on databases that
+    # have never stored a large-config assistant.
+    op.drop_index("idx_assistant_user_graph_config", table_name="assistant")
+    op.create_index(
+        "idx_assistant_user_graph_config",
+        "assistant",
+        ["user_id", "graph_id", "config"],
+        unique=True,
+    )

--- a/libs/aegra-api/alembic/versions/20260612000000_hash_assistant_config_index.py
+++ b/libs/aegra-api/alembic/versions/20260612000000_hash_assistant_config_index.py
@@ -56,8 +56,7 @@ def upgrade() -> None:
     # the assistant table during the index build is acceptable: the table is
     # small and this migration runs once at deployment time.
     op.execute(
-        "CREATE UNIQUE INDEX idx_assistant_user_graph_config"
-        " ON assistant (user_id, graph_id, md5(config::text))"
+        "CREATE UNIQUE INDEX idx_assistant_user_graph_config ON assistant (user_id, graph_id, md5(config::text))"
     )
 
 

--- a/libs/aegra-api/src/aegra_api/core/orm.py
+++ b/libs/aegra-api/src/aegra_api/core/orm.py
@@ -114,7 +114,7 @@ class Assistant(Base):
             "idx_assistant_user_graph_config",
             "user_id",
             "graph_id",
-            "config",
+            text("md5(config::text)"),
             unique=True,
         ),
     )

--- a/libs/aegra-api/tests/integration/test_assistant_large_config_db.py
+++ b/libs/aegra-api/tests/integration/test_assistant_large_config_db.py
@@ -27,6 +27,7 @@ async def test_insert_assistant_with_large_configurable_prompt_succeeds() -> Non
     engine = create_async_engine(settings.db.database_url)
 
     try:
+        assistant_table = None
         try:
             async with engine.begin() as conn:
                 await conn.execute(text("SELECT 1"))

--- a/libs/aegra-api/tests/integration/test_assistant_large_config_db.py
+++ b/libs/aegra-api/tests/integration/test_assistant_large_config_db.py
@@ -1,0 +1,75 @@
+"""Regression tests for assistant configs larger than PostgreSQL btree entries."""
+
+import hashlib
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import delete, text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from aegra_api.core.orm import Assistant as AssistantORM
+from aegra_api.settings import settings
+
+_ASSISTANT_ID = "large-config-index-regression"
+_USER_ID = "large-config-test-user"
+_GRAPH_ID = "large-config-test-graph"
+
+
+def _large_system_prompt() -> str:
+    """Return deterministic, incompressible-ish text above the btree tuple limit."""
+    return "\n".join(hashlib.sha256(f"prompt-line-{i}".encode()).hexdigest() for i in range(512))
+
+
+@pytest.mark.asyncio
+async def test_insert_assistant_with_large_configurable_prompt_succeeds() -> None:
+    """A large prompt in config.configurable must not overflow the unique index."""
+    engine = create_async_engine(settings.db.database_url)
+
+    try:
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text("SELECT 1"))
+                assistant_table = await conn.scalar(text("SELECT to_regclass('public.assistant')"))
+        except (OperationalError, OSError) as exc:
+            pytest.skip(f"PostgreSQL test database is unavailable: {exc}")
+
+        if assistant_table is None:
+            pytest.skip("assistant table is unavailable; run Alembic migrations before this DB regression test")
+
+        prompt = _large_system_prompt()
+        config = {
+            "configurable": {
+                "system_prompt": prompt,
+                "request_id": str(uuid4()),
+            }
+        }
+
+        Session = async_sessionmaker(engine, expire_on_commit=False)
+        async with Session() as session:
+            await session.execute(delete(AssistantORM).where(AssistantORM.assistant_id == _ASSISTANT_ID))
+            await session.commit()
+
+            assistant = AssistantORM(
+                assistant_id=_ASSISTANT_ID,
+                name="Large Config Regression",
+                description="Exercises the md5(config::text) uniqueness index",
+                graph_id=_GRAPH_ID,
+                config=config,
+                context={},
+                user_id=_USER_ID,
+                metadata_dict={"test": "large-config-index"},
+                version=1,
+            )
+            session.add(assistant)
+            await session.commit()
+
+            try:
+                saved = await session.get(AssistantORM, _ASSISTANT_ID)
+                assert saved is not None
+                assert saved.config["configurable"]["system_prompt"] == prompt
+            finally:
+                await session.execute(delete(AssistantORM).where(AssistantORM.assistant_id == _ASSISTANT_ID))
+                await session.commit()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
Fixes #421

## Problem

Revision `76dfdbe90d2b` created a UNIQUE btree index over `(user_id, graph_id, config)` on the `assistant` table. PostgreSQL btree index entries are capped at ~2 704 bytes (1/3 of an 8 KB page). The `config` column is a JSONB object that holds agent configuration under `config.configurable` — including a system prompt that routinely exceeds 2 704 bytes. Every `INSERT` or `UPDATE` whose serialised `config` is larger than that limit fails with:

```
index row size NNNN exceeds btree version 4 maximum 2704 for index
"idx_assistant_user_graph_config"
```

Aegra has no handler for this error, so it surfaces as a 500 with no actionable message.

## Fix

Replace the verbatim-column btree with a fixed-width **expression index** over `md5(config::text)`:

```sql
CREATE UNIQUE INDEX idx_assistant_user_graph_config
    ON assistant (user_id, graph_id, md5(config::text));
```

`md5(config::text)` is always 32 bytes, so the index entry is never larger than the btree limit regardless of config size. The uniqueness guarantee is preserved: PostgreSQL serialises JSONB in canonical form, making `config::text` deterministic for logically-equal configs. `md5` is a PostgreSQL built-in — no `pgcrypto` extension is required.

## Changes

| File | Change |
|---|---|
| `libs/aegra-api/alembic/versions/20260612000000_hash_assistant_config_index.py` | New migration: drop old btree, create md5 expression index |
| `libs/aegra-api/src/aegra_api/core/orm.py` | Update `__table_args__` to match the new expression index |

No changes to `assistant_service.py` — the app-level deduplication query (`AssistantORM.config == config`) uses JSONB equality on the column directly and remains correct.

## Downgrade note

The downgrade path re-creates the original verbatim-config btree. This will fail on any database that already contains a row whose `config::text` exceeds ~2 704 bytes. This migration should be treated as **forward-only** on production databases that have stored large-config assistants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assistant configuration persistence by changing the uniqueness index to use a fixed-size hash derived from the configuration content, preventing PostgreSQL btree index entry-size failures with very large prompts.
  * Included the matching database migration for the updated index strategy; rollback may fail if existing rows contain exceptionally large configuration text values.
* **Tests**
  * Added an integration regression test that inserts an assistant with a large, deterministic configuration and verifies it’s persisted correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a PostgreSQL btree size limit error that caused any `INSERT` or `UPDATE` on the `assistant` table to fail with a 500 when the serialized `config` JSONB exceeded ~2 704 bytes, which is the btree entry cap. The fix replaces the verbatim-column index with a fixed-width `md5(config::text)` expression index — the 32-byte hash is always within the limit while still enforcing uniqueness, since PostgreSQL stores JSONB in canonical form making the cast deterministic.

- **Migration** (`20260612000000_hash_assistant_config_index.py`): drops the old btree and creates the md5 expression index; `revision = "b88bb61be638"` is unique and `down_revision = "c7d1f2a4b6e8"` correctly chains to `cron_cascade_and_claim`, the current HEAD — the duplicate-revision issue from the previous review iteration has been resolved.
- **ORM** (`orm.py`): `__table_args__` is updated to use `text("md5(config::text)")` so the schema produced by `Base.metadata.create_all()` matches the migration.
- **Test** (`test_assistant_large_config_db.py`): new integration regression test inserts a >2 704-byte config, asserts the row was persisted correctly, and skips gracefully when no live database is available.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the migration chain is valid, the ORM and migration are consistent, and the fix is well-scoped to the reported btree overflow.

The migration revision is unique, its down_revision correctly points to the current HEAD, the ORM expression index matches the migration SQL, and the application-level deduplication query (config == config) is unaffected. The md5 approach is a standard, well-understood pattern for this class of problem in PostgreSQL.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/alembic/versions/20260612000000_hash_assistant_config_index.py | New Alembic migration (revision b88bb61be638) that drops the verbatim-config btree index and creates an md5 expression index; revision ID is unique and down_revision correctly chains to cron_cascade_and_claim (c7d1f2a4b6e8), the current HEAD. |
| libs/aegra-api/src/aegra_api/core/orm.py | Updates the Assistant ORM __table_args__ to use text("md5(config::text)") in the expression index, keeping it in sync with the Alembic migration. |
| libs/aegra-api/tests/integration/test_assistant_large_config_db.py | New integration regression test that inserts an assistant with a >2704-byte config, verifies the save succeeded, and cleans up; correctly skips when no live database is available. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Application
    participant PG as PostgreSQL

    Note over App,PG: Before fix — large config fails
    App->>PG: "INSERT INTO assistant (user_id, graph_id, config=large_jsonb)"
    PG-->>App: ERROR: index row size 3500 exceeds btree max 2704

    Note over App,PG: After fix — md5 expression index
    App->>PG: "INSERT INTO assistant (user_id, graph_id, config=large_jsonb)"
    PG->>PG: Index check: md5(config::text) → 32-byte hash
    PG->>PG: Unique check on (user_id, graph_id, hash)
    PG-->>App: OK (row inserted)

    Note over App,PG: Deduplication query unchanged
    App->>PG: "SELECT * WHERE config = :config (JSONB equality)"
    PG-->>App: existing row (if duplicate)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Application
    participant PG as PostgreSQL

    Note over App,PG: Before fix — large config fails
    App->>PG: "INSERT INTO assistant (user_id, graph_id, config=large_jsonb)"
    PG-->>App: ERROR: index row size 3500 exceeds btree max 2704

    Note over App,PG: After fix — md5 expression index
    App->>PG: "INSERT INTO assistant (user_id, graph_id, config=large_jsonb)"
    PG->>PG: Index check: md5(config::text) → 32-byte hash
    PG->>PG: Unique check on (user_id, graph_id, hash)
    PG-->>App: OK (row inserted)

    Note over App,PG: Deduplication query unchanged
    App->>PG: "SELECT * WHERE config = :config (JSONB equality)"
    PG-->>App: existing row (if duplicate)
```

</a>

<sub>Reviews (4): Last reviewed commit: ["fix: initialise assistant\_table before t..."](https://github.com/aegra/aegra/commit/992967d980c08bf6613147996baf3268ad063eda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36893774)</sub>

<!-- /greptile_comment -->