### PR TITLE
feat(store): add opt-in configurable namespace scopes

### DIFF
--- a/aegra.json
+++ b/aegra.json
@@ -12,5 +12,10 @@
   },
   "http": {
     "app": "./examples/custom_routes_example.py:app"
+  },
+  "store": {
+    "scopes": {
+      "orgs": "org_id"
+    }
   }
 }

--- a/aegra.json
+++ b/aegra.json
@@ -15,7 +15,7 @@
   },
   "store": {
     "scopes": {
-      "orgs": "org_id"
+      "orgs": ["org_id"]
     }
   }
 }

--- a/docs/guides/store.mdx
+++ b/docs/guides/store.mdx
@@ -72,7 +72,6 @@ Namespaces organize your data hierarchically. They work like directory paths:
 ```
 ["users", "alice", "preferences"]     → User preferences
 ["users", "alice", "conversations"]   → Conversation history
-["knowledge", "docs"]                 → Shared knowledge base
 ```
 
 ### List namespaces
@@ -93,6 +92,47 @@ All store operations are automatically scoped to the authenticated user's namesp
 - Any other namespace (e.g. `["configs"]`) is automatically prefixed to `["users", <user_id>, "configs"]`
 
 This ensures users can never access each other's data, even if they craft a request with another user's namespace.
+
+### Configurable scoping
+
+Beyond the default per-user scope, you can define **configurable scopes**: a map of **namespace prefix → User attribute** under `store.scopes` in `aegra.json`. A namespace starting with a configured prefix is isolated under `[prefix, <user attribute value>]`, where the value comes from the authenticated user populated by [your auth handler](/guides/authentication).
+
+Every user whose attribute value matches lands in the same scope, so data is shared exactly as widely as that attribute. Mapping an attribute many users share (like `org_id`) is the common way to **share a pool across a group** — for example, a knowledge base or agent skills that every member can read and contribute to.
+
+For example, to share data across an organization, map `"orgs"` to the user's `org_id` in `aegra.json`:
+
+```json
+{
+  "store": {
+    "scopes": {
+      "orgs": "org_id"
+    }
+  }
+}
+```
+
+```python
+# Shared across all members of the caller's organization
+await client.store.put_item(
+    namespace=["orgs", "<org_id>", "shared-skills"],
+    key="summarize-ticket",
+    value={
+        "name": "summarize-ticket",
+        "description": "Condenses a support ticket thread.",
+        "instructions": "..."
+    },
+)
+```
+
+A configured scope follows the same rule as user scoping (using the `"orgs"` → `org_id` example):
+
+- A fully-qualified namespace `["orgs", <org_id>, ...]` passes through unchanged. The `<org_id>` is visible in `get`/`search`/`list_namespaces` responses, which echo the scoped namespace.
+- Any namespace not fully qualified with your own `org_id` (including a foreign org id) is buried under `["orgs", <org_id>, ...]`, so members can never reach another organization's data.
+- A request using the `"orgs"` prefix when the user has no `org_id` returns **403 Forbidden**.
+
+An empty or unconfigured prefix always defaults to user scope — a configured scope is never applied implicitly.
+
+You can map any prefix to any attribute your auth handler sets (`team_id`, `tenant_id`, `region`, …), and configure several at once. The `"users"` prefix is reserved for per-user isolation and cannot be remapped.
 
 ## Semantic search
 

--- a/docs/guides/store.mdx
+++ b/docs/guides/store.mdx
@@ -95,17 +95,17 @@ This ensures users can never access each other's data, even if they craft a requ
 
 ### Configurable scoping
 
-Beyond the default per-user scope, you can define **configurable scopes**: a map of **namespace prefix → User attribute** under `store.scopes` in `aegra.json`. A namespace starting with a configured prefix is isolated under `[prefix, <user attribute value>]`, where the value comes from the authenticated user populated by [your auth handler](/guides/authentication).
+Beyond the default per-user scope, you can define **configurable scopes**: a map of **namespace prefix → list of User attributes** under `store.scopes` in `aegra.json`. A namespace starting with a configured prefix is isolated under `[prefix, *<user attribute values>]`, where the values come from the authenticated user populated by [your auth handler](/guides/authentication).
 
-Every user whose attribute value matches lands in the same scope, so data is shared exactly as widely as that attribute. Mapping an attribute many users share (like `org_id`) is the common way to **share a pool across a group** — for example, a knowledge base or agent skills that every member can read and contribute to.
+Every user whose attribute values match lands in the same scope, so data is shared exactly as widely as those attributes. Mapping an attribute many users share (like `org_id`) is the common way to **share a pool across a group** — for example, a knowledge base or agent skills that every member can read and contribute to.
 
-For example, to share data across an organization, map `"orgs"` to the user's `org_id` in `aegra.json`:
+For example, to share data across an organization, map `"orgs"` to a list containing the user's `org_id` in `aegra.json`:
 
 ```json
 {
   "store": {
     "scopes": {
-      "orgs": "org_id"
+      "orgs": ["org_id"]
     }
   }
 }
@@ -132,7 +132,23 @@ A configured scope follows the same rule as user scoping (using the `"orgs"` →
 
 An empty or unconfigured prefix always defaults to user scope — a configured scope is never applied implicitly.
 
-You can map any prefix to any attribute your auth handler sets (`team_id`, `tenant_id`, `region`, …), and configure several at once. The `"users"` prefix is reserved for per-user isolation and cannot be remapped.
+#### Partitioning by multiple attributes
+
+A scope can list more than one attribute. The namespace is then partitioned by every listed attribute, in order. Reach for this when no single attribute is enough on its own — for example, isolating data per organization **and** per region, where each org/region pair is its own partition:
+
+```json
+{
+  "store": {
+    "scopes": {
+      "regional": ["org_id", "region"]
+    }
+  }
+}
+```
+
+A namespace `["regional", ...]` is isolated under `["regional", <org_id>, <region>, ...]`. **All** listed attributes are required — a user missing any of them gets **403 Forbidden**, exactly as with a single-attribute scope.
+
+You can map any prefix to any attributes your auth handler sets (`team_id`, `tenant_id`, `region`, …), and configure several scopes at once. The `"users"` prefix is reserved for per-user isolation and cannot be remapped.
 
 ## Semantic search
 

--- a/examples/jwt_mock_auth_example.py
+++ b/examples/jwt_mock_auth_example.py
@@ -73,7 +73,8 @@ async def authenticate(headers: dict[str, str]) -> dict[str, str | bool | list[s
 
     user_id = parts[0]
     role = parts[1]
-    team_id = parts[2] if len(parts) > 2 else "team_default"
+    has_team = len(parts) > 2
+    team_id = parts[2] if has_team else "team_default"
 
     # Determine subscription tier based on role
     subscription_tier = "premium" if role in ("admin", "premium") else "free"
@@ -87,6 +88,8 @@ async def authenticate(headers: dict[str, str]) -> dict[str, str | bool | list[s
         "role": role,
         "subscription_tier": subscription_tier,
         "team_id": team_id,
+        # A team doubles as the user's org for org-scoped store sharing; no team => no org.
+        "org_id": team_id if has_team else None,
         "email": f"{user_id}@example.com",
     }
 

--- a/libs/aegra-api/src/aegra_api/api/store.py
+++ b/libs/aegra-api/src/aegra_api/api/store.py
@@ -1,8 +1,13 @@
 """Store endpoints for Agent Protocol"""
 
+from collections.abc import Mapping
+from functools import cache
+
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 
+from aegra_api.config import load_store_config
 from aegra_api.core.auth_deps import auth_dependency, get_current_user
 from aegra_api.core.auth_handlers import build_auth_context, handle_event
 from aegra_api.core.database import db_manager
@@ -18,6 +23,8 @@ from aegra_api.models import (
     User,
 )
 from aegra_api.models.errors import BAD_REQUEST, NOT_FOUND
+
+logger = structlog.get_logger(__name__)
 
 router = APIRouter(tags=["Store"], dependencies=auth_dependency)
 
@@ -44,7 +51,7 @@ async def put_store_item(request: StorePutRequest, user: User = Depends(get_curr
             request.value = filters["value"]
 
     # Apply user namespace scoping
-    scoped_namespace = apply_user_namespace_scoping(user.identity, request.namespace)
+    scoped_namespace = apply_namespace_scoping(request.namespace, user)
 
     store = db_manager.get_store()
 
@@ -78,7 +85,7 @@ async def get_store_item(
             key = filters["key"]
 
     # Apply user namespace scoping
-    scoped_namespace = apply_user_namespace_scoping(user.identity, _normalize_namespace(namespace))
+    scoped_namespace = apply_namespace_scoping(_normalize_namespace(namespace), user)
 
     store = db_manager.get_store()
 
@@ -127,7 +134,7 @@ async def delete_store_item(
             k = filters["key"]
 
     # Apply user namespace scoping
-    scoped_namespace = apply_user_namespace_scoping(user.identity, ns)
+    scoped_namespace = apply_namespace_scoping(ns, user)
 
     store = db_manager.get_store()
 
@@ -160,7 +167,7 @@ async def search_store_items(
             request.filter = {**(request.filter or {}), **handler_filters}
 
     # Apply user namespace scoping
-    scoped_prefix = apply_user_namespace_scoping(user.identity, request.namespace_prefix)
+    scoped_prefix = apply_namespace_scoping(request.namespace_prefix, user)
 
     store = db_manager.get_store()
 
@@ -207,7 +214,7 @@ async def list_namespaces(
             request.suffix = filters["suffix"]
 
     # Apply user namespace scoping to prefix
-    scoped_prefix = apply_user_namespace_scoping(user.identity, request.prefix or [])
+    scoped_prefix = apply_namespace_scoping(request.prefix or [], user)
     prefix: tuple[str, ...] = tuple(scoped_prefix)
     suffix: tuple[str, ...] | None = tuple(request.suffix) if request.suffix else None
 
@@ -233,17 +240,55 @@ def _normalize_namespace(value: str | list[str] | None) -> list[str]:
     return []
 
 
-def apply_user_namespace_scoping(user_id: str, namespace: list[str]) -> list[str]:
-    """Apply user-based namespace scoping for data isolation.
-
-    All store operations are scoped to the authenticated user's namespace.
-    Users can only access namespaces under ["users", <their_user_id>].
-    """
+def _scope(prefix: str, scope_id: str, namespace: list[str]) -> list[str]:
+    """Bury a namespace under [prefix, scope_id] unless it is already exactly that."""
     if not namespace:
-        return ["users", user_id]
+        return [prefix, scope_id]
 
-    if namespace[0] == "users" and len(namespace) >= 2 and namespace[1] == user_id:
+    if namespace[0] == prefix and len(namespace) >= 2 and namespace[1] == scope_id:
         return namespace
 
-    # Scope any other namespace under the user's prefix
-    return ["users", user_id] + namespace
+    return [prefix, scope_id, *namespace]
+
+
+_USER_SCOPE_PREFIX = "users"
+
+
+@cache
+def _scope_attr_map() -> Mapping[str, str]:
+    """Map of namespace prefix -> User attribute, from aegra.json store.scopes.
+
+    Empty unless configured — configurable scopes are entirely opt-in. The
+    reserved "users" prefix is dropped so it can never be remapped away from
+    per-user isolation.
+    """
+    store_config = load_store_config()
+    configured = store_config.get("scopes") if store_config else None
+    if not configured:
+        return {}
+
+    scopes = {prefix: attr for prefix, attr in configured.items() if prefix != _USER_SCOPE_PREFIX}
+    if _USER_SCOPE_PREFIX in configured:
+        logger.warning("store.scopes key %r is reserved and was ignored", _USER_SCOPE_PREFIX)
+    return scopes
+
+
+def apply_namespace_scoping(namespace: list[str], user: User, *, scopes: Mapping[str, str] | None = None) -> list[str]:
+    """Scope store namespaces for data isolation.
+
+    User scope is the default. A leading element matching a configured scope
+    prefix opts into that scope, isolating data under [prefix, <user attr>].
+    Items land in the same scope for every user with the same attribute value,
+    so mapping a shared attribute (e.g. org_id) shares data across that group.
+    The scope value comes from the authenticated user, never the request.
+    """
+    scopes = scopes if scopes is not None else _scope_attr_map()
+
+    if namespace and (prefix := namespace[0]) in scopes:
+        attr = scopes[prefix]
+        value = getattr(user, attr, None)
+        if value is None or value == "":
+            raise HTTPException(403, f"User has no {attr!r} required for {prefix!r}-scoped store access")
+        return _scope(prefix, str(value), namespace)
+
+    return _scope(_USER_SCOPE_PREFIX, user.identity, namespace)

--- a/libs/aegra-api/src/aegra_api/api/store.py
+++ b/libs/aegra-api/src/aegra_api/api/store.py
@@ -240,23 +240,20 @@ def _normalize_namespace(value: str | list[str] | None) -> list[str]:
     return []
 
 
-def _scope(prefix: str, scope_id: str, namespace: list[str]) -> list[str]:
-    """Bury a namespace under [prefix, scope_id] unless it is already exactly that."""
-    if not namespace:
-        return [prefix, scope_id]
-
-    if namespace[0] == prefix and len(namespace) >= 2 and namespace[1] == scope_id:
+def _scope(prefix: str, scope_ids: list[str], namespace: list[str]) -> list[str]:
+    """Bury a namespace under [prefix, *scope_ids] unless it already starts with exactly that."""
+    head = [prefix, *scope_ids]
+    if namespace[: len(head)] == head:
         return namespace
-
-    return [prefix, scope_id, *namespace]
+    return [*head, *namespace]
 
 
 _USER_SCOPE_PREFIX = "users"
 
 
 @cache
-def _scope_attr_map() -> Mapping[str, str]:
-    """Map of namespace prefix -> User attribute, from aegra.json store.scopes.
+def _scope_attr_map() -> Mapping[str, list[str]]:
+    """Map of namespace prefix -> list of User attributes, from aegra.json store.scopes.
 
     Empty unless configured — configurable scopes are entirely opt-in. The
     reserved "users" prefix is dropped so it can never be remapped away from
@@ -267,28 +264,37 @@ def _scope_attr_map() -> Mapping[str, str]:
     if not configured:
         return {}
 
-    scopes = {prefix: attr for prefix, attr in configured.items() if prefix != _USER_SCOPE_PREFIX}
-    if _USER_SCOPE_PREFIX in configured:
-        logger.warning("store.scopes key %r is reserved and was ignored", _USER_SCOPE_PREFIX)
+    scopes: dict[str, list[str]] = {}
+    for prefix, attrs in configured.items():
+        if prefix == _USER_SCOPE_PREFIX:
+            logger.warning("store.scopes key %r is reserved and was ignored", _USER_SCOPE_PREFIX)
+            continue
+        if not isinstance(attrs, list) or not attrs or not all(isinstance(a, str) and a for a in attrs):
+            logger.warning("store.scopes[%r] must be a non-empty list of attribute names; ignoring", prefix)
+            continue
+        scopes[prefix] = attrs
     return scopes
 
 
-def apply_namespace_scoping(namespace: list[str], user: User, *, scopes: Mapping[str, str] | None = None) -> list[str]:
+def apply_namespace_scoping(
+    namespace: list[str], user: User, *, scopes: Mapping[str, list[str]] | None = None
+) -> list[str]:
     """Scope store namespaces for data isolation.
 
     User scope is the default. A leading element matching a configured scope
-    prefix opts into that scope, isolating data under [prefix, <user attr>].
-    Items land in the same scope for every user with the same attribute value,
+    prefix opts into that scope, isolating data under [prefix, *<user attrs>].
+    Items land in the same scope for every user sharing those attribute values,
     so mapping a shared attribute (e.g. org_id) shares data across that group.
-    The scope value comes from the authenticated user, never the request.
     """
     scopes = scopes if scopes is not None else _scope_attr_map()
 
     if namespace and (prefix := namespace[0]) in scopes:
-        attr = scopes[prefix]
-        value = getattr(user, attr, None)
-        if value is None or value == "":
-            raise HTTPException(403, f"User has no {attr!r} required for {prefix!r}-scoped store access")
-        return _scope(prefix, str(value), namespace)
+        values: list[str] = []
+        for attr in scopes[prefix]:
+            value = getattr(user, attr, None)
+            if value is None or value == "":
+                raise HTTPException(403, f"User has no {attr!r} required for {prefix!r}-scoped store access")
+            values.append(str(value))
+        return _scope(prefix, values, namespace)
 
-    return _scope(_USER_SCOPE_PREFIX, user.identity, namespace)
+    return _scope(_USER_SCOPE_PREFIX, [user.identity], namespace)

--- a/libs/aegra-api/src/aegra_api/api/store.py
+++ b/libs/aegra-api/src/aegra_api/api/store.py
@@ -263,6 +263,9 @@ def _scope_attr_map() -> Mapping[str, list[str]]:
     configured = store_config.get("scopes") if store_config else None
     if not configured:
         return {}
+    if not isinstance(configured, dict):
+        logger.warning("store.scopes must be a mapping of prefix -> attribute names; ignoring %r", configured)
+        return {}
 
     scopes: dict[str, list[str]] = {}
     for prefix, attrs in configured.items():

--- a/libs/aegra-api/src/aegra_api/config.py
+++ b/libs/aegra-api/src/aegra_api/config.py
@@ -64,18 +64,8 @@ class StoreConfig(TypedDict, total=False):
 
     index: StoreIndexConfig | None
     """Vector index configuration for semantic search"""
-    scopes: dict[str, str]
-    """Map of namespace prefix -> User attribute used for configurable store scoping.
-
-    A leading namespace element matching a key opts into that scope, isolating
-    data under [prefix, <user attribute value>]. The "users" prefix is reserved
-    for per-user isolation and cannot be remapped. Empty (no extra scopes) unless
-    configured. Mapping a shared attribute (e.g. org_id) shares data across every
-    user with that value — a common use case, but the scope value can be any
-    User attribute.
-    Example: {"orgs": "org_id", "teams": "team_id"} scopes under ["orgs", <org_id>]
-    and ["teams", <team_id>].
-    """
+    scopes: dict[str, list[str]]
+    """Map of namespace prefix -> list of User attributes used for configurable store scoping."""
 
 
 class AuthConfig(TypedDict, total=False):

--- a/libs/aegra-api/src/aegra_api/config.py
+++ b/libs/aegra-api/src/aegra_api/config.py
@@ -64,6 +64,18 @@ class StoreConfig(TypedDict, total=False):
 
     index: StoreIndexConfig | None
     """Vector index configuration for semantic search"""
+    scopes: dict[str, str]
+    """Map of namespace prefix -> User attribute used for configurable store scoping.
+
+    A leading namespace element matching a key opts into that scope, isolating
+    data under [prefix, <user attribute value>]. The "users" prefix is reserved
+    for per-user isolation and cannot be remapped. Empty (no extra scopes) unless
+    configured. Mapping a shared attribute (e.g. org_id) shares data across every
+    user with that value — a common use case, but the scope value can be any
+    User attribute.
+    Example: {"orgs": "org_id", "teams": "team_id"} scopes under ["orgs", <org_id>]
+    and ["teams", <team_id>].
+    """
 
 
 class AuthConfig(TypedDict, total=False):

--- a/libs/aegra-api/tests/e2e/manual_auth_tests/test_store_org_isolation_e2e.py
+++ b/libs/aegra-api/tests/e2e/manual_auth_tests/test_store_org_isolation_e2e.py
@@ -1,0 +1,153 @@
+"""E2E tests verifying store org scoping when authentication is enabled.
+
+Claim under test:
+  A leading "orgs" element in a store namespace scopes items to the caller's
+  organization. Members of the same org share those items; members of a
+  different org (or no org) never reach them.
+
+⚠️ MANUAL TESTS - These are skipped by default. Run with: pytest -m manual_auth
+
+Requires a running Aegra server with auth enabled (the jwt_mock_auth_example
+config) and store.scopes {"orgs": "org_id"} configured (see aegra.auth.json).
+See README.md for setup. The mock auth maps a token's team segment to org_id:
+mock-jwt-<user>-<role>-<org>. A token without a team segment has no org.
+
+Run:
+    pytest tests/e2e/manual_auth_tests/test_store_org_isolation_e2e.py -v -m manual_auth
+"""
+
+import uuid
+
+import httpx
+import pytest
+
+from aegra_api.settings import settings
+from tests.e2e._utils import elog
+
+
+def get_server_url() -> str:
+    """Return the base URL of the running server under test."""
+    return settings.app.SERVER_URL
+
+
+def auth_headers(user_id: str, *, role: str = "user", org: str | None = "org1") -> dict[str, str]:
+    """Build mock-JWT auth headers. org=None omits the team segment, so the user has no org."""
+    token = f"mock-jwt-{user_id}-{role}" if org is None else f"mock-jwt-{user_id}-{role}-{org}"
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.e2e
+@pytest.mark.manual_auth
+class TestOrgStoreSharing:
+    """Items written under the "orgs" prefix are shared across members of that org."""
+
+    @pytest.mark.asyncio
+    async def test_org_member_reads_item_written_by_another_member(self) -> None:
+        """Bob reads a shared item that Alice wrote, because both are in org1."""
+        key = f"greeting-{uuid.uuid4().hex[:8]}"
+        namespace = ["orgs", "org1", "shared-prompts"]
+        value = {"text": "hello org"}
+
+        async with httpx.AsyncClient(base_url=get_server_url(), timeout=30.0) as http:
+            put = await http.put(
+                "/store/items",
+                headers=auth_headers("alice", org="org1"),
+                json={"namespace": namespace, "key": key, "value": value},
+            )
+            assert put.status_code == 204, f"Alice put failed: {put.status_code} {put.text}"
+
+            got = await http.get(
+                "/store/items",
+                headers=auth_headers("bob", org="org1"),
+                params=[("namespace", "orgs"), ("namespace", "org1"), ("namespace", "shared-prompts"), ("key", key)],
+            )
+        elog("Bob GET org1 shared item", {"status": got.status_code, "body": got.text})
+        assert got.status_code == 200, f"Bob (same org) should read the item: {got.status_code} {got.text}"
+        assert got.json()["value"] == value
+
+    @pytest.mark.asyncio
+    async def test_org_member_search_sees_shared_item(self) -> None:
+        """Search under the org prefix returns items written by any member of the org."""
+        key = f"doc-{uuid.uuid4().hex[:8]}"
+        namespace = ["orgs", "org1", "docs"]
+
+        async with httpx.AsyncClient(base_url=get_server_url(), timeout=30.0) as http:
+            put = await http.put(
+                "/store/items",
+                headers=auth_headers("alice", org="org1"),
+                json={"namespace": namespace, "key": key, "value": {"body": "shared"}},
+            )
+            assert put.status_code == 204, put.text
+
+            search = await http.post(
+                "/store/items/search",
+                headers=auth_headers("bob", org="org1"),
+                json={"namespace_prefix": ["orgs", "org1", "docs"], "limit": 100},
+            )
+        assert search.status_code == 200, search.text
+        keys = {item["key"] for item in search.json()["items"]}
+        elog("Bob search org1 docs", sorted(keys))
+        assert key in keys, "Bob (same org) should see the item Alice wrote"
+
+
+@pytest.mark.e2e
+@pytest.mark.manual_auth
+class TestOrgStoreIsolation:
+    """An org's items are unreachable from a different org or from no org at all."""
+
+    @pytest.mark.asyncio
+    async def test_other_org_cannot_read_item(self) -> None:
+        """Carol in org2 requesting org1's namespace is buried under org2, so she gets 404."""
+        key = f"secret-{uuid.uuid4().hex[:8]}"
+        namespace = ["orgs", "org1", "shared-prompts"]
+
+        async with httpx.AsyncClient(base_url=get_server_url(), timeout=30.0) as http:
+            put = await http.put(
+                "/store/items",
+                headers=auth_headers("alice", org="org1"),
+                json={"namespace": namespace, "key": key, "value": {"text": "org1 only"}},
+            )
+            assert put.status_code == 204, put.text
+
+            got = await http.get(
+                "/store/items",
+                headers=auth_headers("carol", org="org2"),
+                params=[("namespace", "orgs"), ("namespace", "org1"), ("namespace", "shared-prompts"), ("key", key)],
+            )
+        elog("Carol (org2) GET org1 item", {"status": got.status_code})
+        assert got.status_code == 404, f"Expected 404 cross-org, got {got.status_code}: {got.text}"
+
+    @pytest.mark.asyncio
+    async def test_other_org_search_does_not_see_item(self) -> None:
+        """Search from org2 under the org1 prefix is scoped to org2 and finds nothing."""
+        key = f"secret-{uuid.uuid4().hex[:8]}"
+
+        async with httpx.AsyncClient(base_url=get_server_url(), timeout=30.0) as http:
+            put = await http.put(
+                "/store/items",
+                headers=auth_headers("alice", org="org1"),
+                json={"namespace": ["orgs", "org1", "docs"], "key": key, "value": {"body": "org1 only"}},
+            )
+            assert put.status_code == 204, put.text
+
+            search = await http.post(
+                "/store/items/search",
+                headers=auth_headers("carol", org="org2"),
+                json={"namespace_prefix": ["orgs", "org1", "docs"], "limit": 100},
+            )
+        assert search.status_code == 200, search.text
+        keys = {item["key"] for item in search.json()["items"]}
+        elog("Carol (org2) search org1 docs", sorted(keys))
+        assert key not in keys, "Carol (org2) must not see org1's item"
+
+    @pytest.mark.asyncio
+    async def test_user_without_org_is_forbidden(self) -> None:
+        """A user with no org using the "orgs" prefix is rejected with 403."""
+        async with httpx.AsyncClient(base_url=get_server_url(), timeout=30.0) as http:
+            resp = await http.put(
+                "/store/items",
+                headers=auth_headers("dave", org=None),
+                json={"namespace": ["orgs", "shared"], "key": "x", "value": {"text": "nope"}},
+            )
+        elog("No-org user PUT orgs namespace", {"status": resp.status_code, "body": resp.text})
+        assert resp.status_code == 403, f"Expected 403 for no-org user, got {resp.status_code}: {resp.text}"

--- a/libs/aegra-api/tests/e2e/manual_auth_tests/test_store_org_isolation_e2e.py
+++ b/libs/aegra-api/tests/e2e/manual_auth_tests/test_store_org_isolation_e2e.py
@@ -8,7 +8,7 @@ Claim under test:
 ⚠️ MANUAL TESTS - These are skipped by default. Run with: pytest -m manual_auth
 
 Requires a running Aegra server with auth enabled (the jwt_mock_auth_example
-config) and store.scopes {"orgs": "org_id"} configured (see aegra.auth.json).
+config) and store.scopes {"orgs": ["org_id"]} configured (see aegra.auth.json).
 See README.md for setup. The mock auth maps a token's team segment to org_id:
 mock-jwt-<user>-<role>-<org>. A token without a team segment has no org.
 
@@ -27,7 +27,9 @@ from tests.e2e._utils import elog
 
 def get_server_url() -> str:
     """Return the base URL of the running server under test."""
-    return settings.app.SERVER_URL
+    url = settings.app.SERVER_URL
+    assert url is not None, "SERVER_URL is derived from HOST/PORT and is never None"
+    return url
 
 
 def auth_headers(user_id: str, *, role: str = "user", org: str | None = "org1") -> dict[str, str]:

--- a/libs/aegra-api/tests/e2e/test_store/test_store.py
+++ b/libs/aegra-api/tests/e2e/test_store/test_store.py
@@ -42,6 +42,23 @@ async def test_store_endpoints_via_sdk():
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+async def test_org_prefix_without_org_membership_is_forbidden():
+    """The anonymous user has no org_id, so the "orgs" prefix is rejected with 403.
+
+    Relies on aegra.json configuring store.scopes {"orgs": "org_id"}. The org-scoped
+    happy path needs auth that sets org_id; it lives in the auth-enabled suite
+    (manual_auth_tests/test_store_org_isolation_e2e.py).
+    """
+    client = get_e2e_client()
+
+    with pytest.raises(Exception) as exc_info:  # noqa: B017 - SDK doesn't expose specific exception type
+        await client.store.put_item(["orgs", "shared-prompts"], key="greeting", value={"text": "hi"})
+    elog("store.put_item orgs prefix rejected", str(exc_info.value))
+    assert "403" in str(exc_info.value) or "organization" in str(exc_info.value).lower()
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
 async def test_store_rejects_non_dict_values():
     """Test that store API rejects non-dictionary values"""
     client = get_e2e_client()

--- a/libs/aegra-api/tests/e2e/test_store/test_store.py
+++ b/libs/aegra-api/tests/e2e/test_store/test_store.py
@@ -45,7 +45,7 @@ async def test_store_endpoints_via_sdk():
 async def test_org_prefix_without_org_membership_is_forbidden():
     """The anonymous user has no org_id, so the "orgs" prefix is rejected with 403.
 
-    Relies on aegra.json configuring store.scopes {"orgs": "org_id"}. The org-scoped
+    Relies on aegra.json configuring store.scopes {"orgs": ["org_id"]}. The org-scoped
     happy path needs auth that sets org_id; it lives in the auth-enabled suite
     (manual_auth_tests/test_store_org_isolation_e2e.py).
     """

--- a/libs/aegra-api/tests/fixtures/clients.py
+++ b/libs/aegra-api/tests/fixtures/clients.py
@@ -22,7 +22,7 @@ def create_test_app(include_runs: bool = True, include_threads: bool = True) -> 
     # ------------------------------------
 
     # 1. Create a proper test user
-    mock_user = User(identity="test-user", display_name="Test User")
+    mock_user = User(identity="test-user", display_name="Test User", org_id="org-1")
 
     # 2. Override dependencies
     # require_auth: allows access to protected routes

--- a/libs/aegra-api/tests/integration/test_api/test_store_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_store_crud.py
@@ -701,19 +701,14 @@ class TestNamespaceScoping:
 
 
 class TestConfiguredScopeIntegration:
-    """A configured store.scopes entry maps a namespace prefix to a User attribute.
-
-    The base `client` user already carries org_id="org-1", so these reuse it and
-    only configure the "orgs" -> org_id scope. Arbitrary-attribute mapping and the
-    edge cases are covered by the unit tests in test_store_namespace_scoping.py.
-    """
+    """A configured store.scopes entry maps a namespace prefix to User attributes"""
 
     @pytest.fixture(autouse=True)
     def _org_scope(self, monkeypatch) -> None:
-        """Configure the "orgs" -> org_id scope for every test in this class."""
+        """Configure the "orgs" -> [org_id] scope for every test in this class."""
         from aegra_api.api import store as store_module
 
-        monkeypatch.setattr(store_module, "_scope_attr_map", lambda: {"orgs": "org_id"})
+        monkeypatch.setattr(store_module, "_scope_attr_map", lambda: {"orgs": ["org_id"]})
 
     def test_put_org_namespace_scopes_to_org(self, client, mock_store) -> None:
         """A fully-qualified org namespace passes through to the org scope."""
@@ -784,6 +779,44 @@ class TestConfiguredScopeIntegration:
 
         assert resp.status_code == 403
         mock_store.aput.assert_not_called()
+
+    def test_fully_qualified_multi_attribute_namespace_passes_through(self, client, mock_store, monkeypatch) -> None:
+        """A namespace already under [prefix, *attr_values] passes through unchanged."""
+        from aegra_api.api import store as store_module
+        from aegra_api.core.auth_deps import get_current_user, require_auth
+        from aegra_api.models.auth import User
+
+        monkeypatch.setattr(store_module, "_scope_attr_map", lambda: {"teams": ["org_id", "team_id"]})
+        user = User(identity="test-user", org_id="org-1", team_id="team-42")
+        client.app.dependency_overrides[require_auth] = lambda: user
+        client.app.dependency_overrides[get_current_user] = lambda: user
+
+        resp = client.put(
+            "/store/items",
+            json={"namespace": ["teams", "org-1", "team-42", "kb"], "key": "greeting", "value": {"text": "hi"}},
+        )
+
+        assert resp.status_code == 204
+        assert mock_store.aput.call_args.kwargs["namespace"] == ("teams", "org-1", "team-42", "kb")
+
+    def test_multi_attribute_scope_buries_under_all_values(self, client, mock_store, monkeypatch) -> None:
+        """A scope listing several attributes partitions by each value, in order."""
+        from aegra_api.api import store as store_module
+        from aegra_api.core.auth_deps import get_current_user, require_auth
+        from aegra_api.models.auth import User
+
+        monkeypatch.setattr(store_module, "_scope_attr_map", lambda: {"teams": ["org_id", "team_id"]})
+        user = User(identity="test-user", org_id="org-1", team_id="team-42")
+        client.app.dependency_overrides[require_auth] = lambda: user
+        client.app.dependency_overrides[get_current_user] = lambda: user
+
+        resp = client.put(
+            "/store/items",
+            json={"namespace": ["teams", "kb"], "key": "greeting", "value": {"text": "hi"}},
+        )
+
+        assert resp.status_code == 204
+        assert mock_store.aput.call_args.kwargs["namespace"] == ("teams", "org-1", "team-42", "teams", "kb")
 
 
 class TestStoreIntegration:

--- a/libs/aegra-api/tests/integration/test_api/test_store_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_store_crud.py
@@ -215,7 +215,7 @@ class TestGetStoreItem:
         """Test empty namespace query param is treated as no namespace"""
         from unittest.mock import patch
 
-        from aegra_api.api.store import apply_user_namespace_scoping
+        from aegra_api.api.store import apply_namespace_scoping
 
         mock_item = DummyStoreItem(
             key="test-key",
@@ -225,13 +225,15 @@ class TestGetStoreItem:
         mock_store.aget.return_value = mock_item
 
         with patch(
-            "aegra_api.api.store.apply_user_namespace_scoping",
-            wraps=apply_user_namespace_scoping,
+            "aegra_api.api.store.apply_namespace_scoping",
+            wraps=apply_namespace_scoping,
         ) as spy:
             resp = client.get("/store/items?namespace=&key=test-key")
 
         assert resp.status_code == 200
-        spy.assert_called_once_with("test-user", [])
+        spy.assert_called_once()
+        assert spy.call_args.args[0] == []
+        assert spy.call_args.args[1].identity == "test-user"
         call_args = mock_store.aget.call_args
         assert call_args[0][0] == ("users", "test-user")
 
@@ -270,16 +272,18 @@ class TestDeleteStoreItem:
         """Test empty namespace query param is treated as no namespace"""
         from unittest.mock import patch
 
-        from aegra_api.api.store import apply_user_namespace_scoping
+        from aegra_api.api.store import apply_namespace_scoping
 
         with patch(
-            "aegra_api.api.store.apply_user_namespace_scoping",
-            wraps=apply_user_namespace_scoping,
+            "aegra_api.api.store.apply_namespace_scoping",
+            wraps=apply_namespace_scoping,
         ) as spy:
             resp = client.delete("/store/items?key=test-key&namespace=")
 
         assert resp.status_code == 204
-        spy.assert_called_once_with("test-user", [])
+        spy.assert_called_once()
+        assert spy.call_args.args[0] == []
+        assert spy.call_args.args[1].identity == "test-user"
         call_args = mock_store.adelete.call_args
         assert call_args[0][0] == ("users", "test-user")
 
@@ -694,6 +698,92 @@ class TestNamespaceScoping:
         call_args = mock_store.asearch.call_args
         namespace_prefix = call_args[0][0]
         assert namespace_prefix == ("users", "test-user", "users", "other-user", "docs")
+
+
+class TestConfiguredScopeIntegration:
+    """A configured store.scopes entry maps a namespace prefix to a User attribute.
+
+    The base `client` user already carries org_id="org-1", so these reuse it and
+    only configure the "orgs" -> org_id scope. Arbitrary-attribute mapping and the
+    edge cases are covered by the unit tests in test_store_namespace_scoping.py.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _org_scope(self, monkeypatch) -> None:
+        """Configure the "orgs" -> org_id scope for every test in this class."""
+        from aegra_api.api import store as store_module
+
+        monkeypatch.setattr(store_module, "_scope_attr_map", lambda: {"orgs": "org_id"})
+
+    def test_put_org_namespace_scopes_to_org(self, client, mock_store) -> None:
+        """A fully-qualified org namespace passes through to the org scope."""
+        resp = client.put(
+            "/store/items",
+            json={
+                "namespace": ["orgs", "org-1", "shared-prompts"],
+                "key": "greeting",
+                "value": {"text": "hi"},
+            },
+        )
+
+        assert resp.status_code == 204
+        assert mock_store.aput.call_args.kwargs["namespace"] == ("orgs", "org-1", "shared-prompts")
+
+    def test_get_org_namespace_scopes_to_org(self, client, mock_store) -> None:
+        """A GET under the org prefix reads from the caller's org scope."""
+        mock_store.aget.return_value = DummyStoreItem("greeting", {"text": "hi"}, ("orgs", "org-1"))
+
+        resp = client.get("/store/items?key=greeting&namespace=orgs&namespace=org-1")
+
+        assert resp.status_code == 200
+        assert mock_store.aget.call_args[0][0] == ("orgs", "org-1")
+
+    def test_search_org_namespace_scopes_to_org(self, client, mock_store) -> None:
+        """A search under the org prefix is scoped to the caller's org."""
+        mock_store.asearch.return_value = []
+
+        resp = client.post(
+            "/store/items/search",
+            json={"namespace_prefix": ["orgs", "org-1", "docs"]},
+        )
+
+        assert resp.status_code == 200
+        assert mock_store.asearch.call_args[0][0] == ("orgs", "org-1", "docs")
+
+    def test_other_org_namespace_is_buried(self, client, mock_store) -> None:
+        """A foreign org id never passes through — it is buried under the caller's org."""
+        resp = client.put(
+            "/store/items",
+            json={
+                "namespace": ["orgs", "victim-org", "secrets"],
+                "key": "stolen",
+                "value": {"data": "nope"},
+            },
+        )
+
+        assert resp.status_code == 204
+        assert mock_store.aput.call_args.kwargs["namespace"] == ("orgs", "org-1", "orgs", "victim-org", "secrets")
+
+    def test_org_prefix_without_org_membership_is_forbidden(self, client, mock_store) -> None:
+        """A user with no org_id using the "orgs" prefix gets 403."""
+        from aegra_api.core.auth_deps import get_current_user, require_auth
+        from aegra_api.models.auth import User
+
+        no_org_user = User(identity="test-user")
+        client.app.dependency_overrides[require_auth] = lambda: no_org_user
+        client.app.dependency_overrides[get_current_user] = lambda: no_org_user
+
+        resp = client.put(
+            "/store/items",
+            json={
+                "namespace": ["orgs", "shared-prompts"],
+                "key": "greeting",
+                "value": {"text": "hi"},
+            },
+        )
+
+        assert resp.status_code == 403
+        mock_store.aput.assert_not_called()
 
 
 class TestStoreIntegration:

--- a/libs/aegra-api/tests/unit/test_api/test_store_namespace_scoping.py
+++ b/libs/aegra-api/tests/unit/test_api/test_store_namespace_scoping.py
@@ -10,7 +10,7 @@ from aegra_api.api.store import _scope_attr_map, apply_namespace_scoping
 from aegra_api.models import User
 
 
-def _user(identity: str, *, org_id: str | None = None, **extra: Any | None) -> User:
+def _user(identity: str, *, org_id: str | None = None, **extra: Any) -> User:
     """Build a User with arbitrary scope attributes for scoping tests."""
     return User(identity=identity, org_id=org_id, **extra)
 
@@ -84,14 +84,14 @@ class TestConfigurableScopes:
 
     def test_fully_qualified_org_namespace_passes_through(self) -> None:
         """A namespace already under the caller's own org value passes through."""
-        scopes = {"orgs": "org_id"}
+        scopes = {"orgs": ["org_id"]}
         user = _user("user-123", org_id="org-1")
         result = apply_namespace_scoping(["orgs", "org-1", "shared-prompts"], user, scopes=scopes)
         assert result == ["orgs", "org-1", "shared-prompts"]
 
     def test_other_org_namespace_is_buried(self) -> None:
         """A foreign org id never passes through — it is buried under the caller's org."""
-        scopes = {"orgs": "org_id"}
+        scopes = {"orgs": ["org_id"]}
         user = _user("user-123", org_id="org-1")
         result = apply_namespace_scoping(["orgs", "victim-org", "secrets"], user, scopes=scopes)
         assert result == ["orgs", "org-1", "orgs", "victim-org", "secrets"]
@@ -99,21 +99,21 @@ class TestConfigurableScopes:
 
     def test_user_scope_takes_precedence_for_empty_namespace(self) -> None:
         """Empty namespace defaults to user scope even when a scope is configured."""
-        scopes = {"orgs": "org_id"}
+        scopes = {"orgs": ["org_id"]}
         user = _user("user-123", org_id="org-1")
         result = apply_namespace_scoping([], user, scopes=scopes)
         assert result == ["users", "user-123"]
 
     def test_custom_scope_buries_foreign_value(self) -> None:
         """A foreign value under a custom scope is buried under the caller's value."""
-        scopes = {"teams": "team_id"}
+        scopes = {"teams": ["team_id"]}
         user = _user("user-123", team_id="team-42")
         result = apply_namespace_scoping(["teams", "other-team"], user, scopes=scopes)
         assert result == ["teams", "team-42", "teams", "other-team"]
 
     def test_custom_scope_missing_attribute_raises_403(self) -> None:
         """Using a scope the user lacks the backing attribute for is forbidden."""
-        scopes = {"teams": "team_id"}
+        scopes = {"teams": ["team_id"]}
         user = _user("user-123")
         with pytest.raises(HTTPException) as exc_info:
             apply_namespace_scoping(["teams", "x"], user, scopes=scopes)
@@ -121,7 +121,7 @@ class TestConfigurableScopes:
 
     def test_custom_scope_empty_string_attribute_raises_403(self) -> None:
         """An empty-string scope value is falsy and must be rejected, like a missing attribute."""
-        scopes = {"orgs": "org_id"}
+        scopes = {"orgs": ["org_id"]}
         user = _user("user-123", org_id="")
         with pytest.raises(HTTPException) as exc_info:
             apply_namespace_scoping(["orgs", "x"], user, scopes=scopes)
@@ -129,38 +129,78 @@ class TestConfigurableScopes:
 
     def test_custom_scope_zero_attribute_is_not_rejected(self) -> None:
         """Integer 0 is a valid primary-key value; only None/empty means 'attribute missing'."""
-        scopes = {"tenants": "tenant_id"}
+        scopes = {"tenants": ["tenant_id"]}
         user = _user("user-123", tenant_id=0)
         result = apply_namespace_scoping(["tenants", "ignored"], user, scopes=scopes)
         assert result == ["tenants", "0", "tenants", "ignored"]
 
     def test_scope_prefix_alone_is_buried_not_rejected(self) -> None:
         """[prefix] with no id is buried under the caller's scope, not treated as an error."""
-        scopes = {"orgs": "org_id"}
+        scopes = {"orgs": ["org_id"]}
         user = _user("user-123", org_id="org-1")
         result = apply_namespace_scoping(["orgs"], user, scopes=scopes)
         assert result == ["orgs", "org-1", "orgs"]
 
     def test_non_string_attribute_value_is_coerced(self) -> None:
         """A non-string scope value is coerced to its string form in the namespace."""
-        scopes = {"tenants": "tenant_id"}
+        scopes = {"tenants": ["tenant_id"]}
         user = _user("user-123", tenant_id=7)
         result = apply_namespace_scoping(["tenants", "ignored"], user, scopes=scopes)
         assert result == ["tenants", "7", "tenants", "ignored"]
 
     def test_unconfigured_prefix_falls_back_to_user_scope(self) -> None:
         """A prefix not in the scopes map is treated as ordinary user-scoped data."""
-        scopes = {"teams": "team_id"}
+        scopes = {"teams": ["team_id"]}
         user = _user("user-123")
         result = apply_namespace_scoping(["orgs", "org-1"], user, scopes=scopes)
         assert result == ["users", "user-123", "orgs", "org-1"]
 
     def test_multiple_scopes(self) -> None:
         """Each configured scope resolves against its own User attribute."""
-        scopes = {"orgs": "org_id", "teams": "team_id"}
+        scopes = {"orgs": ["org_id"], "teams": ["team_id"]}
         user = _user("user-123", org_id="org-1", team_id="team-42")
         assert apply_namespace_scoping(["orgs", "org-1"], user, scopes=scopes) == ["orgs", "org-1"]
         assert apply_namespace_scoping(["teams", "team-42"], user, scopes=scopes) == ["teams", "team-42"]
+
+
+class TestMultiAttributeScopes:
+    """Verify a scope can partition by more than one User attribute, in order."""
+
+    def test_fully_qualified_multi_attr_namespace_passes_through(self) -> None:
+        """A namespace already under [prefix, *attr_values] passes through unchanged."""
+        scopes = {"teams": ["org_id", "team_id"]}
+        user = _user("user-123", org_id="o1", team_id="t1")
+        result = apply_namespace_scoping(["teams", "o1", "t1", "kb"], user, scopes=scopes)
+        assert result == ["teams", "o1", "t1", "kb"]
+
+    def test_multi_attr_buries_under_all_values_in_order(self) -> None:
+        """An unqualified namespace is buried under every attribute value, in listed order."""
+        scopes = {"teams": ["org_id", "team_id"]}
+        user = _user("user-123", org_id="o1", team_id="t1")
+        result = apply_namespace_scoping(["teams", "kb"], user, scopes=scopes)
+        assert result == ["teams", "o1", "t1", "teams", "kb"]
+
+    def test_multi_attr_partial_match_is_buried(self) -> None:
+        """Matching only the first attribute is not 'qualified' — it gets buried."""
+        scopes = {"teams": ["org_id", "team_id"]}
+        user = _user("user-123", org_id="o1", team_id="t1")
+        result = apply_namespace_scoping(["teams", "o1", "kb"], user, scopes=scopes)
+        assert result == ["teams", "o1", "t1", "teams", "o1", "kb"]
+
+    def test_multi_attr_missing_one_attribute_raises_403(self) -> None:
+        """If any required attribute is missing, the whole scope is forbidden."""
+        scopes = {"teams": ["org_id", "team_id"]}
+        user = _user("user-123", org_id="o1")
+        with pytest.raises(HTTPException) as exc_info:
+            apply_namespace_scoping(["teams", "x"], user, scopes=scopes)
+        assert exc_info.value.status_code == 403
+
+    def test_multi_attr_values_are_coerced_to_strings(self) -> None:
+        """Each non-string attribute value is coerced independently."""
+        scopes = {"tenants": ["tenant_id", "region"]}
+        user = _user("user-123", tenant_id=7, region=0)
+        result = apply_namespace_scoping(["tenants", "x"], user, scopes=scopes)
+        assert result == ["tenants", "7", "0", "tenants", "x"]
 
 
 class TestScopeAttrMap:
@@ -185,13 +225,40 @@ class TestScopeAttrMap:
 
     def test_configured_scopes_are_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Configured scopes are surfaced verbatim from the store config."""
-        monkeypatch.setattr("aegra_api.api.store.load_store_config", lambda: {"scopes": {"orgs": "org_id"}})
-        assert _scope_attr_map() == {"orgs": "org_id"}
+        monkeypatch.setattr(
+            "aegra_api.api.store.load_store_config",
+            lambda: {"scopes": {"orgs": ["org_id"], "teams": ["org_id", "team_id"]}},
+        )
+        assert _scope_attr_map() == {"orgs": ["org_id"], "teams": ["org_id", "team_id"]}
 
     def test_reserved_users_prefix_is_dropped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The "users" prefix is reserved for per-user isolation and can never be remapped."""
         monkeypatch.setattr(
             "aegra_api.api.store.load_store_config",
-            lambda: {"scopes": {"users": "org_id", "orgs": "org_id"}},
+            lambda: {"scopes": {"users": ["org_id"], "orgs": ["org_id"]}},
         )
-        assert _scope_attr_map() == {"orgs": "org_id"}
+        assert _scope_attr_map() == {"orgs": ["org_id"]}
+
+    def test_bare_string_value_is_dropped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The legacy single-string form is no longer accepted — it is dropped, not coerced."""
+        monkeypatch.setattr(
+            "aegra_api.api.store.load_store_config",
+            lambda: {"scopes": {"orgs": "org_id", "teams": ["team_id"]}},
+        )
+        assert _scope_attr_map() == {"teams": ["team_id"]}
+
+    def test_empty_list_value_is_dropped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty attribute list is malformed and is dropped."""
+        monkeypatch.setattr(
+            "aegra_api.api.store.load_store_config",
+            lambda: {"scopes": {"orgs": [], "teams": ["team_id"]}},
+        )
+        assert _scope_attr_map() == {"teams": ["team_id"]}
+
+    def test_non_string_element_value_is_dropped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A list containing a non-string (or empty-string) element is malformed and dropped."""
+        monkeypatch.setattr(
+            "aegra_api.api.store.load_store_config",
+            lambda: {"scopes": {"orgs": ["org_id", ""], "teams": ["team_id"]}},
+        )
+        assert _scope_attr_map() == {"teams": ["team_id"]}

--- a/libs/aegra-api/tests/unit/test_api/test_store_namespace_scoping.py
+++ b/libs/aegra-api/tests/unit/test_api/test_store_namespace_scoping.py
@@ -1,61 +1,197 @@
-"""Tests for store namespace scoping / user isolation."""
+"""Tests for store namespace scoping."""
 
-from aegra_api.api.store import apply_user_namespace_scoping
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from aegra_api.api.store import _scope_attr_map, apply_namespace_scoping
+from aegra_api.models import User
 
 
-class TestApplyUserNamespaceScoping:
-    """Verify that apply_user_namespace_scoping enforces per-user isolation."""
+def _user(identity: str, *, org_id: str | None = None, **extra: Any | None) -> User:
+    """Build a User with arbitrary scope attributes for scoping tests."""
+    return User(identity=identity, org_id=org_id, **extra)
+
+
+class TestUserNamespaceScoping:
+    """Verify that apply_namespace_scoping enforces per-user isolation."""
 
     def test_empty_namespace_defaults_to_user_prefix(self) -> None:
-        result = apply_user_namespace_scoping("user-123", [])
+        """An empty namespace resolves to the caller's user scope."""
+        result = apply_namespace_scoping([], _user("user-123"))
         assert result == ["users", "user-123"]
 
     def test_own_namespace_passes_through(self) -> None:
+        """A namespace already under the caller's user scope is left unchanged."""
         ns = ["users", "user-123", "documents"]
-        result = apply_user_namespace_scoping("user-123", ns)
+        result = apply_namespace_scoping(ns, _user("user-123"))
         assert result == ["users", "user-123", "documents"]
 
     def test_own_namespace_exact_passes_through(self) -> None:
+        """The exact user-scope namespace passes through without duplication."""
         ns = ["users", "user-123"]
-        result = apply_user_namespace_scoping("user-123", ns)
+        result = apply_namespace_scoping(ns, _user("user-123"))
         assert result == ["users", "user-123"]
 
     def test_other_user_namespace_is_scoped(self) -> None:
         """A user cannot access another user's namespace — it gets remapped."""
         ns = ["users", "victim-456", "secrets"]
-        result = apply_user_namespace_scoping("user-123", ns)
+        result = apply_namespace_scoping(ns, _user("user-123"))
         assert result == ["users", "user-123", "users", "victim-456", "secrets"]
         assert result != ns
 
     def test_other_user_namespace_no_passthrough(self) -> None:
         """Ensure attacker-supplied namespace for another user is never returned as-is."""
         ns = ["users", "victim-456"]
-        result = apply_user_namespace_scoping("user-123", ns)
+        result = apply_namespace_scoping(ns, _user("user-123"))
         assert result[1] == "user-123"
 
     def test_arbitrary_namespace_is_scoped_under_user(self) -> None:
         """Non-user namespaces get prefixed with the caller's user scope."""
         ns = ["global", "shared-data"]
-        result = apply_user_namespace_scoping("user-123", ns)
+        result = apply_namespace_scoping(ns, _user("user-123"))
         assert result == ["users", "user-123", "global", "shared-data"]
 
     def test_single_element_namespace_is_scoped(self) -> None:
+        """A single-element namespace is buried under the caller's user scope."""
         ns = ["configs"]
-        result = apply_user_namespace_scoping("user-123", ns)
+        result = apply_namespace_scoping(ns, _user("user-123"))
         assert result == ["users", "user-123", "configs"]
 
     def test_users_prefix_without_id_is_scoped(self) -> None:
         """["users"] alone (no user_id) should be scoped, not passed through."""
         ns = ["users"]
-        result = apply_user_namespace_scoping("user-123", ns)
+        result = apply_namespace_scoping(ns, _user("user-123"))
         assert result == ["users", "user-123", "users"]
 
     def test_users_prefix_with_wrong_id_is_scoped(self) -> None:
+        """A "users" prefix bearing another id is re-scoped to the caller."""
         ns = ["users", "other-user"]
-        result = apply_user_namespace_scoping("user-123", ns)
+        result = apply_namespace_scoping(ns, _user("user-123"))
         assert result[1] == "user-123"
 
     def test_deeply_nested_own_namespace(self) -> None:
+        """A deeply nested namespace under the caller's scope passes through intact."""
         ns = ["users", "user-123", "a", "b", "c"]
-        result = apply_user_namespace_scoping("user-123", ns)
+        result = apply_namespace_scoping(ns, _user("user-123"))
         assert result == ["users", "user-123", "a", "b", "c"]
+
+
+class TestConfigurableScopes:
+    """Verify scopes can map any namespace prefix to any User attribute (e.g. org_id)."""
+
+    def test_fully_qualified_org_namespace_passes_through(self) -> None:
+        """A namespace already under the caller's own org value passes through."""
+        scopes = {"orgs": "org_id"}
+        user = _user("user-123", org_id="org-1")
+        result = apply_namespace_scoping(["orgs", "org-1", "shared-prompts"], user, scopes=scopes)
+        assert result == ["orgs", "org-1", "shared-prompts"]
+
+    def test_other_org_namespace_is_buried(self) -> None:
+        """A foreign org id never passes through — it is buried under the caller's org."""
+        scopes = {"orgs": "org_id"}
+        user = _user("user-123", org_id="org-1")
+        result = apply_namespace_scoping(["orgs", "victim-org", "secrets"], user, scopes=scopes)
+        assert result == ["orgs", "org-1", "orgs", "victim-org", "secrets"]
+        assert result[1] == "org-1"
+
+    def test_user_scope_takes_precedence_for_empty_namespace(self) -> None:
+        """Empty namespace defaults to user scope even when a scope is configured."""
+        scopes = {"orgs": "org_id"}
+        user = _user("user-123", org_id="org-1")
+        result = apply_namespace_scoping([], user, scopes=scopes)
+        assert result == ["users", "user-123"]
+
+    def test_custom_scope_buries_foreign_value(self) -> None:
+        """A foreign value under a custom scope is buried under the caller's value."""
+        scopes = {"teams": "team_id"}
+        user = _user("user-123", team_id="team-42")
+        result = apply_namespace_scoping(["teams", "other-team"], user, scopes=scopes)
+        assert result == ["teams", "team-42", "teams", "other-team"]
+
+    def test_custom_scope_missing_attribute_raises_403(self) -> None:
+        """Using a scope the user lacks the backing attribute for is forbidden."""
+        scopes = {"teams": "team_id"}
+        user = _user("user-123")
+        with pytest.raises(HTTPException) as exc_info:
+            apply_namespace_scoping(["teams", "x"], user, scopes=scopes)
+        assert exc_info.value.status_code == 403
+
+    def test_custom_scope_empty_string_attribute_raises_403(self) -> None:
+        """An empty-string scope value is falsy and must be rejected, like a missing attribute."""
+        scopes = {"orgs": "org_id"}
+        user = _user("user-123", org_id="")
+        with pytest.raises(HTTPException) as exc_info:
+            apply_namespace_scoping(["orgs", "x"], user, scopes=scopes)
+        assert exc_info.value.status_code == 403
+
+    def test_custom_scope_zero_attribute_is_not_rejected(self) -> None:
+        """Integer 0 is a valid primary-key value; only None/empty means 'attribute missing'."""
+        scopes = {"tenants": "tenant_id"}
+        user = _user("user-123", tenant_id=0)
+        result = apply_namespace_scoping(["tenants", "ignored"], user, scopes=scopes)
+        assert result == ["tenants", "0", "tenants", "ignored"]
+
+    def test_scope_prefix_alone_is_buried_not_rejected(self) -> None:
+        """[prefix] with no id is buried under the caller's scope, not treated as an error."""
+        scopes = {"orgs": "org_id"}
+        user = _user("user-123", org_id="org-1")
+        result = apply_namespace_scoping(["orgs"], user, scopes=scopes)
+        assert result == ["orgs", "org-1", "orgs"]
+
+    def test_non_string_attribute_value_is_coerced(self) -> None:
+        """A non-string scope value is coerced to its string form in the namespace."""
+        scopes = {"tenants": "tenant_id"}
+        user = _user("user-123", tenant_id=7)
+        result = apply_namespace_scoping(["tenants", "ignored"], user, scopes=scopes)
+        assert result == ["tenants", "7", "tenants", "ignored"]
+
+    def test_unconfigured_prefix_falls_back_to_user_scope(self) -> None:
+        """A prefix not in the scopes map is treated as ordinary user-scoped data."""
+        scopes = {"teams": "team_id"}
+        user = _user("user-123")
+        result = apply_namespace_scoping(["orgs", "org-1"], user, scopes=scopes)
+        assert result == ["users", "user-123", "orgs", "org-1"]
+
+    def test_multiple_scopes(self) -> None:
+        """Each configured scope resolves against its own User attribute."""
+        scopes = {"orgs": "org_id", "teams": "team_id"}
+        user = _user("user-123", org_id="org-1", team_id="team-42")
+        assert apply_namespace_scoping(["orgs", "org-1"], user, scopes=scopes) == ["orgs", "org-1"]
+        assert apply_namespace_scoping(["teams", "team-42"], user, scopes=scopes) == ["teams", "team-42"]
+
+
+class TestScopeAttrMap:
+    """Verify the aegra.json store.scopes loader, including the reserved-prefix guard."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self) -> Iterator[None]:
+        """Reset the @cache on _scope_attr_map around each test."""
+        _scope_attr_map.cache_clear()
+        yield
+        _scope_attr_map.cache_clear()
+
+    def test_no_config_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No store config yields no extra scopes."""
+        monkeypatch.setattr("aegra_api.api.store.load_store_config", lambda: None)
+        assert _scope_attr_map() == {}
+
+    def test_config_without_scopes_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A store config without a scopes key yields no extra scopes."""
+        monkeypatch.setattr("aegra_api.api.store.load_store_config", lambda: {})
+        assert _scope_attr_map() == {}
+
+    def test_configured_scopes_are_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Configured scopes are surfaced verbatim from the store config."""
+        monkeypatch.setattr("aegra_api.api.store.load_store_config", lambda: {"scopes": {"orgs": "org_id"}})
+        assert _scope_attr_map() == {"orgs": "org_id"}
+
+    def test_reserved_users_prefix_is_dropped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The "users" prefix is reserved for per-user isolation and can never be remapped."""
+        monkeypatch.setattr(
+            "aegra_api.api.store.load_store_config",
+            lambda: {"scopes": {"users": "org_id", "orgs": "org_id"}},
+        )
+        assert _scope_attr_map() == {"orgs": "org_id"}

--- a/libs/aegra-api/tests/unit/test_api/test_store_namespace_scoping.py
+++ b/libs/aegra-api/tests/unit/test_api/test_store_namespace_scoping.py
@@ -262,3 +262,19 @@ class TestScopeAttrMap:
             lambda: {"scopes": {"orgs": ["org_id", ""], "teams": ["team_id"]}},
         )
         assert _scope_attr_map() == {"teams": ["team_id"]}
+
+    def test_non_dict_scopes_value_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A truthy non-dict scopes value is malformed; return empty instead of raising AttributeError."""
+        monkeypatch.setattr(
+            "aegra_api.api.store.load_store_config",
+            lambda: {"scopes": "orgs"},
+        )
+        assert _scope_attr_map() == {}
+
+    def test_non_dict_scopes_int_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An int scopes value must not raise; return empty."""
+        monkeypatch.setattr(
+            "aegra_api.api.store.load_store_config",
+            lambda: {"scopes": 42},
+        )
+        assert _scope_attr_map() == {}


### PR DESCRIPTION
Implements #437.

Turns the store's hardcoded per-user namespace scoping into **opt-in configurable scopes**. Operators map a namespace prefix to one or more `User` attributes in `aegra.json` under `store.scopes` (e.g. `{"orgs": ["org_id"]}`), so store data can be shared across a group (org, team) while per-user isolation stays the default.

## What changed

- Parse `store.scopes` from `aegra.json` (prefix → list of `User` attributes).
- Agent and REST write paths resolve a scoped prefix to the same namespace.
- Unlisted prefixes keep the per-user default (`["users", <identity>, …]`).
- Multi-attribute scopes partition in listed order; missing attribute → 403.

## Type of Change
- [x] `feat`: New feature

## Related Issues
Closes #437 

## Changes Made
- Add `store.scopes` config (`StoreConfig.scopes`: prefix → `User` attribute) in `config.py` + `aegra.json`
- Replace `apply_user_namespace_scoping(user_id, ns)` with `apply_namespace_scoping(ns, user, *, scopes=...)`; a leading element matching a configured prefix buries data under `[prefix, <user attr>]`, else falls back to `["users", <identity>]`
- Reserve the `"users"` prefix (cannot be remapped; logs a warning if present in config)
- Return `403` when the user lacks the attribute required by a configured scope
- Map `org_id` in `jwt_mock_auth_example.py` (team doubles as org) for the auth-enabled E2E suite
- Update `docs/guides/store.mdx`

## Testing
- [x] Unit tests added/updated — `test_store_namespace_scoping.py` (configurable scopes, reserved prefix, missing-attr 403)
- [x] Integration tests added/updated — `test_store_crud.py`
- [x] E2E tests added/updated — `test_store.py` (org prefix forbidden w/o org membership) + new `manual_auth_tests/test_store_org_isolation_e2e.py` (org-scoped happy path + cross-org isolation)
- [x] Manual testing performed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added configurable store namespace scoping via `aegra.json` using `store.scopes` (prefix → authenticated user attributes), including org-style sharing while keeping default per-user isolation.
  - Enforced **403 Forbidden** when required attribute-backed scope values are missing/empty (including stricter multi-attribute handling).
- **Documentation**
  - Updated the store guide with the new configurable scoping rules, namespace burying/pass-through behavior, and the reserved `users` prefix.
- **Tests**
  - Expanded E2E, integration, and unit coverage for org sharing/isolation, namespace normalization, and **403** scenarios without org membership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds configurable attribute-backed Store namespace scopes.
- Parses and validates `store.scopes` from project configuration.
- Applies user or configured shared scopes across Store REST operations.
- Adds documentation and unit, integration, and end-to-end coverage for organization sharing, isolation, and invalid configuration.
- Extends the mock authentication example with organization membership.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until the default `orgs` scope activation accounts for existing data stored beneath the former per-user namespace.

The malformed-scope and integer-zero issues are fixed, but upgrading with the committed configuration still redirects existing `orgs` requests to a different physical namespace without migration guidance, and runtime scope edits remain cached without a documented restart requirement.

**Files Needing Attention:** aegra.json, docs/guides/store.mdx, libs/aegra-api/src/aegra_api/api/store.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/store.py | Adds validated configurable namespace resolution across every Store endpoint and fixes the previously reported falsy-value and malformed-map handling. |
| libs/aegra-api/src/aegra_api/config.py | Extends the typed Store configuration with a prefix-to-user-attributes scope map. |
| aegra.json | Enables organization scoping in the operational default configuration, changing access paths for existing `orgs`-prefixed data without migration guidance. |
| examples/jwt_mock_auth_example.py | Maps an explicitly supplied mock team to `org_id` for organization-scoped testing. |
| docs/guides/store.mdx | Documents configurable and multi-attribute scoping but does not explain how existing namespace data should be migrated. |
| libs/aegra-api/tests/unit/test_api/test_store_namespace_scoping.py | Covers default and configurable scopes, missing and falsy attributes, reserved prefixes, malformed configuration, and cache isolation. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Request[Store request namespace] --> Prefix{Configured leading prefix?}
    Prefix -- No --> UserScope[Prefix users and authenticated identity]
    Prefix -- Yes --> Attrs{All configured user attributes present?}
    Attrs -- No --> Forbidden[403 Forbidden]
    Attrs -- Yes --> SharedScope[Prefix configured scope and attribute values]
    UserScope --> Store[(Persistent Store)]
    SharedScope --> Store
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/store-conf..."](https://github.com/aegra/aegra/commit/b0e503428ea8fc05fb46add53eef913bf633e81e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38730029)</sub>

<!-- /greptile_comment -->