### PR TITLE
fix(security): close cross-tenant access via cron assistant and config thread_id

### DIFF
--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -42,15 +42,12 @@ logger = structlog.getLogger(__name__)
 
 thread_state_service = ThreadStateService()
 
-# Identity keys the server pins from the ownership-verified path param. A
-# client checkpoint dict must not redefine them — the checkpointer keys on
-# thread_id alone, so a body-supplied thread_id would redirect reads/writes
-# to another user's thread despite the route ownership check.
+# A body-supplied thread_id overrides the route-verified one (the checkpointer
+# keys on thread_id alone), so the server pins these instead of trusting them.
 _SERVER_PINNED_CONFIG_KEYS: frozenset[str] = frozenset({"thread_id", "run_id"})
 
 
 def _client_checkpoint(checkpoint: dict[str, Any]) -> dict[str, Any]:
-    """Drop server-authoritative identity keys from a client checkpoint dict."""
     return {k: v for k, v in checkpoint.items() if k not in _SERVER_PINNED_CONFIG_KEYS}
 
 

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -42,6 +42,17 @@ logger = structlog.getLogger(__name__)
 
 thread_state_service = ThreadStateService()
 
+# Identity keys the server pins from the ownership-verified path param. A
+# client checkpoint dict must not redefine them — the checkpointer keys on
+# thread_id alone, so a body-supplied thread_id would redirect reads/writes
+# to another user's thread despite the route ownership check.
+_SERVER_PINNED_CONFIG_KEYS: frozenset[str] = frozenset({"thread_id", "run_id"})
+
+
+def _client_checkpoint(checkpoint: dict[str, Any]) -> dict[str, Any]:
+    """Drop server-authoritative identity keys from a client checkpoint dict."""
+    return {k: v for k, v in checkpoint.items() if k not in _SERVER_PINNED_CONFIG_KEYS}
+
 
 # --- Sort resolution for /threads/search ---
 
@@ -473,7 +484,7 @@ async def update_thread_state(
         if request.checkpoint_id:
             config["configurable"]["checkpoint_id"] = request.checkpoint_id
         if request.checkpoint:
-            config["configurable"].update(request.checkpoint)
+            config["configurable"].update(_client_checkpoint(request.checkpoint))
         if request.checkpoint_ns:
             config["configurable"]["checkpoint_ns"] = request.checkpoint_ns
 
@@ -716,7 +727,7 @@ async def get_thread_history_post(
 
         config: dict[str, Any] = create_thread_config(thread_id, user)
         if checkpoint:
-            cfg_cp = checkpoint.copy()
+            cfg_cp = _client_checkpoint(checkpoint)
             if checkpoint_ns is not None:
                 cfg_cp.setdefault("checkpoint_ns", checkpoint_ns)
             config["configurable"].update(cfg_cp)
@@ -733,7 +744,7 @@ async def get_thread_history_post(
             if "configurable" in before:
                 before_config = before
             else:
-                before_config = {"configurable": before}
+                before_config = {"configurable": _client_checkpoint(before)}
 
         state_snapshots = []
         kwargs: dict[str, Any] = {

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -36,18 +36,12 @@ from aegra_api.models import (
 from aegra_api.models.errors import CONFLICT, NOT_FOUND
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.services.thread_state_service import ThreadStateService
+from aegra_api.utils.run_utils import strip_pinned_config_keys
 
 router = APIRouter(tags=["Threads"], dependencies=auth_dependency)
 logger = structlog.getLogger(__name__)
 
 thread_state_service = ThreadStateService()
-
-
-def _client_checkpoint(checkpoint: dict[str, Any]) -> dict[str, Any]:
-    """Drop server-pinned identity keys (thread_id/run_id) from a client dict."""
-    from aegra_api.services.langgraph_service import strip_pinned_config_keys
-
-    return strip_pinned_config_keys(checkpoint)
 
 
 # --- Sort resolution for /threads/search ---
@@ -480,7 +474,7 @@ async def update_thread_state(
         if request.checkpoint_id:
             config["configurable"]["checkpoint_id"] = request.checkpoint_id
         if request.checkpoint:
-            config["configurable"].update(_client_checkpoint(request.checkpoint))
+            config["configurable"].update(strip_pinned_config_keys(request.checkpoint))
         if request.checkpoint_ns:
             config["configurable"]["checkpoint_ns"] = request.checkpoint_ns
 
@@ -723,7 +717,7 @@ async def get_thread_history_post(
 
         config: dict[str, Any] = create_thread_config(thread_id, user)
         if checkpoint:
-            cfg_cp = _client_checkpoint(checkpoint)
+            cfg_cp = strip_pinned_config_keys(checkpoint)
             if checkpoint_ns is not None:
                 cfg_cp.setdefault("checkpoint_ns", checkpoint_ns)
             config["configurable"].update(cfg_cp)
@@ -738,9 +732,9 @@ async def get_thread_history_post(
             before_config = {"configurable": {"checkpoint_id": before}}
         elif isinstance(before, dict):
             if "configurable" in before and isinstance(before["configurable"], dict):
-                before_config = {**before, "configurable": _client_checkpoint(before["configurable"])}
+                before_config = {**before, "configurable": strip_pinned_config_keys(before["configurable"])}
             else:
-                before_config = {"configurable": _client_checkpoint(before)}
+                before_config = {"configurable": strip_pinned_config_keys(before)}
 
         state_snapshots = []
         kwargs: dict[str, Any] = {

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -727,14 +727,13 @@ async def get_thread_history_post(
         # Convert `before` to a RunnableConfig for aget_state_history.
         # The SDK sends `before` as either a checkpoint ID string, a raw
         # checkpoint dict, or a full RunnableConfig with a "configurable" key.
+        # No thread_id scrub here: aget_state_history reads only checkpoint_id
+        # from `before` (the thread comes from the main config, pinned above).
         before_config: dict[str, Any] | None = None
         if isinstance(before, str):
             before_config = {"configurable": {"checkpoint_id": before}}
         elif isinstance(before, dict):
-            if "configurable" in before and isinstance(before["configurable"], dict):
-                before_config = {**before, "configurable": strip_pinned_config_keys(before["configurable"])}
-            else:
-                before_config = {"configurable": strip_pinned_config_keys(before)}
+            before_config = before if "configurable" in before else {"configurable": before}
 
         state_snapshots = []
         kwargs: dict[str, Any] = {

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -741,8 +741,8 @@ async def get_thread_history_post(
         if isinstance(before, str):
             before_config = {"configurable": {"checkpoint_id": before}}
         elif isinstance(before, dict):
-            if "configurable" in before:
-                before_config = before
+            if "configurable" in before and isinstance(before["configurable"], dict):
+                before_config = {**before, "configurable": _client_checkpoint(before["configurable"])}
             else:
                 before_config = {"configurable": _client_checkpoint(before)}
 

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -42,13 +42,12 @@ logger = structlog.getLogger(__name__)
 
 thread_state_service = ThreadStateService()
 
-# A body-supplied thread_id overrides the route-verified one (the checkpointer
-# keys on thread_id alone), so the server pins these instead of trusting them.
-_SERVER_PINNED_CONFIG_KEYS: frozenset[str] = frozenset({"thread_id", "run_id"})
-
 
 def _client_checkpoint(checkpoint: dict[str, Any]) -> dict[str, Any]:
-    return {k: v for k, v in checkpoint.items() if k not in _SERVER_PINNED_CONFIG_KEYS}
+    """Drop server-pinned identity keys (thread_id/run_id) from a client dict."""
+    from aegra_api.services.langgraph_service import strip_pinned_config_keys
+
+    return strip_pinned_config_keys(checkpoint)
 
 
 # --- Sort resolution for /threads/search ---

--- a/libs/aegra-api/src/aegra_api/services/cron_service.py
+++ b/libs/aegra-api/src/aegra_api/services/cron_service.py
@@ -245,9 +245,8 @@ class CronService:
         requested_assistant_id = str(request.assistant_id)
         resolved_assistant_id = resolve_assistant_id(requested_assistant_id, available_graphs)
 
-        # Validate assistant exists and is owned by the caller (or is a shared
-        # system assistant). Without the user_id scope, any user could pin
-        # another user's assistant — and its private config — onto a cron.
+        # Scope to caller (or system): without it, a user could pin another
+        # user's assistant — and its private config — onto a cron.
         assistant = await self.session.scalar(
             select(AssistantORM).where(
                 AssistantORM.assistant_id == resolved_assistant_id,

--- a/libs/aegra-api/src/aegra_api/services/cron_service.py
+++ b/libs/aegra-api/src/aegra_api/services/cron_service.py
@@ -13,7 +13,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import structlog
 from croniter import croniter
 from fastapi import Depends, HTTPException
-from sqlalchemy import CursorResult, func, select, update
+from sqlalchemy import CursorResult, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aegra_api.core.orm import Assistant as AssistantORM
@@ -245,9 +245,14 @@ class CronService:
         requested_assistant_id = str(request.assistant_id)
         resolved_assistant_id = resolve_assistant_id(requested_assistant_id, available_graphs)
 
-        # Validate assistant exists
+        # Validate assistant exists and is owned by the caller (or is a shared
+        # system assistant). Without the user_id scope, any user could pin
+        # another user's assistant — and its private config — onto a cron.
         assistant = await self.session.scalar(
-            select(AssistantORM).where(AssistantORM.assistant_id == resolved_assistant_id)
+            select(AssistantORM).where(
+                AssistantORM.assistant_id == resolved_assistant_id,
+                or_(AssistantORM.user_id == user_identity, AssistantORM.user_id == "system"),
+            )
         )
         if not assistant:
             raise HTTPException(404, f"Assistant '{request.assistant_id}' not found")

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -39,18 +39,10 @@ from aegra_api.services.graph_factory import (
     invoke_factory,
     is_factory,
 )
+from aegra_api.utils.run_utils import strip_pinned_config_keys
 
 State = TypeVar("State")
 logger = structlog.get_logger(__name__)
-
-# A body-supplied thread_id overrides the route-verified one (the checkpointer
-# keys on thread_id alone), so the server pins these instead of trusting them.
-SERVER_PINNED_CONFIG_KEYS: frozenset[str] = frozenset({"thread_id", "run_id"})
-
-
-def strip_pinned_config_keys(client_config: dict[str, Any]) -> dict[str, Any]:
-    """Drop server-authoritative identity keys from a client-supplied config dict."""
-    return {k: v for k, v in client_config.items() if k not in SERVER_PINNED_CONFIG_KEYS}
 
 
 def _module_name_for(graph_id: str) -> str:

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -707,9 +707,11 @@ def create_run_config(
 ) -> dict[str, Any]:
     """Create LangGraph configuration for a specific run with full context.
 
-    The function is *additive*: it never removes or renames anything the client
-    supplied.  We simply ensure a `configurable` dict exists and then merge a
-    few server-side keys so graph nodes can rely on them.
+    The function is *additive* for most keys, but `thread_id` and `run_id` are
+    server-authoritative: a client-supplied `configurable.thread_id` would
+    otherwise point graph execution (and the checkpointer, which keys solely on
+    thread_id) at another user's thread, bypassing the route ownership check.
+    We force the server values so the request body cannot redirect execution.
     """
     from copy import deepcopy
 
@@ -718,9 +720,9 @@ def create_run_config(
     # Ensure a configurable section exists
     cfg.setdefault("configurable", {})
 
-    # Merge server-provided fields (do NOT overwrite if client already set)
-    cfg["configurable"].setdefault("thread_id", thread_id)
-    cfg["configurable"].setdefault("run_id", run_id)
+    # Force server-authoritative identity keys — never honor a client override.
+    cfg["configurable"]["thread_id"] = thread_id
+    cfg["configurable"]["run_id"] = run_id
 
     # Ensure the root run ID is set to match so that astream_events recognizes it
     cfg.setdefault("run_id", run_id)

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -43,6 +43,15 @@ from aegra_api.services.graph_factory import (
 State = TypeVar("State")
 logger = structlog.get_logger(__name__)
 
+# A body-supplied thread_id overrides the route-verified one (the checkpointer
+# keys on thread_id alone), so the server pins these instead of trusting them.
+SERVER_PINNED_CONFIG_KEYS: frozenset[str] = frozenset({"thread_id", "run_id"})
+
+
+def strip_pinned_config_keys(client_config: dict[str, Any]) -> dict[str, Any]:
+    """Drop server-authoritative identity keys from a client-supplied config dict."""
+    return {k: v for k, v in client_config.items() if k not in SERVER_PINNED_CONFIG_KEYS}
+
 
 def _module_name_for(graph_id: str) -> str:
     """Return a safe ``sys.modules`` key for a dynamically loaded graph.
@@ -740,9 +749,11 @@ def create_run_config(
     observability_metadata = get_tracing_metadata(run_id, thread_id, user_identity)
     cfg["metadata"].update(observability_metadata)
 
-    # Apply checkpoint parameters if provided
+    # Apply checkpoint parameters if provided. Strip pinned identity keys so a
+    # client checkpoint can't redirect execution to another user's thread.
     if checkpoint and isinstance(checkpoint, dict):
-        cfg["configurable"].update({k: v for k, v in checkpoint.items() if v is not None})
+        safe = strip_pinned_config_keys(checkpoint)
+        cfg["configurable"].update({k: v for k, v in safe.items() if v is not None})
 
     # Finally inject user context via existing helper
     return inject_user_context(user, cfg)

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -707,20 +707,16 @@ def create_run_config(
 ) -> dict[str, Any]:
     """Create LangGraph configuration for a specific run with full context.
 
-    The function is *additive* for most keys, but `thread_id` and `run_id` are
-    server-authoritative: a client-supplied `configurable.thread_id` would
-    otherwise point graph execution (and the checkpointer, which keys solely on
-    thread_id) at another user's thread, bypassing the route ownership check.
-    We force the server values so the request body cannot redirect execution.
+    Additive for client keys, except thread_id/run_id which are forced: a
+    body-supplied configurable.thread_id would redirect execution to another
+    user's thread (the checkpointer keys on thread_id alone).
     """
     from copy import deepcopy
 
     cfg: dict = deepcopy(additional_config) if additional_config else {}
-
-    # Ensure a configurable section exists
     cfg.setdefault("configurable", {})
 
-    # Force server-authoritative identity keys — never honor a client override.
+    # Server-authoritative — overwrite, never honor a client override.
     cfg["configurable"]["thread_id"] = thread_id
     cfg["configurable"]["run_id"] = run_id
 

--- a/libs/aegra-api/src/aegra_api/utils/run_utils.py
+++ b/libs/aegra-api/src/aegra_api/utils/run_utils.py
@@ -6,6 +6,15 @@ from langgraph.types import Command, Send
 
 logger = structlog.getLogger(__name__)
 
+# A body-supplied thread_id overrides the route-verified one (the checkpointer
+# keys on thread_id alone), so the server pins these instead of trusting them.
+SERVER_PINNED_CONFIG_KEYS: frozenset[str] = frozenset({"thread_id", "run_id"})
+
+
+def strip_pinned_config_keys(client_config: dict[str, Any]) -> dict[str, Any]:
+    """Drop server-authoritative identity keys from a client-supplied config dict."""
+    return {k: v for k, v in client_config.items() if k not in SERVER_PINNED_CONFIG_KEYS}
+
 
 def map_command_to_langgraph(cmd: dict[str, Any]) -> Command:
     """Convert an API command dict to a LangGraph Command object."""

--- a/libs/aegra-api/tests/integration/test_api/test_threads_history.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_history.py
@@ -258,30 +258,11 @@ class TestBeforeParameterFormats:
         # Must NOT be double-wrapped as {"configurable": {"configurable": {...}}}
         assert captured[0] == {"configurable": {"checkpoint_id": "cp_xyz789"}}
 
-    def test_before_as_runnable_config_strips_thread_id(self, capturing_client: tuple) -> None:
-        """A thread_id inside a full-RunnableConfig `before` must be stripped.
-
-        Otherwise it redirects history to another user's thread despite the
-        route ownership check (cross-tenant read).
-        """
-        client, captured = capturing_client
-        thread_id = _ensure_thread(client)
-
-        before = {"configurable": {"thread_id": "victim", "checkpoint_id": "cp1"}}
-        resp = client.post(
-            f"/threads/{thread_id}/history",
-            json={"before": before},
-        )
-        assert resp.status_code == 200
-
-        assert len(captured) == 1
-        assert captured[0] == {"configurable": {"checkpoint_id": "cp1"}}
-
     def test_before_as_raw_checkpoint_dict(self, capturing_client: tuple) -> None:
-        """Raw checkpoint dict is wrapped, but a client thread_id is stripped.
+        """Raw checkpoint dict (no 'configurable' key) is wrapped, passed as-is.
 
-        A thread_id inside `before` must not redirect history away from the
-        ownership-verified thread (cross-tenant read).
+        No thread_id scrub: aget_state_history reads only checkpoint_id from
+        `before`; the thread comes from the main config.
         """
         client, captured = capturing_client
         thread_id = _ensure_thread(client)
@@ -294,7 +275,7 @@ class TestBeforeParameterFormats:
         assert resp.status_code == 200
 
         assert len(captured) == 1
-        assert captured[0] == {"configurable": {"checkpoint_id": "cp_raw"}}
+        assert captured[0] == {"configurable": {"checkpoint_id": "cp_raw", "thread_id": "t1"}}
 
     def test_before_none(self, capturing_client: tuple) -> None:
         """None before should pass through as None."""

--- a/libs/aegra-api/tests/integration/test_api/test_threads_history.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_history.py
@@ -258,6 +258,25 @@ class TestBeforeParameterFormats:
         # Must NOT be double-wrapped as {"configurable": {"configurable": {...}}}
         assert captured[0] == {"configurable": {"checkpoint_id": "cp_xyz789"}}
 
+    def test_before_as_runnable_config_strips_thread_id(self, capturing_client: tuple) -> None:
+        """A thread_id inside a full-RunnableConfig `before` must be stripped.
+
+        Otherwise it redirects history to another user's thread despite the
+        route ownership check (cross-tenant read).
+        """
+        client, captured = capturing_client
+        thread_id = _ensure_thread(client)
+
+        before = {"configurable": {"thread_id": "victim", "checkpoint_id": "cp1"}}
+        resp = client.post(
+            f"/threads/{thread_id}/history",
+            json={"before": before},
+        )
+        assert resp.status_code == 200
+
+        assert len(captured) == 1
+        assert captured[0] == {"configurable": {"checkpoint_id": "cp1"}}
+
     def test_before_as_raw_checkpoint_dict(self, capturing_client: tuple) -> None:
         """Raw checkpoint dict is wrapped, but a client thread_id is stripped.
 

--- a/libs/aegra-api/tests/integration/test_api/test_threads_history.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_history.py
@@ -259,7 +259,11 @@ class TestBeforeParameterFormats:
         assert captured[0] == {"configurable": {"checkpoint_id": "cp_xyz789"}}
 
     def test_before_as_raw_checkpoint_dict(self, capturing_client: tuple) -> None:
-        """Raw checkpoint dict (no 'configurable' key) should be wrapped."""
+        """Raw checkpoint dict is wrapped, but a client thread_id is stripped.
+
+        A thread_id inside `before` must not redirect history away from the
+        ownership-verified thread (cross-tenant read).
+        """
         client, captured = capturing_client
         thread_id = _ensure_thread(client)
 
@@ -271,7 +275,7 @@ class TestBeforeParameterFormats:
         assert resp.status_code == 200
 
         assert len(captured) == 1
-        assert captured[0] == {"configurable": {"checkpoint_id": "cp_raw", "thread_id": "t1"}}
+        assert captured[0] == {"configurable": {"checkpoint_id": "cp_raw"}}
 
     def test_before_none(self, capturing_client: tuple) -> None:
         """None before should pass through as None."""

--- a/libs/aegra-api/tests/unit/test_api/test_thread_checkpoint_scoping.py
+++ b/libs/aegra-api/tests/unit/test_api/test_thread_checkpoint_scoping.py
@@ -1,0 +1,25 @@
+"""Unit tests for client-checkpoint sanitization on thread state/history routes."""
+
+from aegra_api.api.threads import _client_checkpoint
+
+
+class TestClientCheckpoint:
+    def test_strips_thread_id_and_run_id(self) -> None:
+        """Server-authoritative identity keys must be dropped from client input.
+
+        A client checkpoint carrying thread_id would otherwise override the
+        ownership-verified thread and redirect state reads/writes (GHSA cross
+        -tenant class).
+        """
+        cleaned = _client_checkpoint({"thread_id": "victim", "run_id": "victim-run", "checkpoint_id": "cp-1"})
+
+        assert "thread_id" not in cleaned
+        assert "run_id" not in cleaned
+
+    def test_preserves_legitimate_checkpoint_keys(self) -> None:
+        cleaned = _client_checkpoint({"checkpoint_id": "cp-1", "checkpoint_ns": "ns"})
+
+        assert cleaned == {"checkpoint_id": "cp-1", "checkpoint_ns": "ns"}
+
+    def test_empty_dict_returns_empty(self) -> None:
+        assert _client_checkpoint({}) == {}

--- a/libs/aegra-api/tests/unit/test_api/test_thread_checkpoint_scoping.py
+++ b/libs/aegra-api/tests/unit/test_api/test_thread_checkpoint_scoping.py
@@ -1,9 +1,9 @@
-"""Unit tests for client-checkpoint sanitization on thread state/history routes."""
+"""Unit tests for client-config sanitization (strip_pinned_config_keys)."""
 
-from aegra_api.api.threads import _client_checkpoint
+from aegra_api.utils.run_utils import strip_pinned_config_keys
 
 
-class TestClientCheckpoint:
+class TestStripPinnedConfigKeys:
     def test_strips_thread_id_and_run_id(self) -> None:
         """Server-authoritative identity keys must be dropped from client input.
 
@@ -11,15 +11,15 @@ class TestClientCheckpoint:
         ownership-verified thread and redirect state reads/writes (GHSA cross
         -tenant class).
         """
-        cleaned = _client_checkpoint({"thread_id": "victim", "run_id": "victim-run", "checkpoint_id": "cp-1"})
+        cleaned = strip_pinned_config_keys({"thread_id": "victim", "run_id": "victim-run", "checkpoint_id": "cp-1"})
 
         assert "thread_id" not in cleaned
         assert "run_id" not in cleaned
 
     def test_preserves_legitimate_checkpoint_keys(self) -> None:
-        cleaned = _client_checkpoint({"checkpoint_id": "cp-1", "checkpoint_ns": "ns"})
+        cleaned = strip_pinned_config_keys({"checkpoint_id": "cp-1", "checkpoint_ns": "ns"})
 
         assert cleaned == {"checkpoint_id": "cp-1", "checkpoint_ns": "ns"}
 
     def test_empty_dict_returns_empty(self) -> None:
-        assert _client_checkpoint({}) == {}
+        assert strip_pinned_config_keys({}) == {}

--- a/libs/aegra-api/tests/unit/test_services/test_cron_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_cron_service.py
@@ -218,6 +218,28 @@ class TestCreateCron:
         assert exc.value.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_assistant_lookup_is_scoped_to_owner(
+        self,
+        cron_service: CronService,
+        mock_session: AsyncMock,
+        sample_create: CronCreate,
+    ) -> None:
+        """The assistant validation query must filter by the caller's user_id.
+
+        Without it, a user could pin another user's assistant (and its private
+        config) onto a cron via assistant_id.
+        """
+        mock_session.scalar.return_value = _make_assistant_orm()
+
+        await cron_service.create_cron(sample_create, "test-user")
+
+        stmt = mock_session.scalar.await_args_list[0].args[0]
+        sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "user_id" in sql
+        assert "test-user" in sql
+        assert "system" in sql
+
+    @pytest.mark.asyncio
     async def test_rejects_missing_graph(
         self,
         cron_service: CronService,

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -685,6 +685,27 @@ class TestLangGraphServiceConfigs:
         assert result["configurable"]["thread_id"] == "thread-456"
         assert result["configurable"]["run_id"] == "run-789"
 
+    def test_create_run_config_checkpoint_cannot_override_thread_id(self):
+        """The checkpoint param is merged last; it must not redefine thread_id.
+
+        RunCreate.checkpoint is a free-form client dict — a thread_id inside it
+        would otherwise win over the server-pinned value at the final merge.
+        """
+        mock_user = Mock()
+        mock_user.identity = "user-123"
+        mock_user.display_name = "Test User"
+
+        malicious_checkpoint = {"thread_id": "victim-thread", "checkpoint_id": "cp-9"}
+
+        with patch(
+            "aegra_api.services.langgraph_service.get_tracing_callbacks",
+            return_value=[],
+        ):
+            result = create_run_config("run-789", "thread-456", mock_user, checkpoint=malicious_checkpoint)
+
+        assert result["configurable"]["thread_id"] == "thread-456"
+        assert result["configurable"]["checkpoint_id"] == "cp-9"
+
     def test_create_run_config_with_tracing_callbacks(self):
         """Test creating run config with tracing callbacks"""
         mock_user = Mock()

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -663,6 +663,28 @@ class TestLangGraphServiceConfigs:
 
         assert result["configurable"]["checkpoint_key"] == "checkpoint_value"
 
+    def test_create_run_config_ignores_client_thread_id_override(self):
+        """A client-supplied configurable.thread_id must not redirect execution.
+
+        The checkpointer keys solely on thread_id, so honoring a body override
+        would let a user read/write another user's thread despite the route
+        ownership check.
+        """
+        mock_user = Mock()
+        mock_user.identity = "user-123"
+        mock_user.display_name = "Test User"
+
+        attacker_override = {"configurable": {"thread_id": "victim-thread", "run_id": "victim-run"}}
+
+        with patch(
+            "aegra_api.services.langgraph_service.get_tracing_callbacks",
+            return_value=[],
+        ):
+            result = create_run_config("run-789", "thread-456", mock_user, additional_config=attacker_override)
+
+        assert result["configurable"]["thread_id"] == "thread-456"
+        assert result["configurable"]["run_id"] == "run-789"
+
     def test_create_run_config_with_tracing_callbacks(self):
         """Test creating run config with tracing callbacks"""
         mock_user = Mock()


### PR DESCRIPTION
## Summary

Three cross-tenant access holes, all the same class: **the route verifies ownership of a path param, then a request-body field redirects access to another user's resource.** Auth handlers are default-allow, so the SQL/config scoping is the only real boundary (GHSA-m98r-6667-4wq7).

These are sibling to #424 (run-path assistant lookup). This PR covers the three holes #424 does not.

### 1. Cron pins another user's assistant — `cron_service.py`
`create_cron` validated the target assistant by id **without a `user_id` filter**. Any user could reference a victim's `assistant_id`; the cron persists under the attacker's id and, on every tick, fires a run that merges the victim's private `config`/`context` (API keys, system prompts). Worse than a one-shot read — it recurs.

**Fix:** scope the lookup to `user_id == caller OR == "system"`, returning 404 otherwise — exactly the predicate used throughout `AssistantService`.

### 2. Client `configurable.thread_id` redirects run execution — `langgraph_service.py`
`create_run_config` honored a client-supplied `configurable.thread_id` / `run_id` via `setdefault`. The LangGraph checkpointer keys **solely** on `thread_id`, so a body override pointed graph reads/writes at a **victim's thread** despite the route checking the *path* thread. Read AND write of another user's conversation state.

**Fix:** force the server-authoritative `thread_id`/`run_id`; never honor a client override.

### 3. Client `checkpoint` / `before` dict redirects thread state & history — `threads.py`
`POST /threads/{id}/state` and `/history` merged a client `checkpoint` (and bare `before`) dict straight into `configurable`, the same override vector.

**Fix:** `_client_checkpoint()` strips the server-pinned identity keys (`thread_id`, `run_id`) before merge.

## Tests

- `test_assistant_lookup_is_scoped_to_owner` — the cron query's WHERE includes `user_id` + the caller + `"system"`.
- `test_create_run_config_ignores_client_thread_id_override` — a body `thread_id`/`run_id` does not survive.
- `test_thread_checkpoint_scoping.py` — `_client_checkpoint` drops `thread_id`/`run_id`, keeps `checkpoint_id`/`checkpoint_ns`.
- An existing history test that asserted the **vulnerable** passthrough is updated to the secure behavior.

Full suite: 1557 passed. ruff + format clean.

## Note

Hole #1 of this class (run-path `_prepare_run` assistant lookup) is handled by #424 and intentionally left to that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stripped server-pinned identity fields (`thread_id`, `run_id`) from client-supplied checkpoint/config data before execution and thread history handling.
  * Enforced server-authoritative `thread_id`/`run_id` in run configuration, preventing client routing overrides.
  * Tightened cron assistant validation so `assistant_id` must belong to the requesting user or the shared system assistant.
* **Tests**
  * Added coverage for pinned-config sanitization, thread history `before` protection across config shapes, run config override resistance, and scoped assistant lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes three cross-tenant access vulnerabilities by scoping assistant lookups to the requesting user in the cron service, forcing server-authoritative `thread_id`/`run_id` in `create_run_config`, and stripping those identity keys from any client-supplied checkpoint dicts before merging them into the LangGraph configurable.

- **`cron_service.py`**: The assistant-validation query now includes `OR(user_id == caller, user_id == "system")`, preventing a user from pinning another user's private assistant (and its config/context) onto a recurring cron job.
- **`langgraph_service.py`**: `thread_id`/`run_id` are now assigned with `=` (not `setdefault`) and the checkpoint dict is passed through `strip_pinned_config_keys` before merge, closing both the `additional_config` and `checkpoint` override vectors.
- **`threads.py` / `run_utils.py`**: A shared `strip_pinned_config_keys` helper strips `thread_id`/`run_id` from the client `checkpoint` field in both the state-update and history endpoints; the `before` parameter intentionally skips stripping because `aget_state_history` scopes by the main `config` (pinned above), not by `before`.

<h3>Confidence Score: 5/5</h3>

All three cross-tenant access holes are correctly closed; no new issues introduced.

Each fix is minimal and targeted: the cron assistant query now requires ownership, create_run_config overwrites rather than defaults the identity keys, and strip_pinned_config_keys is applied at every point where a client dict reaches the LangGraph configurable. The before parameter in history intentionally skips stripping and is backed by a clear code comment explaining that aget_state_history scopes by the main config, not before. Tests inspect the compiled SQL, test both override vectors in run config, and cover the strip helper directly. Previously flagged issues have been addressed.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/utils/run_utils.py | Adds SERVER_PINNED_CONFIG_KEYS frozenset and strip_pinned_config_keys helper; clean, minimal, correctly strips only the two checkpointer identity keys. |
| libs/aegra-api/src/aegra_api/services/cron_service.py | Scopes assistant lookup to user_id == caller OR system using SQLAlchemy or_; correctly mirrors the predicate used in AssistantService throughout the codebase. |
| libs/aegra-api/src/aegra_api/services/langgraph_service.py | Forces thread_id/run_id with direct assignment instead of setdefault, and strips pinned identity keys from the client checkpoint dict before merge, closing both override vectors. |
| libs/aegra-api/src/aegra_api/api/threads.py | Applies strip_pinned_config_keys to the client checkpoint dict in both the state-update and history-POST endpoints; before is intentionally not stripped with a clear explanatory comment. |
| libs/aegra-api/tests/unit/test_api/test_thread_checkpoint_scoping.py | New unit tests for strip_pinned_config_keys: covers stripping of thread_id/run_id, preservation of checkpoint_id/checkpoint_ns, and empty input. |
| libs/aegra-api/tests/unit/test_services/test_langgraph_service.py | Adds two tests covering both override vectors: client additional_config.configurable.thread_id and checkpoint.thread_id; both confirm server-pinned values win. |
| libs/aegra-api/tests/integration/test_api/test_threads_history.py | Updates docstring on the raw-checkpoint-dict test to reflect the intentional non-stripping of before; no behavioral change to the test itself. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant R as Route (ownership check)
    participant LS as LangGraph Service
    participant CS as Cron Service
    participant DB as Database / Checkpointer

    note over C,DB: Fix 1 - Cron assistant scoping
    C->>R: "POST /crons (assistant_id=victim)"
    R->>CS: create_cron(request, user_id)
    CS->>DB: "SELECT WHERE assistant_id=X AND (user_id=caller OR user_id=system)"
    DB-->>CS: 404 not found for this owner
    CS-->>C: 404 Not Found

    note over C,DB: Fix 2 - create_run_config thread_id override
    C->>R: "POST /runs (configurable.thread_id=victim-thread)"
    R->>LS: "create_run_config(run_id, server_thread_id, user, additional_config=body)"
    LS->>LS: "cfg configurable thread_id = server_thread_id forced assignment"
    LS->>DB: Run on server_thread_id
    DB-->>C: Result scoped to caller's thread

    note over C,DB: Fix 3 - checkpoint dict override
    C->>R: "POST /threads/id/state (checkpoint.thread_id=victim)"
    R->>R: strip_pinned_config_keys drops thread_id and run_id
    R->>DB: configurable.update(safe_checkpoint)
    DB-->>C: State update scoped to route-verified thread
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant R as Route (ownership check)
    participant LS as LangGraph Service
    participant CS as Cron Service
    participant DB as Database / Checkpointer

    note over C,DB: Fix 1 - Cron assistant scoping
    C->>R: "POST /crons (assistant_id=victim)"
    R->>CS: create_cron(request, user_id)
    CS->>DB: "SELECT WHERE assistant_id=X AND (user_id=caller OR user_id=system)"
    DB-->>CS: 404 not found for this owner
    CS-->>C: 404 Not Found

    note over C,DB: Fix 2 - create_run_config thread_id override
    C->>R: "POST /runs (configurable.thread_id=victim-thread)"
    R->>LS: "create_run_config(run_id, server_thread_id, user, additional_config=body)"
    LS->>LS: "cfg configurable thread_id = server_thread_id forced assignment"
    LS->>DB: Run on server_thread_id
    DB-->>C: Result scoped to caller's thread

    note over C,DB: Fix 3 - checkpoint dict override
    C->>R: "POST /threads/id/state (checkpoint.thread_id=victim)"
    R->>R: strip_pinned_config_keys drops thread_id and run_id
    R->>DB: configurable.update(safe_checkpoint)
    DB-->>C: State update scoped to route-verified thread
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `libs/aegra-api/src/aegra_api/services/langgraph_service.py`, line 748-749 ([link](https://github.com/aegra/aegra/blob/b5c9a9f5f957406362d313c5557bfa9536e53c01/libs/aegra-api/src/aegra_api/services/langgraph_service.py#L748-L749)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **`checkpoint` dict can still override the server-pinned `thread_id`/`run_id`**

   The server-authoritative assignment at lines 724–725 is undone by this `update` call, which runs unconditionally afterwards. A client that passes `{"thread_id": "victim-thread"}` inside the `checkpoint` field of a run request flows through `request.checkpoint` → `RunExecution.checkpoint` → `job.execution.checkpoint` → `create_run_config(..., checkpoint=...)` and reaches this line, overwriting the forced values. The new test (`test_create_run_config_ignores_client_thread_id_override`) only exercises the `additional_config` vector and does not cover this path, so the bypass survives the test suite. The fix should filter identity keys from the checkpoint dict before merging, exactly as `_client_checkpoint` does in `threads.py`.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%0ALine%3A%20748-749%0A%0AComment%3A%0A**%60checkpoint%60%20dict%20can%20still%20override%20the%20server-pinned%20%60thread_id%60%2F%60run_id%60**%0A%0AThe%20server-authoritative%20assignment%20at%20lines%20724%E2%80%93725%20is%20undone%20by%20this%20%60update%60%20call%2C%20which%20runs%20unconditionally%20afterwards.%20A%20client%20that%20passes%20%60%7B%22thread_id%22%3A%20%22victim-thread%22%7D%60%20inside%20the%20%60checkpoint%60%20field%20of%20a%20run%20request%20flows%20through%20%60request.checkpoint%60%20%E2%86%92%20%60RunExecution.checkpoint%60%20%E2%86%92%20%60job.execution.checkpoint%60%20%E2%86%92%20%60create_run_config%28...%2C%20checkpoint%3D...%29%60%20and%20reaches%20this%20line%2C%20overwriting%20the%20forced%20values.%20The%20new%20test%20%28%60test_create_run_config_ignores_client_thread_id_override%60%29%20only%20exercises%20the%20%60additional_config%60%20vector%20and%20does%20not%20cover%20this%20path%2C%20so%20the%20bypass%20survives%20the%20test%20suite.%20The%20fix%20should%20filter%20identity%20keys%20from%20the%20checkpoint%20dict%20before%20merging%2C%20exactly%20as%20%60_client_checkpoint%60%20does%20in%20%60threads.py%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=431&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%0ALine%3A%20748-749%0A%0AComment%3A%0A**%60checkpoint%60%20dict%20can%20still%20override%20the%20server-pinned%20%60thread_id%60%2F%60run_id%60**%0A%0AThe%20server-authoritative%20assignment%20at%20lines%20724%E2%80%93725%20is%20undone%20by%20this%20%60update%60%20call%2C%20which%20runs%20unconditionally%20afterwards.%20A%20client%20that%20passes%20%60%7B%22thread_id%22%3A%20%22victim-thread%22%7D%60%20inside%20the%20%60checkpoint%60%20field%20of%20a%20run%20request%20flows%20through%20%60request.checkpoint%60%20%E2%86%92%20%60RunExecution.checkpoint%60%20%E2%86%92%20%60job.execution.checkpoint%60%20%E2%86%92%20%60create_run_config%28...%2C%20checkpoint%3D...%29%60%20and%20reaches%20this%20line%2C%20overwriting%20the%20forced%20values.%20The%20new%20test%20%28%60test_create_run_config_ignores_client_thread_id_override%60%29%20only%20exercises%20the%20%60additional_config%60%20vector%20and%20does%20not%20cover%20this%20path%2C%20so%20the%20bypass%20survives%20the%20test%20suite.%20The%20fix%20should%20filter%20identity%20keys%20from%20the%20checkpoint%20dict%20before%20merging%2C%20exactly%20as%20%60_client_checkpoint%60%20does%20in%20%60threads.py%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=431&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fcross-tenant-thread-and-cron-scoping%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcross-tenant-thread-and-cron-scoping%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%0ALine%3A%20748-749%0A%0AComment%3A%0A**%60checkpoint%60%20dict%20can%20still%20override%20the%20server-pinned%20%60thread_id%60%2F%60run_id%60**%0A%0AThe%20server-authoritative%20assignment%20at%20lines%20724%E2%80%93725%20is%20undone%20by%20this%20%60update%60%20call%2C%20which%20runs%20unconditionally%20afterwards.%20A%20client%20that%20passes%20%60%7B%22thread_id%22%3A%20%22victim-thread%22%7D%60%20inside%20the%20%60checkpoint%60%20field%20of%20a%20run%20request%20flows%20through%20%60request.checkpoint%60%20%E2%86%92%20%60RunExecution.checkpoint%60%20%E2%86%92%20%60job.execution.checkpoint%60%20%E2%86%92%20%60create_run_config%28...%2C%20checkpoint%3D...%29%60%20and%20reaches%20this%20line%2C%20overwriting%20the%20forced%20values.%20The%20new%20test%20%28%60test_create_run_config_ignores_client_thread_id_override%60%29%20only%20exercises%20the%20%60additional_config%60%20vector%20and%20does%20not%20cover%20this%20path%2C%20so%20the%20bypass%20survives%20the%20test%20suite.%20The%20fix%20should%20filter%20identity%20keys%20from%20the%20checkpoint%20dict%20before%20merging%2C%20exactly%20as%20%60_client_checkpoint%60%20does%20in%20%60threads.py%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=431&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["fix(security): drop dead thread\_id scrub..."](https://github.com/aegra/aegra/commit/b3f060eb3e71ea87c02e5d8923ddff092e725dca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38535565)</sub>

<!-- /greptile_comment -->