### PR TITLE
chore(release): bump version to 0.9.22

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.21"
+    "version": "0.9.22"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.21"
+version = "0.9.22"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.21"
+version = "0.9.22"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.21"
+version = "0.9.22"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.21"
+version = "0.9.22"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
Patch release covering everything merged since 0.9.21.

## Included
- #431 — close cross-tenant access via cron assistant and config thread_id (security)
- #424 — enforce assistant ownership check in run preparation (security)
- #429 — emit no-auth warning once at startup, not per request
- #425 — warn when running without authentication configured
- #418 — raise hitl interrupt-poll timeout to reduce CI flake

All fixes / non-breaking, so a patch bump. No schema migration, no API surface change — the `aegra-api~=0.9.0` constraint stays.

## Bumped
- `libs/aegra-api/pyproject.toml`
- `libs/aegra-cli/pyproject.toml`
- `uv.lock`
- `docs/openapi.json` (info.version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.9.22 release - maintenance update applied across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `aegra-api` and `aegra-cli` from 0.9.21 to 0.9.22, updating the four release artifacts — both `pyproject.toml` files, `uv.lock`, and `docs/openapi.json` — consistently. It packages five previously merged fixes (cross-tenant access closure, assistant ownership enforcement, no-auth warning deduplication, startup auth warning, and HITL poll timeout increase) as a patch release.

- **Version bump only**: all changes are mechanical version string replacements; no code, schema, or API surface is modified in this PR.
- **Dependency constraint intact**: `aegra-cli`'s `aegra-api~=0.9.0` constraint (`>=0.9.0, <0.10.0`) correctly covers 0.9.22 without any update needed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four files contain only mechanical version string replacements with no logic changes.

Every change in this PR is a single-line version string update. The aegra-api~=0.9.0 compatible-release constraint in aegra-cli already covers 0.9.22, the lock file is in sync with both manifests, and the OpenAPI document version matches. Nothing here can regress runtime behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/pyproject.toml | Version bumped from 0.9.21 to 0.9.22; no dependency changes. |
| libs/aegra-cli/pyproject.toml | Version bumped from 0.9.21 to 0.9.22; aegra-api~=0.9.0 constraint unchanged and correctly covers 0.9.22. |
| docs/openapi.json | OpenAPI info.version updated to 0.9.22 to match the package release. |
| uv.lock | Lock file updated for both aegra-api and aegra-cli entries to reflect 0.9.22. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["PR #433 — bump 0.9.21 → 0.9.22"] --> B["libs/aegra-api/pyproject.toml\nversion = 0.9.22"]
    A --> C["libs/aegra-cli/pyproject.toml\nversion = 0.9.22"]
    A --> D["docs/openapi.json\ninfo.version = 0.9.22"]
    A --> E["uv.lock\naegra-api 0.9.22\naegra-cli 0.9.22"]
    C -->|"aegra-api~=0.9.0\n(>=0.9.0, <0.10.0)"| B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["PR #433 — bump 0.9.21 → 0.9.22"] --> B["libs/aegra-api/pyproject.toml\nversion = 0.9.22"]
    A --> C["libs/aegra-cli/pyproject.toml\nversion = 0.9.22"]
    A --> D["docs/openapi.json\ninfo.version = 0.9.22"]
    A --> E["uv.lock\naegra-api 0.9.22\naegra-cli 0.9.22"]
    C -->|"aegra-api~=0.9.0\n(>=0.9.0, <0.10.0)"| B
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump version to 0.9.22"](https://github.com/aegra/aegra/commit/2e49be0dad4e7e5280f07ce3451ce6820a7f8d3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38805684)</sub>

<!-- /greptile_comment -->