### PR TITLE
fix(runs): enforce assistant ownership check in run preparation

### DIFF
--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 import structlog
 from asgi_correlation_id import correlation_id
 from fastapi import HTTPException
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aegra_api.core.orm import Assistant as AssistantORM
@@ -200,6 +200,7 @@ async def _prepare_run(
 
     assistant_stmt = select(AssistantORM).where(
         AssistantORM.assistant_id == resolved_assistant_id,
+        or_(AssistantORM.user_id == user.identity, AssistantORM.user_id == "system"),
     )
     assistant = await session.scalar(assistant_stmt)
     if not assistant:


### PR DESCRIPTION
## Problem

When creating a run (`POST /threads/{thread_id}/runs`), the assistant is fetched from the database using only `assistant_id` — with no `user_id` ownership check. Any authenticated user who knows another user's assistant UUID can create a run that merges the victim's assistant config (including API keys, system prompts, and LLM credentials stored in `config.configurable`) into their own run record. The merged config is returned verbatim in the `POST /runs` and `GET /runs/{run_id}` responses.

This was a sibling gap to the thread ownership bug fixed in PR #337 — that PR added user_id guards to thread operations but missed the assistant lookup in `_prepare_run`.

## Fix

Add the same user_id scoping guard used by `get_assistant()` and `update_assistant()` — restrict the assistant lookup to the requesting user's own assistants plus shared system assistants (`user_id == 'system'`).

```python
# Before (vulnerable)
assistant_stmt = select(AssistantORM).where(
    AssistantORM.assistant_id == resolved_assistant_id,
)

# After (fixed)
assistant_stmt = select(AssistantORM).where(
    AssistantORM.assistant_id == resolved_assistant_id,
    or_(AssistantORM.user_id == user.identity, AssistantORM.user_id == "system"),
)
```

## Test Plan

- [ ] Existing test suite passes (`python3 -m pytest libs/aegra-api/tests/`)
- [ ] Creating a run with another user's assistant_id returns 404
- [ ] Creating a run with own assistant_id succeeds as before
- [ ] Creating a run with a system assistant_id succeeds (shared assistants remain accessible)

## Security Note

**Severity:** High — cross-user configuration disclosure including potential API key exfiltration.

This PR is filed directly because the fix is minimal (2-line change) and this bug class was already publicly disclosed via the merged PR #337 and GHSA-m98r-6667-4wq7. The sister bug in assistant lookup was not covered by either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System assistants can now be selected when preparing runs, in addition to user-owned assistants. This expands assistant selection options for run configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a user ownership check to the assistant lookup inside `_prepare_run`, closing a cross-user data-exfiltration hole where any authenticated user could supply another user's `assistant_id` to pull that assistant's merged config (including API keys and system prompts) into their own run record.

- **Core fix** (`run_preparation.py` line 203): wraps the `WHERE` clause with `or_(AssistantORM.user_id == user.identity, AssistantORM.user_id == "system")`, mirroring the identical guard already present in `AssistantService.get_assistant()`, `list_assistants()`, `search_assistants()`, and `get_assistant_schemas()`.
- **Coverage**: because all run-creation endpoints (threaded `POST /threads/{id}/runs`, stateless `/runs`, `/runs/wait`, `/runs/stream`) funnel through `_prepare_run`, the single change closes the gap for every surface.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the two-line change is a surgical, targeted fix with no side effects on the run creation flow.

The added predicate is character-for-character identical to the ownership guard already used in every read path of AssistantService. The 404 on a missing or unauthorized assistant is unchanged, the stateless endpoints are covered because they all delegate to _prepare_run, and no new code paths are introduced.

No files require special attention; the single changed file applies the fix cleanly.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/run_preparation.py | Adds user-scoped ownership predicate to the assistant SELECT in `_prepare_run`; the new condition exactly matches the pattern used in AssistantService — correct and minimal change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant RunsAPI as POST /threads/{id}/runs
    participant PrepareRun as _prepare_run
    participant DB as Database

    Client->>RunsAPI: assistant_id (possibly another user's)
    RunsAPI->>PrepareRun: user, assistant_id
    PrepareRun->>PrepareRun: resolve_assistant_id()

    Note over PrepareRun,DB: BEFORE this PR
    PrepareRun->>DB: "SELECT * FROM assistants WHERE assistant_id = ?"
    DB-->>PrepareRun: returns ANY user's assistant

    Note over PrepareRun,DB: AFTER this PR
    PrepareRun->>DB: "SELECT * FROM assistants WHERE assistant_id = ? AND (user_id = current_user OR user_id = 'system')"
    DB-->>PrepareRun: returns own / system assistants only

    alt Assistant found
        PrepareRun-->>RunsAPI: run created with merged config
        RunsAPI-->>Client: 200 run record
    else Not found / unauthorized
        PrepareRun-->>RunsAPI: HTTPException 404
        RunsAPI-->>Client: 404 Not Found
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(runs): enforce assistant ownership c..."](https://github.com/aegra/aegra/commit/2a69b6247f9ebfe71f12fb4e175c0e45b11ef302) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37448444)</sub>

<!-- /greptile_comment -->