### PR TITLE
fix(auth): warn when server runs without authentication configured

### DIFF
--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -224,8 +224,14 @@ class LangGraphAuthBackend(AuthenticationBackend):
         # Default to noop (anonymous) authentication when no auth file is found,
         # regardless of AUTH_TYPE setting. This ensures the server works out-of-the-box.
         if self.auth_instance is None:
-            logger.debug("No auth file configured, defaulting to noop (anonymous) authentication")
-            # Return anonymous user when no auth is configured
+            logger.warning(
+                "No auth file configured — all requests share a single 'anonymous' identity. "
+                "Data is NOT isolated between users in this mode. "
+                "Configure 'auth.path' in aegra.json before serving multiple users. "
+                "See: https://docs.aegra.dev/guides/authentication"
+            )
+            # Return anonymous user when no auth is configured.
+            # WARNING: all callers share this identity; no tenant isolation is enforced.
             user_data: Auth.types.MinimalUserDict = {
                 "identity": "anonymous",
                 "display_name": "Anonymous User",


### PR DESCRIPTION
## Problem

When no `auth.path` is configured in `aegra.json` (the default out-of-the-box state), the authentication middleware assigns every request the hardcoded identity `"anonymous"` with `is_authenticated=True`. Because all aegra data is scoped by `user_id`, all users on a shared server end up in the same `"anonymous"` data bucket — threads, runs, cron jobs, and store items are visible and mutable by anyone.

The existing log call was `logger.debug(...)`, making this silent in default log levels. Operators sharing an unauthenticated server have no way of knowing their data is exposed.

## Fix

Upgrade the log call from `debug` to `warning` and add a clear message directing operators to the auth documentation. Single-user local setups are unaffected.

## Test Plan

- [ ] Existing test suite passes
- [ ] `WARNING` log message emitted at server start when no auth is configured
- [ ] No change in behavior for authenticated setups

## Security Note

**Severity:** Medium — affects shared deployments running without auth configuration. Single-developer local setups are unaffected by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning message clarity when authentication is not configured, explicitly indicating that all requests share a single anonymous identity until proper authentication configuration is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades a silent `debug` log to a `warning` when no `auth.path` is configured, so operators of shared servers are alerted that all requests share a single `"anonymous"` identity and data is not isolated between users.

- The new warning message is clear and actionable, pointing to the auth documentation.
- However, the warning is placed in `authenticate()` — a method called on every HTTP request — rather than in `_load_auth_instance()` which runs once at startup. This means the identical warning will be emitted for every request, creating severe log noise in any real deployment.

<h3>Confidence Score: 3/5</h3>

The intention is correct — operators need to see this warning — but the placement causes it to repeat on every HTTP request rather than once at startup, which will spam logs in any shared deployment.

The warning message itself is well-written and the goal is sound. The problem is that authenticate() is called per request, so when no auth is configured every incoming HTTP call emits the same multi-line warning. In a moderately busy server this produces thousands of duplicate log entries per minute, which can hide real alerts, fill log storage, and undermine the readability of the very signal this PR is trying to add. Moving the call one level up to _load_auth_instance() (which runs exactly once) would fully address this.

libs/aegra-api/src/aegra_api/core/auth_middleware.py — specifically the placement of the new warning inside authenticate() vs. _load_auth_instance().

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/auth_middleware.py | Upgrades silent debug log to a user-visible warning when no auth is configured, but places the call in the per-request authenticate() method instead of the one-time _load_auth_instance() initializer, causing the warning to repeat on every HTTP request. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Middleware as AuthenticationMiddleware
    participant Backend as LangGraphAuthBackend
    participant Logger

    Note over Backend: __init__() — runs once via lru_cache
    Backend->>Backend: _load_auth_instance()
    Backend->>Logger: debug("No auth instance found from config") [line 100]

    loop Every HTTP Request
        Client->>Middleware: HTTP Request
        Middleware->>Backend: authenticate(conn)
        alt auth_instance is None (unauthenticated mode)
            Backend->>Logger: warning("No auth file configured...") ⚠️ REPEATED
            Backend-->>Middleware: (anonymous user)
        else auth_instance configured
            Backend->>Backend: call _authenticate_handler
            Backend-->>Middleware: (real user)
        end
        Middleware-->>Client: Response
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%3A226-232%0A**Warning%20fires%20on%20every%20request%2C%20not%20once%20at%20startup**%0A%0A%60authenticate%60%20is%20a%20per-request%20middleware%20method%2C%20so%20this%20%60logger.warning%28...%29%60%20block%20will%20fire%20on%20every%20single%20HTTP%20request%20when%20no%20auth%20is%20configured.%20In%20any%20non-trivial%20deployment%20this%20produces%20thousands%20of%20identical%20warning%20lines%20per%20minute%2C%20drowning%20out%20real%20alerts%20and%20potentially%20filling%20log%20storage.%0A%0AThe%20right%20place%20for%20this%20warning%20is%20%60_load_auth_instance%60%20%28called%20only%20from%20%60__init__%60%2C%20which%20itself%20runs%20once%20thanks%20to%20%60%40functools.lru_cache%60%20on%20%60get_auth_backend%60%29.%20Line%20100%20already%20has%20a%20%60logger.debug%28%22No%20auth%20instance%20found%20from%20config%22%29%60%20call%20there%20%E2%80%94%20upgrading%20or%20replacing%20that%20single%20call%20would%20emit%20the%20warning%20exactly%20once%20at%20startup%20and%20keep%20the%20per-request%20%60authenticate%60%20path%20noise-free.%0A%0A&repo=aegra%2Faegra&pr=425&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%3A226-232%0A**Warning%20fires%20on%20every%20request%2C%20not%20once%20at%20startup**%0A%0A%60authenticate%60%20is%20a%20per-request%20middleware%20method%2C%20so%20this%20%60logger.warning%28...%29%60%20block%20will%20fire%20on%20every%20single%20HTTP%20request%20when%20no%20auth%20is%20configured.%20In%20any%20non-trivial%20deployment%20this%20produces%20thousands%20of%20identical%20warning%20lines%20per%20minute%2C%20drowning%20out%20real%20alerts%20and%20potentially%20filling%20log%20storage.%0A%0AThe%20right%20place%20for%20this%20warning%20is%20%60_load_auth_instance%60%20%28called%20only%20from%20%60__init__%60%2C%20which%20itself%20runs%20once%20thanks%20to%20%60%40functools.lru_cache%60%20on%20%60get_auth_backend%60%29.%20Line%20100%20already%20has%20a%20%60logger.debug%28%22No%20auth%20instance%20found%20from%20config%22%29%60%20call%20there%20%E2%80%94%20upgrading%20or%20replacing%20that%20single%20call%20would%20emit%20the%20warning%20exactly%20once%20at%20startup%20and%20keep%20the%20per-request%20%60authenticate%60%20path%20noise-free.%0A%0A&pr=425&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Ffind-002-anonymous-auth-warning%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Ffind-002-anonymous-auth-warning%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fauth_middleware.py%3A226-232%0A**Warning%20fires%20on%20every%20request%2C%20not%20once%20at%20startup**%0A%0A%60authenticate%60%20is%20a%20per-request%20middleware%20method%2C%20so%20this%20%60logger.warning%28...%29%60%20block%20will%20fire%20on%20every%20single%20HTTP%20request%20when%20no%20auth%20is%20configured.%20In%20any%20non-trivial%20deployment%20this%20produces%20thousands%20of%20identical%20warning%20lines%20per%20minute%2C%20drowning%20out%20real%20alerts%20and%20potentially%20filling%20log%20storage.%0A%0AThe%20right%20place%20for%20this%20warning%20is%20%60_load_auth_instance%60%20%28called%20only%20from%20%60__init__%60%2C%20which%20itself%20runs%20once%20thanks%20to%20%60%40functools.lru_cache%60%20on%20%60get_auth_backend%60%29.%20Line%20100%20already%20has%20a%20%60logger.debug%28%22No%20auth%20instance%20found%20from%20config%22%29%60%20call%20there%20%E2%80%94%20upgrading%20or%20replacing%20that%20single%20call%20would%20emit%20the%20warning%20exactly%20once%20at%20startup%20and%20keep%20the%20per-request%20%60authenticate%60%20path%20noise-free.%0A%0A&repo=aegra%2Faegra&pr=425&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): warn when server runs without..."](https://github.com/aegra/aegra/commit/ac322e6bcc0a90686fca1d9830229095a8cc8cc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37570865)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->