### PR TITLE
Add assistant id as condintion for polling from postgres

### DIFF
--- a/libs/aegra-api/src/aegra_api/services/lease_reaper.py
+++ b/libs/aegra-api/src/aegra_api/services/lease_reaper.py
@@ -93,6 +93,7 @@ class LeaseReaper:
         Returns (crashed_run_ids, stuck_pending_run_ids) separately so retry
         budget is only charged to crashed runs, not stuck pending ones.
         """
+        assistant_id = settings.worker.ASSISTANT_ID
         now = datetime.now(UTC)
         maker = _get_session_maker()
         async with maker() as session:
@@ -101,6 +102,10 @@ class LeaseReaper:
                     RunORM.status == "running",
                     RunORM.lease_expires_at.isnot(None),
                     RunORM.lease_expires_at < now,
+                    or_(
+                        assistant_id is None,
+                        RunORM.assistant_id == assistant_id
+                    )
                 )
             )
             crashed = [row[0] for row in crashed_result.fetchall()]
@@ -110,6 +115,10 @@ class LeaseReaper:
                     RunORM.status == "pending",
                     RunORM.claimed_by.is_(None),
                     RunORM.created_at < now - timedelta(seconds=settings.worker.STUCK_PENDING_THRESHOLD_SECONDS),
+                    or_(
+                        assistant_id is None,
+                        RunORM.assistant_id == assistant_id
+                    )
                 )
             )
             stuck_pending = [row[0] for row in stuck_result.fetchall()]

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -20,7 +20,7 @@ import structlog
 from asgi_correlation_id import correlation_id
 from redis import RedisError
 from redis import TimeoutError as RedisTimeoutError
-from sqlalchemy import select, update
+from sqlalchemy import select, update, or_
 
 from aegra_api.core.active_runs import active_runs
 from aegra_api.core.orm import Run as RunORM
@@ -316,11 +316,20 @@ class WorkerExecutor(BaseExecutor):
     @staticmethod
     async def _poll_postgres() -> str | None:
         """Pick the oldest pending, unclaimed run from Postgres."""
+
+        assistant_id = settings.worker.ASSISTANT_ID
         maker = _get_session_maker()
         async with maker() as session:
             run_id = await session.scalar(
                 select(RunORM.run_id)
-                .where(RunORM.status == "pending", RunORM.claimed_by.is_(None))
+                .where(
+                    RunORM.status == "pending",
+                    RunORM.claimed_by.is_(None),
+                    or_(
+                        assistant_id is None,
+                        RunORM.assistant_id == assistant_id
+                    )
+                )
                 .order_by(RunORM.created_at.asc())
                 .limit(1)
             )

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -351,7 +351,7 @@ class WorkerSettings(EnvBase):
     Each worker loop dequeues run_ids from Redis and spawns up to
     N_JOBS_PER_WORKER concurrent asyncio tasks for graph execution.
     """
-
+    ASSISTANT_ID: str | None = None
     WORKER_COUNT: int = 3
     N_JOBS_PER_WORKER: int = 10
     WORKER_QUEUE_KEY: str = "aegra:jobs"


### PR DESCRIPTION
## Description
<!-- Provide a clear description of your changes -->

## Type of Change
<!-- Check the relevant option -->
- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->

## Changes Made
<!-- List the main changes -->
-
-
-

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist
<!-- Ensure all items are checked before requesting review -->
- [ ] Code follows project style (Ruff formatting)
- [ ] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`)
- [ ] All tests pass (`make test`)
- [ ] Documentation updated (if needed)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] PR title follows Conventional Commits format

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Notes
<!-- Any additional information for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ASSISTANT_ID` worker configuration setting to scope worker operations by assistant identifier.

* **Bug Fixes**
  * Updated lease recovery mechanism to respect assistant ID filtering, ensuring only eligible runs are recovered.
  * Enhanced fallback query logic to filter runs by assistant ID when primary service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes Postgres polling (worker executor, lease reaper) and stuck-run recovery to a specific `ASSISTANT_ID` when the env var is set, allowing multiple workers to share a single database without interfering with each other's runs.

- `settings.py` adds an optional `ASSISTANT_ID: str | None = None` field to `WorkerSettings` — safe and correctly defaulted.
- `worker_executor.py` correctly imports `or_` and gates `_poll_postgres` on `assistant_id`, but uses `or_(assistant_id is None, ...)` which passes a Python `bool` to SQLAlchemy's `or_()` — unsupported in SQLAlchemy 2.0+ and should use conditional query building instead.
- `lease_reaper.py` applies the same scoping to both the crashed-lease and stuck-pending queries but **omits the `or_` import**, causing an immediate `NameError` whenever the reaper fires.

<h3>Confidence Score: 2/5</h3>

Not safe to merge — the lease reaper will crash on every cycle due to a missing import, and all three polling sites use a SQLAlchemy anti-pattern that breaks under SQLAlchemy 2.x.

The lease reaper's `_find_recoverable` will throw `NameError: name 'or_' is not defined` on every scheduled run because `or_` was never added to `lease_reaper.py`'s SQLAlchemy import. Additionally, all three query sites pass a Python `bool` (result of `assistant_id is None`) directly to SQLAlchemy's `or_()`, which is not a valid clause element and is known to be broken in SQLAlchemy 2.0+.

`lease_reaper.py` needs the `or_` import added and the query-building pattern fixed; `worker_executor.py` needs the same query-building fix.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/lease_reaper.py | Adds `assistant_id` scoping to both lease-expired and stuck-pending queries, but is missing the `or_` import (NameError at runtime) and uses a Python `bool` as a SQLAlchemy clause element. |
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Correctly imports `or_` and adds `assistant_id` filtering to `_poll_postgres`, but uses the same fragile Python-bool-in-`or_()` anti-pattern that may break in SQLAlchemy 2.0+. |
| libs/aegra-api/src/aegra_api/settings.py | Adds `ASSISTANT_ID: str | None = None` to `WorkerSettings` — straightforward optional env-var with a safe default. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant LR as LeaseReaper
    participant WE as WorkerExecutor
    participant PG as Postgres (RunORM)
    participant S as Settings

    S-->>LR: "ASSISTANT_ID (str | None)"
    S-->>WE: "ASSISTANT_ID (str | None)"

    Note over LR: _find_recoverable()
    LR->>PG: "SELECT run_id WHERE status='running' AND lease_expires_at < now [AND assistant_id = ? if set]"
    PG-->>LR: crashed run_ids

    LR->>PG: "SELECT run_id WHERE status='pending' AND claimed_by IS NULL AND created_at < threshold [AND assistant_id = ? if set]"
    PG-->>LR: stuck_pending run_ids

    Note over WE: _poll_postgres()
    WE->>PG: "SELECT run_id WHERE status='pending' AND claimed_by IS NULL [AND assistant_id = ? if set] ORDER BY created_at ASC LIMIT 1"
    PG-->>WE: "run_id | None"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant LR as LeaseReaper
    participant WE as WorkerExecutor
    participant PG as Postgres (RunORM)
    participant S as Settings

    S-->>LR: "ASSISTANT_ID (str | None)"
    S-->>WE: "ASSISTANT_ID (str | None)"

    Note over LR: _find_recoverable()
    LR->>PG: "SELECT run_id WHERE status='running' AND lease_expires_at < now [AND assistant_id = ? if set]"
    PG-->>LR: crashed run_ids

    LR->>PG: "SELECT run_id WHERE status='pending' AND claimed_by IS NULL AND created_at < threshold [AND assistant_id = ? if set]"
    PG-->>LR: stuck_pending run_ids

    Note over WE: _poll_postgres()
    WE->>PG: "SELECT run_id WHERE status='pending' AND claimed_by IS NULL [AND assistant_id = ? if set] ORDER BY created_at ASC LIMIT 1"
    PG-->>WE: "run_id | None"
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `libs/aegra-api/src/aegra_api/services/lease_reaper.py`, line 15 ([link](https://github.com/aegra/aegra/blob/5b07df69af4a6ecd4edb27f8bb5865b0569021f1/libs/aegra-api/src/aegra_api/services/lease_reaper.py#L15)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=9" align="top"></a> **Missing `or_` import — `NameError` at runtime**

   `or_` is used in `_find_recoverable()` (lines 105 and 118) but is never imported. `worker_executor.py` correctly added `or_` to its import, but the equivalent change was missed here. Every invocation of the lease reaper will crash with `NameError: name 'or_' is not defined`.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%0ALine%3A%2015%0A%0AComment%3A%0A**Missing%20%60or_%60%20import%20%E2%80%94%20%60NameError%60%20at%20runtime**%0A%0A%60or_%60%20is%20used%20in%20%60_find_recoverable%28%29%60%20%28lines%20105%20and%20118%29%20but%20is%20never%20imported.%20%60worker_executor.py%60%20correctly%20added%20%60or_%60%20to%20its%20import%2C%20but%20the%20equivalent%20change%20was%20missed%20here.%20Every%20invocation%20of%20the%20lease%20reaper%20will%20crash%20with%20%60NameError%3A%20name%20'or_'%20is%20not%20defined%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%0ALine%3A%2015%0A%0AComment%3A%0A**Missing%20%60or_%60%20import%20%E2%80%94%20%60NameError%60%20at%20runtime**%0A%0A%60or_%60%20is%20used%20in%20%60_find_recoverable%28%29%60%20%28lines%20105%20and%20118%29%20but%20is%20never%20imported.%20%60worker_executor.py%60%20correctly%20added%20%60or_%60%20to%20its%20import%2C%20but%20the%20equivalent%20change%20was%20missed%20here.%20Every%20invocation%20of%20the%20lease%20reaper%20will%20crash%20with%20%60NameError%3A%20name%20'or_'%20is%20not%20defined%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fpersistent-queue-routing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpersistent-queue-routing%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%0ALine%3A%2015%0A%0AComment%3A%0A**Missing%20%60or_%60%20import%20%E2%80%94%20%60NameError%60%20at%20runtime**%0A%0A%60or_%60%20is%20used%20in%20%60_find_recoverable%28%29%60%20%28lines%20105%20and%20118%29%20but%20is%20never%20imported.%20%60worker_executor.py%60%20correctly%20added%20%60or_%60%20to%20its%20import%2C%20but%20the%20equivalent%20change%20was%20missed%20here.%20Every%20invocation%20of%20the%20lease%20reaper%20will%20crash%20with%20%60NameError%3A%20name%20'or_'%20is%20not%20defined%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>


2. `libs/aegra-api/src/aegra_api/services/lease_reaper.py`, line 100-110 ([link](https://github.com/aegra/aegra/blob/5b07df69af4a6ecd4edb27f8bb5865b0569021f1/libs/aegra-api/src/aegra_api/services/lease_reaper.py#L100-L110)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Python `bool` passed to SQLAlchemy `or_()` — unreliable SQL generation**

   `assistant_id is None` evaluates to a Python `bool` (`True` or `False`) at query-construction time, not a SQLAlchemy clause element. In SQLAlchemy 2.0+ the `or_()` / `and_()` functions no longer accept plain Python booleans and will raise `ArgumentError` or silently generate wrong SQL. The idiomatic fix is to only append the `assistant_id` filter when the value is non-`None`, avoiding `or_()` entirely. The same issue exists in `worker_executor.py` and both occurrences in this file.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%0ALine%3A%20100-110%0A%0AComment%3A%0A**Python%20%60bool%60%20passed%20to%20SQLAlchemy%20%60or_%28%29%60%20%E2%80%94%20unreliable%20SQL%20generation**%0A%0A%60assistant_id%20is%20None%60%20evaluates%20to%20a%20Python%20%60bool%60%20%28%60True%60%20or%20%60False%60%29%20at%20query-construction%20time%2C%20not%20a%20SQLAlchemy%20clause%20element.%20In%20SQLAlchemy%202.0%2B%20the%20%60or_%28%29%60%20%2F%20%60and_%28%29%60%20functions%20no%20longer%20accept%20plain%20Python%20booleans%20and%20will%20raise%20%60ArgumentError%60%20or%20silently%20generate%20wrong%20SQL.%20The%20idiomatic%20fix%20is%20to%20only%20append%20the%20%60assistant_id%60%20filter%20when%20the%20value%20is%20non-%60None%60%2C%20avoiding%20%60or_%28%29%60%20entirely.%20The%20same%20issue%20exists%20in%20%60worker_executor.py%60%20and%20both%20occurrences%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20select%28RunORM.run_id%29.where%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.status%20%3D%3D%20%22running%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at.isnot%28None%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at%20%3C%20now%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20assistant_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20crashed_query.where%28RunORM.assistant_id%20%3D%3D%20assistant_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_result%20%3D%20await%20session.execute%28crashed_query%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%0ALine%3A%20100-110%0A%0AComment%3A%0A**Python%20%60bool%60%20passed%20to%20SQLAlchemy%20%60or_%28%29%60%20%E2%80%94%20unreliable%20SQL%20generation**%0A%0A%60assistant_id%20is%20None%60%20evaluates%20to%20a%20Python%20%60bool%60%20%28%60True%60%20or%20%60False%60%29%20at%20query-construction%20time%2C%20not%20a%20SQLAlchemy%20clause%20element.%20In%20SQLAlchemy%202.0%2B%20the%20%60or_%28%29%60%20%2F%20%60and_%28%29%60%20functions%20no%20longer%20accept%20plain%20Python%20booleans%20and%20will%20raise%20%60ArgumentError%60%20or%20silently%20generate%20wrong%20SQL.%20The%20idiomatic%20fix%20is%20to%20only%20append%20the%20%60assistant_id%60%20filter%20when%20the%20value%20is%20non-%60None%60%2C%20avoiding%20%60or_%28%29%60%20entirely.%20The%20same%20issue%20exists%20in%20%60worker_executor.py%60%20and%20both%20occurrences%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20select%28RunORM.run_id%29.where%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.status%20%3D%3D%20%22running%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at.isnot%28None%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at%20%3C%20now%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20assistant_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20crashed_query.where%28RunORM.assistant_id%20%3D%3D%20assistant_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_result%20%3D%20await%20session.execute%28crashed_query%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fpersistent-queue-routing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpersistent-queue-routing%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%0ALine%3A%20100-110%0A%0AComment%3A%0A**Python%20%60bool%60%20passed%20to%20SQLAlchemy%20%60or_%28%29%60%20%E2%80%94%20unreliable%20SQL%20generation**%0A%0A%60assistant_id%20is%20None%60%20evaluates%20to%20a%20Python%20%60bool%60%20%28%60True%60%20or%20%60False%60%29%20at%20query-construction%20time%2C%20not%20a%20SQLAlchemy%20clause%20element.%20In%20SQLAlchemy%202.0%2B%20the%20%60or_%28%29%60%20%2F%20%60and_%28%29%60%20functions%20no%20longer%20accept%20plain%20Python%20booleans%20and%20will%20raise%20%60ArgumentError%60%20or%20silently%20generate%20wrong%20SQL.%20The%20idiomatic%20fix%20is%20to%20only%20append%20the%20%60assistant_id%60%20filter%20when%20the%20value%20is%20non-%60None%60%2C%20avoiding%20%60or_%28%29%60%20entirely.%20The%20same%20issue%20exists%20in%20%60worker_executor.py%60%20and%20both%20occurrences%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20select%28RunORM.run_id%29.where%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.status%20%3D%3D%20%22running%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at.isnot%28None%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at%20%3C%20now%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20assistant_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20crashed_query.where%28RunORM.assistant_id%20%3D%3D%20assistant_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_result%20%3D%20await%20session.execute%28crashed_query%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%3A15%0A**Missing%20%60or_%60%20import%20%E2%80%94%20%60NameError%60%20at%20runtime**%0A%0A%60or_%60%20is%20used%20in%20%60_find_recoverable%28%29%60%20%28lines%20105%20and%20118%29%20but%20is%20never%20imported.%20%60worker_executor.py%60%20correctly%20added%20%60or_%60%20to%20its%20import%2C%20but%20the%20equivalent%20change%20was%20missed%20here.%20Every%20invocation%20of%20the%20lease%20reaper%20will%20crash%20with%20%60NameError%3A%20name%20'or_'%20is%20not%20defined%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%3A100-110%0A**Python%20%60bool%60%20passed%20to%20SQLAlchemy%20%60or_%28%29%60%20%E2%80%94%20unreliable%20SQL%20generation**%0A%0A%60assistant_id%20is%20None%60%20evaluates%20to%20a%20Python%20%60bool%60%20%28%60True%60%20or%20%60False%60%29%20at%20query-construction%20time%2C%20not%20a%20SQLAlchemy%20clause%20element.%20In%20SQLAlchemy%202.0%2B%20the%20%60or_%28%29%60%20%2F%20%60and_%28%29%60%20functions%20no%20longer%20accept%20plain%20Python%20booleans%20and%20will%20raise%20%60ArgumentError%60%20or%20silently%20generate%20wrong%20SQL.%20The%20idiomatic%20fix%20is%20to%20only%20append%20the%20%60assistant_id%60%20filter%20when%20the%20value%20is%20non-%60None%60%2C%20avoiding%20%60or_%28%29%60%20entirely.%20The%20same%20issue%20exists%20in%20%60worker_executor.py%60%20and%20both%20occurrences%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20select%28RunORM.run_id%29.where%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.status%20%3D%3D%20%22running%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at.isnot%28None%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at%20%3C%20now%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20assistant_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20crashed_query.where%28RunORM.assistant_id%20%3D%3D%20assistant_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_result%20%3D%20await%20session.execute%28crashed_query%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fworker_executor.py%3A323-335%0A**Same%20Python%20%60bool%60%20in%20%60or_%28%29%60%20pattern%20%E2%80%94%20unreliable%20in%20SQLAlchemy%202.0%2B**%0A%0A%60assistant_id%20is%20None%60%20is%20a%20Python-level%20boolean%2C%20not%20a%20SQLAlchemy%20clause%20element.%20Passing%20it%20to%20%60or_%28%29%60%20works%20by%20accident%20in%20some%20SQLAlchemy%201.x%20versions%20but%20is%20not%20supported%20in%202.0%2B%20and%20can%20silently%20produce%20%60WHERE%20%28false%20OR%20assistant_id%20%3D%20...%29%60%20as%20a%20bound%20parameter%20instead%20of%20a%20SQL%20literal.%20Conditional%20query%20building%20is%20the%20correct%20approach%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20poll_query%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20select%28RunORM.run_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.where%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.status%20%3D%3D%20%22pending%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.claimed_by.is_%28None%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.order_by%28RunORM.created_at.asc%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.limit%281%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20assistant_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20poll_query%20%3D%20poll_query.where%28RunORM.assistant_id%20%3D%3D%20assistant_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20run_id%20%3D%20await%20session.scalar%28poll_query%29%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%3A15%0A**Missing%20%60or_%60%20import%20%E2%80%94%20%60NameError%60%20at%20runtime**%0A%0A%60or_%60%20is%20used%20in%20%60_find_recoverable%28%29%60%20%28lines%20105%20and%20118%29%20but%20is%20never%20imported.%20%60worker_executor.py%60%20correctly%20added%20%60or_%60%20to%20its%20import%2C%20but%20the%20equivalent%20change%20was%20missed%20here.%20Every%20invocation%20of%20the%20lease%20reaper%20will%20crash%20with%20%60NameError%3A%20name%20'or_'%20is%20not%20defined%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%3A100-110%0A**Python%20%60bool%60%20passed%20to%20SQLAlchemy%20%60or_%28%29%60%20%E2%80%94%20unreliable%20SQL%20generation**%0A%0A%60assistant_id%20is%20None%60%20evaluates%20to%20a%20Python%20%60bool%60%20%28%60True%60%20or%20%60False%60%29%20at%20query-construction%20time%2C%20not%20a%20SQLAlchemy%20clause%20element.%20In%20SQLAlchemy%202.0%2B%20the%20%60or_%28%29%60%20%2F%20%60and_%28%29%60%20functions%20no%20longer%20accept%20plain%20Python%20booleans%20and%20will%20raise%20%60ArgumentError%60%20or%20silently%20generate%20wrong%20SQL.%20The%20idiomatic%20fix%20is%20to%20only%20append%20the%20%60assistant_id%60%20filter%20when%20the%20value%20is%20non-%60None%60%2C%20avoiding%20%60or_%28%29%60%20entirely.%20The%20same%20issue%20exists%20in%20%60worker_executor.py%60%20and%20both%20occurrences%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20select%28RunORM.run_id%29.where%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.status%20%3D%3D%20%22running%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at.isnot%28None%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at%20%3C%20now%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20assistant_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20crashed_query.where%28RunORM.assistant_id%20%3D%3D%20assistant_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_result%20%3D%20await%20session.execute%28crashed_query%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fworker_executor.py%3A323-335%0A**Same%20Python%20%60bool%60%20in%20%60or_%28%29%60%20pattern%20%E2%80%94%20unreliable%20in%20SQLAlchemy%202.0%2B**%0A%0A%60assistant_id%20is%20None%60%20is%20a%20Python-level%20boolean%2C%20not%20a%20SQLAlchemy%20clause%20element.%20Passing%20it%20to%20%60or_%28%29%60%20works%20by%20accident%20in%20some%20SQLAlchemy%201.x%20versions%20but%20is%20not%20supported%20in%202.0%2B%20and%20can%20silently%20produce%20%60WHERE%20%28false%20OR%20assistant_id%20%3D%20...%29%60%20as%20a%20bound%20parameter%20instead%20of%20a%20SQL%20literal.%20Conditional%20query%20building%20is%20the%20correct%20approach%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20poll_query%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20select%28RunORM.run_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.where%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.status%20%3D%3D%20%22pending%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.claimed_by.is_%28None%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.order_by%28RunORM.created_at.asc%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.limit%281%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20assistant_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20poll_query%20%3D%20poll_query.where%28RunORM.assistant_id%20%3D%3D%20assistant_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20run_id%20%3D%20await%20session.scalar%28poll_query%29%0A%60%60%60%0A%0A&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fpersistent-queue-routing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpersistent-queue-routing%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%3A15%0A**Missing%20%60or_%60%20import%20%E2%80%94%20%60NameError%60%20at%20runtime**%0A%0A%60or_%60%20is%20used%20in%20%60_find_recoverable%28%29%60%20%28lines%20105%20and%20118%29%20but%20is%20never%20imported.%20%60worker_executor.py%60%20correctly%20added%20%60or_%60%20to%20its%20import%2C%20but%20the%20equivalent%20change%20was%20missed%20here.%20Every%20invocation%20of%20the%20lease%20reaper%20will%20crash%20with%20%60NameError%3A%20name%20'or_'%20is%20not%20defined%60.%0A%0A%23%23%23%20Issue%202%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flease_reaper.py%3A100-110%0A**Python%20%60bool%60%20passed%20to%20SQLAlchemy%20%60or_%28%29%60%20%E2%80%94%20unreliable%20SQL%20generation**%0A%0A%60assistant_id%20is%20None%60%20evaluates%20to%20a%20Python%20%60bool%60%20%28%60True%60%20or%20%60False%60%29%20at%20query-construction%20time%2C%20not%20a%20SQLAlchemy%20clause%20element.%20In%20SQLAlchemy%202.0%2B%20the%20%60or_%28%29%60%20%2F%20%60and_%28%29%60%20functions%20no%20longer%20accept%20plain%20Python%20booleans%20and%20will%20raise%20%60ArgumentError%60%20or%20silently%20generate%20wrong%20SQL.%20The%20idiomatic%20fix%20is%20to%20only%20append%20the%20%60assistant_id%60%20filter%20when%20the%20value%20is%20non-%60None%60%2C%20avoiding%20%60or_%28%29%60%20entirely.%20The%20same%20issue%20exists%20in%20%60worker_executor.py%60%20and%20both%20occurrences%20in%20this%20file.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20select%28RunORM.run_id%29.where%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.status%20%3D%3D%20%22running%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at.isnot%28None%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.lease_expires_at%20%3C%20now%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20assistant_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20crashed_query%20%3D%20crashed_query.where%28RunORM.assistant_id%20%3D%3D%20assistant_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20crashed_result%20%3D%20await%20session.execute%28crashed_query%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fworker_executor.py%3A323-335%0A**Same%20Python%20%60bool%60%20in%20%60or_%28%29%60%20pattern%20%E2%80%94%20unreliable%20in%20SQLAlchemy%202.0%2B**%0A%0A%60assistant_id%20is%20None%60%20is%20a%20Python-level%20boolean%2C%20not%20a%20SQLAlchemy%20clause%20element.%20Passing%20it%20to%20%60or_%28%29%60%20works%20by%20accident%20in%20some%20SQLAlchemy%201.x%20versions%20but%20is%20not%20supported%20in%202.0%2B%20and%20can%20silently%20produce%20%60WHERE%20%28false%20OR%20assistant_id%20%3D%20...%29%60%20as%20a%20bound%20parameter%20instead%20of%20a%20SQL%20literal.%20Conditional%20query%20building%20is%20the%20correct%20approach%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20poll_query%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20select%28RunORM.run_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.where%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.status%20%3D%3D%20%22pending%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RunORM.claimed_by.is_%28None%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.order_by%28RunORM.created_at.asc%28%29%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20.limit%281%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20assistant_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20poll_query%20%3D%20poll_query.where%28RunORM.assistant_id%20%3D%3D%20assistant_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20run_id%20%3D%20await%20session.scalar%28poll_query%29%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=430&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add assistant id as condintion for polli..."](https://github.com/aegra/aegra/commit/5b07df69af4a6ecd4edb27f8bb5865b0569021f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38368023)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->