### PR TITLE
fix(auth): emit no-auth warning once at startup, not per request

### DIFF
--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -73,6 +73,13 @@ class LangGraphAuthBackend(AuthenticationBackend):
 
     def __init__(self) -> None:
         self.auth_instance = self._load_auth_instance()
+        if self.auth_instance is None:
+            logger.warning(
+                "No auth file configured — all requests share a single 'anonymous' identity. "
+                "Data is NOT isolated between users in this mode. "
+                "Configure 'auth.path' in aegra.json before serving multiple users. "
+                "See: https://docs.aegra.dev/guides/authentication"
+            )
 
     def _load_auth_instance(self) -> Auth | None:
         """Load the auth instance from config or fallback to hardcoded candidates.
@@ -224,12 +231,9 @@ class LangGraphAuthBackend(AuthenticationBackend):
         # Default to noop (anonymous) authentication when no auth file is found,
         # regardless of AUTH_TYPE setting. This ensures the server works out-of-the-box.
         if self.auth_instance is None:
-            logger.warning(
-                "No auth file configured — all requests share a single 'anonymous' identity. "
-                "Data is NOT isolated between users in this mode. "
-                "Configure 'auth.path' in aegra.json before serving multiple users. "
-                "See: https://docs.aegra.dev/guides/authentication"
-            )
+            # The no-auth warning is emitted once at startup in __init__;
+            # logging here would repeat it on every request.
+            logger.debug("No auth file configured, defaulting to noop (anonymous) authentication")
             # Return anonymous user when no auth is configured.
             # WARNING: all callers share this identity; no tenant isolation is enforced.
             user_data: Auth.types.MinimalUserDict = {

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -109,6 +109,29 @@ class TestLangGraphAuthBackend:
             backend = LangGraphAuthBackend()
             assert backend.auth_instance is None
 
+    def test_no_auth_warning_emitted_once_at_init(self, capsys: pytest.CaptureFixture[str]):
+        """The no-auth warning fires once at startup, not on every request."""
+        with patch.object(LangGraphAuthBackend, "_load_auth_instance", return_value=None):
+            LangGraphAuthBackend()
+
+        out = capsys.readouterr().out
+        assert out.count("single 'anonymous' identity") == 1
+
+    @pytest.mark.asyncio
+    async def test_authenticate_does_not_warn_per_request(self, capsys: pytest.CaptureFixture[str]):
+        """authenticate() must not emit the no-auth warning; that would flood logs."""
+        with patch.object(LangGraphAuthBackend, "_load_auth_instance", return_value=None):
+            backend = LangGraphAuthBackend()
+        capsys.readouterr()  # drop the startup warning emitted in __init__
+
+        mock_conn = Mock(spec=HTTPConnection)
+        mock_conn.headers = {}
+
+        for _ in range(3):
+            await backend.authenticate(mock_conn)
+
+        assert "single 'anonymous' identity" not in capsys.readouterr().out
+
     def test_load_auth_instance_success(self):
         """Test successful auth instance loading"""
         mock_auth_instance = Mock()

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -109,28 +109,35 @@ class TestLangGraphAuthBackend:
             backend = LangGraphAuthBackend()
             assert backend.auth_instance is None
 
-    def test_no_auth_warning_emitted_once_at_init(self, capsys: pytest.CaptureFixture[str]):
+    def test_no_auth_warning_emitted_once_at_init(self, monkeypatch: pytest.MonkeyPatch):
         """The no-auth warning fires once at startup, not on every request."""
+        from aegra_api.core import auth_middleware
+
+        warnings: list[str] = []
+        monkeypatch.setattr(auth_middleware.logger, "warning", lambda msg, *a, **k: warnings.append(msg))
+
         with patch.object(LangGraphAuthBackend, "_load_auth_instance", return_value=None):
             LangGraphAuthBackend()
 
-        out = capsys.readouterr().out
-        assert out.count("single 'anonymous' identity") == 1
+        assert sum("single 'anonymous' identity" in w for w in warnings) == 1
 
     @pytest.mark.asyncio
-    async def test_authenticate_does_not_warn_per_request(self, capsys: pytest.CaptureFixture[str]):
+    async def test_authenticate_does_not_warn_per_request(self, monkeypatch: pytest.MonkeyPatch):
         """authenticate() must not emit the no-auth warning; that would flood logs."""
+        from aegra_api.core import auth_middleware
+
         with patch.object(LangGraphAuthBackend, "_load_auth_instance", return_value=None):
             backend = LangGraphAuthBackend()
-        capsys.readouterr()  # drop the startup warning emitted in __init__
+
+        warnings: list[str] = []
+        monkeypatch.setattr(auth_middleware.logger, "warning", lambda msg, *a, **k: warnings.append(msg))
 
         mock_conn = Mock(spec=HTTPConnection)
         mock_conn.headers = {}
-
         for _ in range(3):
             await backend.authenticate(mock_conn)
 
-        assert "single 'anonymous' identity" not in capsys.readouterr().out
+        assert not any("single 'anonymous' identity" in w for w in warnings)
 
     def test_load_auth_instance_success(self):
         """Test successful auth instance loading"""


### PR DESCRIPTION
## Problem

#425 added a warning when the server runs without auth configured (all requests share the `anonymous` identity, no tenant isolation). The intent is right, but the warning was placed in `authenticate()`, which runs on **every HTTP request**.

On an unconfigured shared server this emits the same four-line warning on every incoming call — thousands of duplicate entries per minute on a busy server. That buries the real signal it is trying to surface, fills log storage, and hides other alerts. Greptile flagged this on #425.

## Fix

Move the warning to `LangGraphAuthBackend.__init__`, which runs exactly once when the backend loads. If `_load_auth_instance()` returns `None`, warn there. `authenticate()` goes back to a single `debug` line.

Same message, same intent (operators still get warned), fired once at startup instead of per request.

## Tests

- `test_no_auth_warning_emitted_once_at_init` — warning appears exactly once when the backend initializes with no auth.
- `test_authenticate_does_not_warn_per_request` — three `authenticate()` calls emit the warning zero times.

Full `test_auth_middleware.py` suite passes (36), ruff clean.

Follow-up to #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging behavior for unauthenticated access: the anonymous identity warning now appears once during backend startup instead of being logged repeatedly on every request.
* **Tests**
  * Added unit tests to verify the warning is emitted only once at initialization and not during subsequent per-request authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the no-auth startup warning from `authenticate()` (per-request) to `LangGraphAuthBackend.__init__()` (once at startup), preventing log flooding on unconfigured servers. The tests use direct `monkeypatch` on `auth_middleware.logger.warning` — the robust approach recommended in the previous review thread — and correctly verify both that the warning fires once at init and that `authenticate()` remains warning-free.

- **`auth_middleware.py`**: Warning call relocated to `__init__`; `authenticate()` now emits only a `debug` line with a comment explaining why.
- **`test_auth_middleware.py`**: Two new tests added — `test_no_auth_warning_emitted_once_at_init` and `test_authenticate_does_not_warn_per_request` — using `monkeypatch` to patch the logger attribute directly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a contained one-file logic change with two targeted new tests that directly validate the fix.

The change is minimal and correct: the warning is moved from a hot per-request path to the constructor, which runs exactly once. The new tests use direct logger monkeypatching (not capsys) so they remain stable under any structlog configuration. No auth logic, credential handling, or request routing is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/auth_middleware.py | Warning moved from authenticate() to __init__(); debug log with explanatory comment replaces it at the call site. Change is correct and well-scoped. |
| libs/aegra-api/tests/unit/test_core/test_auth_middleware.py | Two new tests added using monkeypatch on the logger attribute directly — correctly robust against logging configuration changes. Ordering of patch/monkeypatch setup is intentional and correct. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App as Application Startup
    participant Init as LangGraphAuthBackend.__init__()
    participant Load as _load_auth_instance()
    participant Log as structlog logger
    participant Req as HTTP Request
    participant Auth as authenticate()

    App->>Init: instantiate backend (once)
    Init->>Load: _load_auth_instance()
    Load-->>Init: returns None (no auth configured)
    Init->>Log: logger.warning("No auth file configured…") ← emitted ONCE

    Note over App,Log: Startup complete

    Req->>Auth: authenticate(conn) [request 1]
    Auth->>Log: logger.debug("No auth file configured…")
    Auth-->>Req: (anonymous user)

    Req->>Auth: authenticate(conn) [request 2…N]
    Auth->>Log: logger.debug(…)
    Auth-->>Req: (anonymous user)

    Note over Req,Log: Warning never re-emitted per request
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App as Application Startup
    participant Init as LangGraphAuthBackend.__init__()
    participant Load as _load_auth_instance()
    participant Log as structlog logger
    participant Req as HTTP Request
    participant Auth as authenticate()

    App->>Init: instantiate backend (once)
    Init->>Load: _load_auth_instance()
    Load-->>Init: returns None (no auth configured)
    Init->>Log: logger.warning("No auth file configured…") ← emitted ONCE

    Note over App,Log: Startup complete

    Req->>Auth: authenticate(conn) [request 1]
    Auth->>Log: logger.debug("No auth file configured…")
    Auth-->>Req: (anonymous user)

    Req->>Auth: authenticate(conn) [request 2…N]
    Auth->>Log: logger.debug(…)
    Auth-->>Req: (anonymous user)

    Note over Req,Log: Warning never re-emitted per request
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test(auth): capture no-auth warning via ..."](https://github.com/aegra/aegra/commit/fb46c33491bc144c6ceb73baf70292ca9e913987) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38158329)</sub>

<!-- /greptile_comment -->