### PR TITLE
fix(api): release db sessions before SSE streaming

### DIFF
--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -89,7 +89,6 @@ async def create_and_stream_run(
     thread_id: str,
     request: RunCreate,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> EventSourceResponse:
     """Create a new run and stream its execution via SSE.
 
@@ -105,11 +104,13 @@ async def create_and_stream_run(
     ``KEEPALIVE_INTERVAL_SECS`` so idle proxies don't drop long-running
     silent nodes (e.g. agents holding an upstream WebSocket).
     """
-    existing_thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == thread_id))
-    if existing_thread and existing_thread.user_id != user.identity:
-        raise HTTPException(404, f"Thread '{thread_id}' not found")
+    maker = _get_session_maker()
+    async with maker() as session:
+        existing_thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == thread_id))
+        if existing_thread and existing_thread.user_id != user.identity:
+            raise HTTPException(404, f"Thread '{thread_id}' not found")
 
-    run_id, run, _job = await _prepare_run(session, thread_id, request, user, initial_status="pending")
+        run_id, run, _job = await _prepare_run(session, thread_id, request, user, initial_status="pending")
 
     # Default to cancel on disconnect - this matches user expectation that clicking
     # "Cancel" in the frontend will stop the backend task. Users can explicitly
@@ -377,31 +378,35 @@ async def stream_run(
     A periodic SSE keepalive comment is sent every
     ``KEEPALIVE_INTERVAL_SECS`` so idle proxies don't drop attached streams.
     """
-    logger.info(f"[stream_run] fetch for stream run_id={run_id} thread_id={thread_id} user={user.identity}")
-    run_orm = await session.scalar(
-        select(RunORM).where(
-            RunORM.run_id == str(run_id),
-            RunORM.thread_id == thread_id,
-            RunORM.user_id == user.identity,
+    maker = _get_session_maker()
+    async with maker() as session:
+        logger.info(f"[stream_run] fetch for stream run_id={run_id} thread_id={thread_id} user={user.identity}")
+        run_orm = await session.scalar(
+            select(RunORM).where(
+                RunORM.run_id == str(run_id),
+                RunORM.thread_id == thread_id,
+                RunORM.user_id == user.identity,
+            )
         )
-    )
-    if not run_orm:
-        raise HTTPException(404, f"Run '{run_id}' not found")
+        if not run_orm:
+            raise HTTPException(404, f"Run '{run_id}' not found")
 
-    logger.info(f"[stream_run] status={run_orm.status} user={user.identity} thread_id={thread_id} run_id={run_id}")
+        logger.info(f"[stream_run] status={run_orm.status} user={user.identity} thread_id={thread_id} run_id={run_id}")
+        run_status = run_orm.status
+        run_model = Run.model_validate(run_orm)
     # No client_close_handler_callable: this is a reconnect-style endpoint, so
     # a single client disconnecting must not cancel the shared run — other
     # consumers may still be attached via /join or another /stream.
     # If already terminal and no Last-Event-ID, just emit end.
     # If Last-Event-ID is present, fall through to stream_run_execution
     # which will replay missed events from the buffer before ending.
-    if run_orm.status in TERMINAL_STATES and not last_event_id:
-        final_status = "error" if run_orm.status == "error" else run_orm.status
+    if run_status in TERMINAL_STATES and not last_event_id:
+        final_status = "error" if run_status == "error" else run_status
 
         async def generate_final() -> AsyncGenerator[str, None]:
             yield create_end_event(status=final_status)
 
-        logger.info(f"[stream_run] starting terminal stream run_id={run_id} status={run_orm.status}")
+        logger.info(f"[stream_run] starting terminal stream run_id={run_id} status={run_status}")
         return make_sse_response(
             sse_to_bytes(generate_final()),
             headers={
@@ -413,8 +418,6 @@ async def stream_run(
 
     # Stream active or pending runs via broker
 
-    # Build a lightweight Pydantic Run from ORM for streaming context (IDs already strings)
-    run_model = Run.model_validate(run_orm)
 
     return make_sse_response(
         sse_to_bytes(streaming_service.stream_run_execution(run_model, last_event_id)),
@@ -441,7 +444,6 @@ async def cancel_run_endpoint(
         description="Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
     ),
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> Run:
     """Cancel or interrupt a running execution.
 

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -366,7 +366,6 @@ async def stream_run(
     last_event_id: str | None = Header(None, alias="Last-Event-ID"),
     _stream_mode: str | None = Query(None, description="Override the stream mode for this connection."),
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> EventSourceResponse:
     """Stream an existing run's execution via SSE.
 
@@ -444,6 +443,7 @@ async def cancel_run_endpoint(
         description="Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
     ),
     user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
 ) -> Run:
     """Cancel or interrupt a running execution.
 
@@ -576,3 +576,4 @@ async def delete_run(
 
     # 204 No Content
     return
+

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -417,7 +417,6 @@ async def stream_run(
 
     # Stream active or pending runs via broker
 
-
     return make_sse_response(
         sse_to_bytes(streaming_service.stream_run_execution(run_model, last_event_id)),
         headers={
@@ -576,4 +575,3 @@ async def delete_run(
 
     # 204 No Content
     return
-

--- a/libs/aegra-api/src/aegra_api/api/stateless_runs.py
+++ b/libs/aegra-api/src/aegra_api/api/stateless_runs.py
@@ -195,7 +195,6 @@ async def stateless_wait_for_run(
 async def stateless_stream_run(
     request: RunCreate,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> EventSourceResponse:
     """Create a stateless run and stream its execution.
 

--- a/libs/aegra-api/src/aegra_api/api/stateless_runs.py
+++ b/libs/aegra-api/src/aegra_api/api/stateless_runs.py
@@ -207,7 +207,7 @@ async def stateless_stream_run(
     should_delete = request.on_completion != "keep"
 
     try:
-        response = await create_and_stream_run(thread_id, request, user, session)
+        response = await create_and_stream_run(thread_id, request, user)
     except Exception:
         # create_and_stream_run may have auto-created the thread via
         # update_thread_metadata before raising; clean up to avoid orphans.


### PR DESCRIPTION
## Summary

Fixes #423.

The SSE streaming endpoints were using FastAPI's request-scoped `Depends(get_session)` dependency. For streaming responses, FastAPI keeps yield dependencies alive until the response completes, causing SQLAlchemy sessions and database connections to remain checked out for the full lifetime of the SSE connection.

Under concurrent long-running streams, this can exhaust the connection pool and cause unrelated API requests to fail with pool timeout errors.

## Changes

* Removed request-scoped `Depends(get_session)` from:

  * `POST /threads/{thread_id}/runs/stream`
  * `GET /threads/{thread_id}/runs/{run_id}/stream`
* Switched both endpoints to use short-lived sessions via `_get_session_maker()`
* Completed all database validation and run loading before returning the SSE response
* Returned database connections to the pool immediately while allowing streaming to continue

## Rationale

This follows the same pattern already used by `join_run()` and `wait_for_run()`, which avoid holding database connections during long-lived responses.

Fixes #423.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated run creation and SSE streaming to use short-lived internal database sessions instead of request-scoped injected sessions.
  * Adjusted stateless streaming to no longer pass existing session context into the run-stream setup.

* **Bug Fixes**
  * Improved SSE startup by resolving run status/model before beginning playback.
  * For already-terminal runs without a provided `Last-Event-ID`, streaming now emits only a single `end` event (including correct mapping for terminal `error`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a database connection pool exhaustion bug by releasing SQLAlchemy sessions before returning SSE streaming responses. The `Depends(get_session)` yield-dependency was holding connections for the full lifetime of each SSE connection; the fix replaces it with short-lived `async with maker() as session:` blocks that complete all DB work upfront and release the connection before streaming begins.

- `create_and_stream_run` and `stream_run` in `runs.py` now open their own internal sessions, perform all validation and ORM loading, extract plain Python/Pydantic objects (`run_status`, `run_model`, `run_id`), and close the session before returning the `EventSourceResponse`.
- `stateless_stream_run` in `stateless_runs.py` drops its own `session` dependency and no longer forwards it to `create_and_stream_run`, matching the updated signature.

<h3>Confidence Score: 5/5</h3>

Safe to merge — DB work completes and connections are returned to the pool before any SSE response is returned, with no ORM objects used outside their session scope.

All three changed endpoints correctly extract plain Python/Pydantic values inside the session block before closing it. _prepare_run returns a Pydantic Run model, and expire_on_commit=False ensures it is fully populated. cancel_run_endpoint retains its original Depends(get_session) and is unaffected. No regressions found.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/runs.py | Removed Depends(get_session) from create_and_stream_run and stream_run; replaced with short-lived async with maker() blocks. |
| libs/aegra-api/src/aegra_api/api/stateless_runs.py | Removed session dependency from stateless_stream_run and updated the call to create_and_stream_run to match its new signature. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `libs/aegra-api/src/aegra_api/api/runs.py`, line 363-370 ([link](https://github.com/aegra/aegra/blob/c7066f49eff73505947d9b762d06e1ea221aaf27/libs/aegra-api/src/aegra_api/api/runs.py#L363-L370)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale `Depends(get_session)` left in `stream_run` signature**

   `session: AsyncSession = Depends(get_session)` was not removed from the function signature (line 369). FastAPI will still inject and hold a yield-dependency-scoped session for the full lifetime of the SSE response, which is exactly the pool-exhaustion problem this PR intends to fix. The inner `async with maker() as session:` block creates and closes a second, correctly-scoped session, but the outer dependency session remains checked out until the stream completes. `create_and_stream_run` had its `Depends(get_session)` correctly removed, but `stream_run` did not.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fruns.py%0ALine%3A%20363-370%0A%0AComment%3A%0A**Stale%20%60Depends%28get_session%29%60%20left%20in%20%60stream_run%60%20signature**%0A%0A%60session%3A%20AsyncSession%20%3D%20Depends%28get_session%29%60%20was%20not%20removed%20from%20the%20function%20signature%20%28line%20369%29.%20FastAPI%20will%20still%20inject%20and%20hold%20a%20yield-dependency-scoped%20session%20for%20the%20full%20lifetime%20of%20the%20SSE%20response%2C%20which%20is%20exactly%20the%20pool-exhaustion%20problem%20this%20PR%20intends%20to%20fix.%20The%20inner%20%60async%20with%20maker%28%29%20as%20session%3A%60%20block%20creates%20and%20closes%20a%20second%2C%20correctly-scoped%20session%2C%20but%20the%20outer%20dependency%20session%20remains%20checked%20out%20until%20the%20stream%20completes.%20%60create_and_stream_run%60%20had%20its%20%60Depends%28get_session%29%60%20correctly%20removed%2C%20but%20%60stream_run%60%20did%20not.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=428&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fruns.py%0ALine%3A%20363-370%0A%0AComment%3A%0A**Stale%20%60Depends%28get_session%29%60%20left%20in%20%60stream_run%60%20signature**%0A%0A%60session%3A%20AsyncSession%20%3D%20Depends%28get_session%29%60%20was%20not%20removed%20from%20the%20function%20signature%20%28line%20369%29.%20FastAPI%20will%20still%20inject%20and%20hold%20a%20yield-dependency-scoped%20session%20for%20the%20full%20lifetime%20of%20the%20SSE%20response%2C%20which%20is%20exactly%20the%20pool-exhaustion%20problem%20this%20PR%20intends%20to%20fix.%20The%20inner%20%60async%20with%20maker%28%29%20as%20session%3A%60%20block%20creates%20and%20closes%20a%20second%2C%20correctly-scoped%20session%2C%20but%20the%20outer%20dependency%20session%20remains%20checked%20out%20until%20the%20stream%20completes.%20%60create_and_stream_run%60%20had%20its%20%60Depends%28get_session%29%60%20correctly%20removed%2C%20but%20%60stream_run%60%20did%20not.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=428&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fsse-db-session-lifetime-clean%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsse-db-session-lifetime-clean%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fruns.py%0ALine%3A%20363-370%0A%0AComment%3A%0A**Stale%20%60Depends%28get_session%29%60%20left%20in%20%60stream_run%60%20signature**%0A%0A%60session%3A%20AsyncSession%20%3D%20Depends%28get_session%29%60%20was%20not%20removed%20from%20the%20function%20signature%20%28line%20369%29.%20FastAPI%20will%20still%20inject%20and%20hold%20a%20yield-dependency-scoped%20session%20for%20the%20full%20lifetime%20of%20the%20SSE%20response%2C%20which%20is%20exactly%20the%20pool-exhaustion%20problem%20this%20PR%20intends%20to%20fix.%20The%20inner%20%60async%20with%20maker%28%29%20as%20session%3A%60%20block%20creates%20and%20closes%20a%20second%2C%20correctly-scoped%20session%2C%20but%20the%20outer%20dependency%20session%20remains%20checked%20out%20until%20the%20stream%20completes.%20%60create_and_stream_run%60%20had%20its%20%60Depends%28get_session%29%60%20correctly%20removed%2C%20but%20%60stream_run%60%20did%20not.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=428&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `libs/aegra-api/src/aegra_api/api/runs.py`, line 444-509 ([link](https://github.com/aegra/aegra/blob/66bf443215d77eeea056f62e8334a685182be14c/libs/aegra-api/src/aegra_api/api/runs.py#L444-L509)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=9" align="top"></a> **`cancel_run_endpoint` crashes on every invocation after `session` dependency was removed**

   The diff removes `session: AsyncSession = Depends(get_session)` from `cancel_run_endpoint`'s signature, but the function body still references `session` on lines 456, 470, 475, 480, 485, 494, 495, and 500. Every `POST /threads/{thread_id}/runs/{run_id}/cancel` call will raise `NameError: name 'session' is not defined` at the first `await session.scalar(...)`, making cancel and interrupt completely broken. The fix should either restore the dependency or wrap the body in an `async with maker() as session:` block matching the pattern used for the streaming endpoints.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fruns.py%0ALine%3A%20444-509%0A%0AComment%3A%0A**%60cancel_run_endpoint%60%20crashes%20on%20every%20invocation%20after%20%60session%60%20dependency%20was%20removed**%0A%0AThe%20diff%20removes%20%60session%3A%20AsyncSession%20%3D%20Depends%28get_session%29%60%20from%20%60cancel_run_endpoint%60's%20signature%2C%20but%20the%20function%20body%20still%20references%20%60session%60%20on%20lines%20456%2C%20470%2C%20475%2C%20480%2C%20485%2C%20494%2C%20495%2C%20and%20500.%20Every%20%60POST%20%2Fthreads%2F%7Bthread_id%7D%2Fruns%2F%7Brun_id%7D%2Fcancel%60%20call%20will%20raise%20%60NameError%3A%20name%20'session'%20is%20not%20defined%60%20at%20the%20first%20%60await%20session.scalar%28...%29%60%2C%20making%20cancel%20and%20interrupt%20completely%20broken.%20The%20fix%20should%20either%20restore%20the%20dependency%20or%20wrap%20the%20body%20in%20an%20%60async%20with%20maker%28%29%20as%20session%3A%60%20block%20matching%20the%20pattern%20used%20for%20the%20streaming%20endpoints.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=428&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fruns.py%0ALine%3A%20444-509%0A%0AComment%3A%0A**%60cancel_run_endpoint%60%20crashes%20on%20every%20invocation%20after%20%60session%60%20dependency%20was%20removed**%0A%0AThe%20diff%20removes%20%60session%3A%20AsyncSession%20%3D%20Depends%28get_session%29%60%20from%20%60cancel_run_endpoint%60's%20signature%2C%20but%20the%20function%20body%20still%20references%20%60session%60%20on%20lines%20456%2C%20470%2C%20475%2C%20480%2C%20485%2C%20494%2C%20495%2C%20and%20500.%20Every%20%60POST%20%2Fthreads%2F%7Bthread_id%7D%2Fruns%2F%7Brun_id%7D%2Fcancel%60%20call%20will%20raise%20%60NameError%3A%20name%20'session'%20is%20not%20defined%60%20at%20the%20first%20%60await%20session.scalar%28...%29%60%2C%20making%20cancel%20and%20interrupt%20completely%20broken.%20The%20fix%20should%20either%20restore%20the%20dependency%20or%20wrap%20the%20body%20in%20an%20%60async%20with%20maker%28%29%20as%20session%3A%60%20block%20matching%20the%20pattern%20used%20for%20the%20streaming%20endpoints.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=428&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fsse-db-session-lifetime-clean%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsse-db-session-lifetime-clean%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fruns.py%0ALine%3A%20444-509%0A%0AComment%3A%0A**%60cancel_run_endpoint%60%20crashes%20on%20every%20invocation%20after%20%60session%60%20dependency%20was%20removed**%0A%0AThe%20diff%20removes%20%60session%3A%20AsyncSession%20%3D%20Depends%28get_session%29%60%20from%20%60cancel_run_endpoint%60's%20signature%2C%20but%20the%20function%20body%20still%20references%20%60session%60%20on%20lines%20456%2C%20470%2C%20475%2C%20480%2C%20485%2C%20494%2C%20495%2C%20and%20500.%20Every%20%60POST%20%2Fthreads%2F%7Bthread_id%7D%2Fruns%2F%7Brun_id%7D%2Fcancel%60%20call%20will%20raise%20%60NameError%3A%20name%20'session'%20is%20not%20defined%60%20at%20the%20first%20%60await%20session.scalar%28...%29%60%2C%20making%20cancel%20and%20interrupt%20completely%20broken.%20The%20fix%20should%20either%20restore%20the%20dependency%20or%20wrap%20the%20body%20in%20an%20%60async%20with%20maker%28%29%20as%20session%3A%60%20block%20matching%20the%20pattern%20used%20for%20the%20streaming%20endpoints.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=428&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["fix(api): remove unused stateless stream..."](https://github.com/aegra/aegra/commit/4cd93991fe94d28b716bedf2b8c8b6318cc10a41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38024154)</sub>

<!-- /greptile_comment -->