### PR TITLE
feat(streaming): Agent Protocol v2 event streaming via native v3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,8 +97,8 @@ CRON_ENABLED=true
 # --- Event Streaming (Agent Protocol v2) ---
 # The v2 thread streaming endpoints (/threads/{id}/stream/events and
 # /threads/{id}/commands) used by the latest LangGraph JS/Python SDKs.
-# On by default. This flag is a kill switch: set false to unregister the
-# routes (clients get 404) and roll back without a redeploy.
+# On by default. This flag is a kill switch: set false to disable v2 serving
+# (requests return 503 with an enable hint) and roll back without a redeploy.
 # FF_V2_EVENT_STREAMING=true
 
 # --- LLM Providers ---

--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,13 @@ CRON_ENABLED=true
 # Soft cap on the JSONB payload size (bytes) accepted on create/update.
 # CRON_MAX_PAYLOAD_BYTES=65536
 
+# --- Event Streaming (Agent Protocol v2) ---
+# The v2 thread streaming endpoints (/threads/{id}/stream/events and
+# /threads/{id}/commands) used by the latest LangGraph JS/Python SDKs.
+# On by default. This flag is a kill switch: set false to unregister the
+# routes (clients get 404) and roll back without a redeploy.
+# FF_V2_EVENT_STREAMING=true
+
 # --- LLM Providers ---
 OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=...

--- a/dev-docs/v2-streaming-architecture.md
+++ b/dev-docs/v2-streaming-architecture.md
@@ -1,0 +1,246 @@
+# v2 Event Streaming — Maintainer / Debug Guide
+
+Internal engineering notes for Agent Protocol v2 streaming. NOT user-facing.
+Lives outside `docs/` so Mintlify never publishes it. Read this before debugging
+a v2 streaming issue.
+
+---
+
+## 1. One-paragraph model
+
+v2 is a **thread-scoped** SSE protocol (v1 is run-scoped). A client opens ONE
+stream on a thread, fires commands, and events for **any run on that thread**
+flow down the single open connection. Events travel
+graph → `native_stream` → broker → `session` → socket. `session.py` is the only
+file with real logic (seq stamping, channel filter, interrupt split, lifecycle
+derivation); everything else forwards. v1 is untouched; a per-run flag
+(`event_streaming_v2`) routes each run to the v2 or v1 stream consumer.
+
+---
+
+## 2. Endpoints (entire public surface)
+
+```
+POST /threads/{id}/stream/events   → SSE stream (long-lived)
+POST /threads/{id}/commands        → one command in, one JSON envelope out
+```
+
+Client choreography — every bug traces back to this sequence:
+
+```
+1. open   stream/events          (SSE stays open for the whole session)
+2. post   commands {run.start}   (starts run A)
+3. run A's events flow down the step-1 stream
+4. [HITL] interrupt surfaces on the stream as input.requested
+   → post commands {input.respond} → starts run B on the SAME thread
+   → run B's events flow down the SAME step-1 stream (never reopened)
+5. lifecycle: completed closes it
+```
+
+Resume is **a new run on the same open stream**, not a new connection. Hold this.
+
+---
+
+## 3. Pipeline (physical path of an event)
+
+```
+LangGraph graph
+  │  astream_events(version="v3")            engine emits protocol-shaped events
+  ▼
+services/event_streaming/native_stream.py    thin: forward, unwrap [event,meta] msg tuples
+  │  (method, event) pairs
+  ▼
+services/broker.py  (in-memory)  OR  redis_broker.py  (prod)
+  │  per-run buffer + live fan-out to EVERY subscriber
+  ▼
+services/event_streaming/session.py  (ThreadEventSession)   THE BRAIN
+  │  re-stamp seq, channel filter, split interrupts, derive lifecycle
+  ▼
+api/event_streaming.py  (_frame_events)      frame as SSE, write to socket
+  ▼
+client SDK
+```
+
+Which file when X breaks:
+
+| Symptom | File |
+| --- | --- |
+| wrong event *content* (tool call malformed, message shape) | `normalizers.py` |
+| event on wrong channel / missing lifecycle / seq off / interrupt not split | `session.py` |
+| one consumer gets events, another doesn't / HITL watcher blind | `broker.py` / `redis_broker.py` |
+| run won't start / resume rejected / auth | `commands.py` + `run_preparation.py` |
+| everything v2 dead / 503 | `capabilities.py` + `FF_V2_EVENT_STREAMING` |
+| old thread hangs on open | `_drain_run` status backstop (`session.py`) |
+
+---
+
+## 4. `session.py` — per-event work
+
+`_project → _channel_events → _emit` for each raw broker event:
+
+1. **seq** — thread-monotonic counter, the reconnect cursor. Client resends last
+   `seq` as `since`; session skips `<= since`. seq increments BEFORE channel
+   filtering (absolute), so reconnecting with a different channel set still
+   resumes correctly.
+2. **channel filter** — drop events for channels the client didn't subscribe to.
+3. **interrupt split** — an interrupt rides inside `values`/`updates`; pull it
+   onto the `input` channel as `input.requested`. This is how HITL surfaces.
+4. **lifecycle derivation** — root `running` seed at run start; per-subgraph
+   `started`/`completed`/`failed`; terminal `completed`/`failed`/`interrupted`
+   at end; terminal cascades any still-open subgraph namespaces (deepest first).
+
+---
+
+## 5. Broker — the subtle one (broke HITL twice)
+
+Per-run object: buffer (reconnect replay) + live fan-out.
+
+**The gotcha:** the v2 SDK opens **TWO** SSE per run — the main event stream AND a
+separate lifecycle-watcher (channels `lifecycle`+`input`) that populates
+`thread.interrupts`. Both must receive **every** event. The original in-memory
+broker used one shared queue → the two consumers competed → watcher missed the
+interrupt → resume broke. Redis pub/sub already fanned out, so **prod worked
+while dev was broken**. Fixed: each `aiter()` gets its own queue; `put()` writes
+to all; replay buffer on subscribe so nothing is dropped.
+
+**Rule: always `make e2e-both` (dev in-memory + prod Redis).** Prod-only
+verification hides dev broker-fanout bugs.
+
+**Expired-broker wedge (fixed):** opening a stream on an OLD thread whose run
+events expired (Redis TTL ~10 min / in-memory cleanup ~1 h) used to recreate an
+empty never-finished broker → `aiter` waited forever → whole stream hung with
+zero events. Fix: the run lister returns `(run_id, status, graph_name)` and
+`_drain_run` uses the persisted status as a backstop — terminal status + empty
+replay = silent skip; terminal + partial replay = synthesized terminal.
+
+---
+
+## 6. HITL flow (the hardest path)
+
+```
+run A → interrupt
+  → session splits it onto input channel → client sees input.requested
+  → SDK watcher SSE registers it in thread.interrupts
+  → client posts commands {input.respond, interrupt_id, response}
+  → commands.py builds Command(resume={interrupt_id: response})
+  → _prepare_run starts run B on the SAME thread
+  → session (still open) picks up run B, streams it → lifecycle: completed
+```
+
+Four fixed regression points (likely places a future change re-breaks HITL):
+
+- **Stream must stay open** across the A→B gap — idle-grace applied after every
+  drain, not exit-on-first-drain.
+- **Assistant recovery** — SDK sends no `assistant_id` on respond; recovered from
+  the thread's most recent run (`_thread_assistant_id`, user-scoped).
+- **Resume race** — the interrupt reaches the client before the run executor
+  commits `thread_status="interrupted"`; a fast respond gets a spurious 400.
+  Fix: after the first read isn't interrupted, poll a few FRESH short-lived
+  sessions before rejecting. Do NOT rollback the request session (broke a v1
+  mocked-session test).
+- **Resume by id** — `Command(resume={interrupt_id: value})` map; langgraph
+  detects a map by all-keys-being-xxh3-128-hexdigests. A bare value RAISES when
+  more than one interrupt is pending. Batch form: `{responses:[{interrupt_id,
+  response}]}` merged into one map. Unknown/malformed id → `no_such_interrupt`.
+
+---
+
+## 7. Security (the config-injection class)
+
+Threat: a client sends another user's `thread_id` (in the path, or smuggled via
+`config.configurable.thread_id`, or via a checkpoint) and runs on their state.
+The checkpointer keys state **solely on thread_id**, so this must be airtight.
+
+Three layers, all present + tested:
+
+1. **Route ownership check** — `_verify_thread_owned_or_new` at the top of BOTH
+   v2 routes → 404 if the path thread_id is owned by another user. Runs before
+   any run work. Tests: `test_cross_tenant_thread_is_404` (both routes).
+2. **Server forces thread_id** — `create_run_config` (`langgraph_service.py`)
+   merges client config additively but then OVERWRITES
+   `configurable.thread_id`/`run_id` with the route-verified values. A body- or
+   checkpoint-supplied thread_id is discarded. The v2 path uses this via
+   `run_executor.py` (shared executor). Tests:
+   `test_create_run_config_ignores_client_thread_id_override`,
+   `test_create_run_config_checkpoint_cannot_override_thread_id`,
+   `test_thread_checkpoint_scoping.py`.
+3. **SQL tenant filter** — every v2 DB query carries `user_id == user.identity`
+   (`_thread_assistant_id`, `_thread_is_interrupted`, the run lister); assistant
+   resolution is `user.identity OR "system"`. Required because `@auth.on` is
+   default-allow when no handler matches (GHSA-m98r-6667-4wq7).
+
+Known latent debt (pre-existing, NOT v2, not exploitable): `update_thread_metadata`
+in `run_preparation.py` reads/updates the thread row with no user_id filter. Only
+reached after the route ownership check passes, so no live hole. Belongs in the
+auth-dispatch hoist workstream (the ThreadService/RunService follow-ups to #401).
+
+---
+
+## 8. Flag / kill switch (operational lever)
+
+`FF_V2_EVENT_STREAMING` — **default ON**. Set `false` → both v2 routes return 503
+(they stay mounted, capability-gated), v2 is dead, v1 fully unaffected. This is
+the **instant rollback** if v2 misbehaves in prod: flip the env var, no code
+redeploy. Also 503 if the runtime is too old (capability probe in
+`capabilities.py` checks for the required langgraph symbols).
+
+---
+
+## 9. Heartbeats
+
+The v2 stream route uses `make_sse_response`, which sets
+`ping=SSE_PING_INTERVAL_SECS` with a cached `: heartbeat` comment frame. Keeps the
+connection warm while the graph is silent (LLM call, sitting on an interrupt) so
+proxies/LBs don't kill an idle SSE. The heartbeat is a comment frame — no seq,
+clients ignore it; it exists purely to keep the socket alive.
+
+---
+
+## 10. Deliberately NOT implemented (don't chase these as bugs)
+
+- **`tools` channel** — silent. The streaming engine (`astream_events v3`) has no
+  tools transformer on the transformer path we use; `StreamToolCallHandler` (added
+  in langgraph 1.2.7) rides the `stream_mode=["tools"]` path, which v3 rejects
+  (v3 builds stream modes only from transformer `required_stream_modes`, and no
+  tools transformer exists). Tool calls + results are still fully visible via the
+  `messages` (content-block `tool_call` chunks) and `values`/`updates` (tool-role
+  messages, matched by `tool_call_id`) channels — verified live. Revisit when
+  langgraph ships a ToolsTransformer: then it's forward the events + promote
+  `__node`→`params.node` + optional tool-output-message mirroring + a capability
+  probe.
+- **WebSocket transport + WS-only commands** (`subscription.*`, `agent.getTree`) —
+  N/A, we're SSE.
+- **Multi-run live interleaving** — runs drain oldest-first; concurrent runs on
+  one thread are not interleaved (newer run's events wait for the older to end).
+  Rare; a bigger redesign if ever needed.
+
+---
+
+## 11. Debug cheat-sheet
+
+| Symptom | First thing to check |
+| --- | --- |
+| client hangs, zero events | broker empty/wedged, or `_drain_run` status backstop |
+| HITL resume returns 400 | resume race (`_validate_resume_command`) or interrupt_id shape |
+| works in prod, not dev (or reverse) | broker fan-out / Redis-vs-in-memory divergence — run `make e2e-both` |
+| wrong event content | `normalizers.py` |
+| wrong channel / no lifecycle / seq off | `session.py` |
+| cross-tenant leak fear | route `_verify_thread_owned_or_new` + `create_run_config` thread_id force |
+| all v2 dead / 503 | `FF_V2_EVENT_STREAMING` off, or capability probe failing |
+| old thread hangs on open | expired-broker wedge → `_drain_run` status backstop |
+
+---
+
+## 12. Test map
+
+- Unit — `tests/unit/test_services/test_event_streaming/` (session, normalizers,
+  commands, protocol, capabilities, broker).
+- Integration — `tests/integration/test_api/test_event_streaming.py` (routes,
+  validation, ownership 404, SSE frames; DB + broker faked).
+- E2E — `tests/e2e/test_event_streaming/test_sdk_v2_e2e.py` (stock langgraph SDK
+  against a real server; the only layer that proves wire compat + the two-SSE
+  fan-out + real HITL). MUST pass in both dev and prod: `make e2e-both`.
+
+Integration canNOT replace e2e: it mocks the broker + DB + real SDK, so the two
+biggest historical bugs (broker fan-out, resume race, expired-broker wedge) are
+invisible to it by construction. Keep both levels.

--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -235,3 +235,78 @@ Events are retained for 1 hour after the run completes.
 <Note>
   In production deployments, SSE events are delivered via Redis pub/sub from workers — the client's SSE connection and the worker executing the run can be on different instances. See the [worker architecture guide](/guides/worker-architecture) for details on how this works.
 </Note>
+
+## Agent Protocol v2 event streaming
+
+The latest LangGraph JS and Python SDKs (including `@langchain/langgraph-sdk` and the Vue/React `useStream()` composables) speak a newer streaming protocol with a dedicated event envelope and a content-block message model. Aegra serves this protocol natively.
+
+<Note>
+  v2 streaming is **on by default** — it's a new endpoint set the SDK targets and has no v1 to break; the legacy `runs/stream` endpoints are unchanged. `FF_V2_EVENT_STREAMING` is a kill switch: set it to `false` to unregister the routes (clients then get `404`) and roll back without a redeploy. The endpoints require a `langgraph` / `langchain-core` new enough to emit native v3 events; the server returns `503` with an upgrade hint if the runtime is too old.
+</Note>
+
+### Using the SDK
+
+The stock LangGraph SDK drives both endpoints for you. Streaming is **thread-scoped**: open the stream, start a run, and consume the events:
+
+```python
+from langgraph_sdk import get_client
+
+client = get_client(url="http://localhost:8000")
+
+async with client.threads.stream(assistant_id="agent") as ts:
+    await ts.run.start(input={"messages": [{"role": "user", "content": "hi"}]})
+    async for event in ts.events:
+        print(event["method"], event["params"]["data"])
+```
+
+The same flow backs the Vue/React `useStream()` composables.
+
+### Endpoints
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /threads/{thread_id}/commands` | Run a command: `run.start` (start a run), `input.respond` (resume an interrupt). Returns a JSON response envelope. |
+| `POST /threads/{thread_id}/stream/events` | Open a channel-filtered SSE stream of the thread's run events. |
+
+The stream is scoped to the **thread**, not a run — you open it, then issue `run.start`, and the events of whatever run executes flow through. The client mints the thread id, and `run.start` creates the thread if it doesn't exist yet.
+
+### Starting a run
+
+```bash
+curl -X POST http://localhost:8000/threads/$THREAD/commands \
+  -H "Content-Type: application/json" \
+  -d '{
+        "id": 1,
+        "method": "run.start",
+        "params": {"assistant_id": "agent", "input": {"messages": [{"role": "user", "content": "hi"}]}}
+      }'
+# → {"type": "success", "id": 1, "result": {"run_id": "..."}}
+```
+
+### Streaming events
+
+The SSE filter is a POST body listing the channels you want — no run id. Pass `since` (the last `seq` you saw) to resume after a dropped connection.
+
+```bash
+curl -N -X POST http://localhost:8000/threads/$THREAD/stream/events \
+  -H "Content-Type: application/json" \
+  -d '{"channels": ["messages", "values", "lifecycle"]}'
+```
+
+The client reads each frame's `data:` line — a protocol event envelope. `seq` is the cursor you echo back as `since`; `event_id` dedups across reconnects; `params.data` is the payload and `params.namespace` the subgraph path:
+
+```
+data: {"type":"event","seq":1,"event_id":"...:1","method":"messages","params":{"data":{"event":"message-start","role":"ai","id":"msg_1"},"namespace":[]}}
+
+data: {"type":"event","seq":2,"event_id":"...:2","method":"messages","params":{"data":{"event":"content-block-delta","index":0,"delta":{"type":"text-delta","text":"Hello"}},"namespace":[]}}
+
+data: {"type":"event","seq":3,"event_id":"...:3","method":"lifecycle","params":{"data":{"event":"completed"},"namespace":[]}}
+```
+
+### Channels
+
+`values`, `updates`, `messages`, `tools`, `lifecycle`, `input`, `checkpoints`, `tasks`, and `custom` (plus `custom:<name>`). Message streams arrive as content-block events (`message-start` → `content-block-delta` → `message-finish`); lifecycle reports `started` / `completed` / `failed` / `interrupted`.
+
+<Note>
+  This first release covers the HTTP SSE + commands path the JS/Python SDKs use, verified end-to-end against the stock `langgraph-sdk`. The WebSocket transport and the `agent.getTree` / `state.fork` / `subscription.*` commands are not yet implemented; SSE filtering via the POST body covers the `useStream()` path without them.
+</Note>

--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -241,7 +241,7 @@ Events are retained for 1 hour after the run completes.
 The latest LangGraph JS and Python SDKs (including `@langchain/langgraph-sdk` and the Vue/React `useStream()` composables) speak a newer streaming protocol with a dedicated event envelope and a content-block message model. Aegra serves this protocol natively.
 
 <Note>
-  v2 streaming is **on by default** — it's a new endpoint set the SDK targets and has no v1 to break; the legacy `runs/stream` endpoints are unchanged. `FF_V2_EVENT_STREAMING` is a kill switch: set it to `false` to unregister the routes (clients then get `404`) and roll back without a redeploy. The endpoints require a `langgraph` / `langchain-core` new enough to emit native v3 events; the server returns `503` with an upgrade hint if the runtime is too old.
+  v2 streaming is **on by default** — it's a new endpoint set the SDK targets and has no v1 to break; the legacy `runs/stream` endpoints are unchanged. `FF_V2_EVENT_STREAMING` is a kill switch: set it to `false` to disable v2 serving (requests return `503` with an enable hint) and roll back without a redeploy. The endpoints also require a `langgraph` / `langchain-core` new enough to emit native v3 events; the server returns `503` with an upgrade hint if the runtime is too old.
 </Note>
 
 ### Using the SDK

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3150,12 +3150,19 @@
         },
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "SSE stream of protocol event envelopes",
             "content": {
-              "application/json": {
-                "schema": {}
-              }
+              "text/event-stream": {}
             }
+          },
+          "400": {
+            "description": "Invalid request (unsupported channels, malformed command)"
+          },
+          "404": {
+            "description": "Thread owned by another user"
+          },
+          "503": {
+            "description": "v2 disabled by flag, or runtime too old for native v3 events"
           },
           "422": {
             "description": "Validation Error",
@@ -3207,6 +3214,15 @@
                 "schema": {}
               }
             }
+          },
+          "400": {
+            "description": "Invalid request (unsupported channels, malformed command)"
+          },
+          "404": {
+            "description": "Thread owned by another user"
+          },
+          "503": {
+            "description": "v2 disabled by flag, or runtime too old for native v3 events"
           },
           "422": {
             "description": "Validation Error",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3118,6 +3118,108 @@
           }
         }
       }
+    },
+    "/threads/{thread_id}/stream/events": {
+      "post": {
+        "tags": [
+          "Event Streaming"
+        ],
+        "summary": "Stream Thread Events",
+        "description": "Open a channel-filtered SSE stream of the thread's run events.\n\nThread-scoped: events for any run on the thread flow through, so a\nclient can open the stream then issue ``run.start``. Each SSE frame's\n``data:`` is a protocol event envelope; ``id:`` is the ``seq`` a client\nechoes back as ``since`` on resume.",
+        "operationId": "stream_thread_events_threads__thread_id__stream_events_post",
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Thread Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventStreamRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/{thread_id}/commands": {
+      "post": {
+        "tags": [
+          "Event Streaming"
+        ],
+        "summary": "Post Thread Command",
+        "description": "Run a single v2 command on the thread and return its response envelope.",
+        "operationId": "post_thread_command_threads__thread_id__commands_post",
+        "parameters": [
+          {
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Thread Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ThreadCommand"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -4239,6 +4341,68 @@
         "title": "CronUpdate",
         "description": "Request body for updating an existing cron job."
       },
+      "EventStreamRequest": {
+        "properties": {
+          "channels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Channels",
+            "description": "Channels to subscribe to (e.g. messages, values, lifecycle)."
+          },
+          "namespaces": {
+            "anyOf": [
+              {
+                "items": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Namespaces",
+            "description": "Subgraph namespace prefixes to include."
+          },
+          "depth": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Depth",
+            "description": "Max subgraph nesting depth to include."
+          },
+          "since": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Since",
+            "description": "Last seq the client saw; events at or below it are skipped on resume."
+          }
+        },
+        "type": "object",
+        "required": [
+          "channels"
+        ],
+        "title": "EventStreamRequest",
+        "description": "Body for ``POST /threads/{thread_id}/stream/events``.\n\nThread-scoped, matching the LangGraph SDK: no run id \u2014 the stream\ncarries events for whatever run(s) execute on the thread."
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -5099,6 +5263,33 @@
         "title": "ThreadCheckpointPostRequest",
         "description": "Request model for fetching thread checkpoint"
       },
+      "ThreadCommand": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id",
+            "description": "Client-assigned command id, echoed in the response."
+          },
+          "method": {
+            "type": "string",
+            "title": "Method",
+            "description": "Command method, e.g. run.start or input.respond."
+          },
+          "params": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Params",
+            "description": "Method parameters."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "method"
+        ],
+        "title": "ThreadCommand",
+        "description": "Body for ``POST /threads/{thread_id}/commands`` (JSON-RPC style)."
+      },
       "ThreadCreate": {
         "properties": {
           "metadata": {
@@ -5669,6 +5860,10 @@
     {
       "name": "Store",
       "description": "Persistent key-value and semantic storage available from any thread."
+    },
+    {
+      "name": "Event Streaming",
+      "description": "Agent Protocol v2 thread event streaming and commands."
     },
     {
       "name": "Health",

--- a/libs/aegra-api/src/aegra_api/api/event_streaming.py
+++ b/libs/aegra-api/src/aegra_api/api/event_streaming.py
@@ -73,7 +73,22 @@ def _require_v2_enabled() -> None:
         raise HTTPException(503, caps.error_message)
 
 
-@router.post("/threads/{thread_id}/stream/events")
+# Error responses both v2 routes can emit, for an accurate OpenAPI contract.
+_V2_ERROR_RESPONSES: dict[int | str, dict[str, str]] = {
+    400: {"description": "Invalid request (unsupported channels, malformed command)"},
+    404: {"description": "Thread owned by another user"},
+    503: {"description": "v2 disabled by flag, or runtime too old for native v3 events"},
+}
+
+
+@router.post(
+    "/threads/{thread_id}/stream/events",
+    response_class=EventSourceResponse,
+    responses={
+        200: {"description": "SSE stream of protocol event envelopes", "content": {"text/event-stream": {}}},
+        **_V2_ERROR_RESPONSES,
+    },
+)
 async def stream_thread_events(
     thread_id: str,
     body: EventStreamRequest,
@@ -106,7 +121,7 @@ async def stream_thread_events(
     return make_sse_response(sse_to_bytes(_frame_events(session_stream)), headers=get_sse_headers())
 
 
-@router.post("/threads/{thread_id}/commands")
+@router.post("/threads/{thread_id}/commands", responses=dict(_V2_ERROR_RESPONSES))
 async def post_thread_command(
     thread_id: str,
     body: ThreadCommand,

--- a/libs/aegra-api/src/aegra_api/api/event_streaming.py
+++ b/libs/aegra-api/src/aegra_api/api/event_streaming.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette import EventSourceResponse
 
 from aegra_api.core.auth_deps import auth_dependency, get_current_user
+from aegra_api.core.orm import Assistant as AssistantORM
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import _get_session_maker
@@ -49,22 +50,25 @@ async def _verify_thread_owned_or_new(session: AsyncSession, thread_id: str, use
 
 
 def _thread_run_lister(thread_id: str, user: User) -> RunLister:
-    """Async callable returning the thread's run ids (oldest first), user-scoped.
+    """Async callable returning the thread's (run_id, status, graph_name) rows (oldest first), user-scoped.
 
     Called repeatedly while a stream is live so a run started after the stream
-    opened is picked up. Each tick uses a short-lived session so a connection
-    is not held for the whole SSE lifetime (see #423).
+    opened is picked up. Status lets the session drain historical runs whose
+    broker events expired instead of tailing them forever; graph_name feeds the
+    run's root lifecycle events. Each tick uses a short-lived session so a
+    connection is not held for the whole SSE lifetime (see #423).
     """
 
-    async def list_run_ids() -> list[str]:
+    async def list_run_ids() -> list[tuple[str, str | None, str | None]]:
         maker = _get_session_maker()
         async with maker() as session:
-            rows = await session.scalars(
-                select(RunORM.run_id)
+            rows = await session.execute(
+                select(RunORM.run_id, RunORM.status, AssistantORM.graph_id)
+                .outerjoin(AssistantORM, RunORM.assistant_id == AssistantORM.assistant_id)
                 .where(RunORM.thread_id == thread_id, RunORM.user_id == user.identity)
                 .order_by(RunORM.created_at.asc())
             )
-            return list(rows.all())
+            return [(run_id, status, graph_id) for run_id, status, graph_id in rows.all()]
 
     return list_run_ids
 
@@ -131,7 +135,14 @@ async def stream_thread_events(
     return make_sse_response(sse_to_bytes(_frame_events(session_stream)), headers=get_sse_headers())
 
 
-@router.post("/threads/{thread_id}/commands", responses=dict(_V2_ERROR_RESPONSES))
+@router.post(
+    "/threads/{thread_id}/commands",
+    responses={
+        200: {"description": "Protocol response envelope (success or error)"},
+        404: {"description": "Thread owned by another user"},
+        503: {"description": "v2 disabled by flag, or runtime too old for native v3 events"},
+    },
+)
 async def post_thread_command(
     thread_id: str,
     body: ThreadCommand,
@@ -151,8 +162,9 @@ async def post_thread_command(
         await _verify_thread_owned_or_new(session, thread_id, user)
         response, _run_id = await handle_command(body.model_dump(), session=session, thread_id=thread_id, user=user)
 
-    status_code = 200 if response.get("type") == "success" else 400
-    return JSONResponse(response, status_code=status_code)
+    # Protocol error envelopes ride HTTP 200 — a client treating non-2xx as a
+    # transport failure would throw before parsing the envelope's error code.
+    return JSONResponse(response, status_code=200)
 
 
 async def _frame_events(session_stream: ThreadEventSession) -> AsyncGenerator[str, None]:

--- a/libs/aegra-api/src/aegra_api/api/event_streaming.py
+++ b/libs/aegra-api/src/aegra_api/api/event_streaming.py
@@ -125,6 +125,8 @@ async def stream_thread_events(
         channels=channels,
         list_run_ids=_thread_run_lister(thread_id, user),
         since=body.since,
+        namespaces=body.namespaces,
+        depth=body.depth,
     )
     return make_sse_response(sse_to_bytes(_frame_events(session_stream)), headers=get_sse_headers())
 

--- a/libs/aegra-api/src/aegra_api/api/event_streaming.py
+++ b/libs/aegra-api/src/aegra_api/api/event_streaming.py
@@ -23,7 +23,7 @@ from sse_starlette import EventSourceResponse
 from aegra_api.core.auth_deps import auth_dependency, get_current_user
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
-from aegra_api.core.orm import get_session
+from aegra_api.core.orm import _get_session_maker
 from aegra_api.core.sse import format_sse_message, get_sse_headers, make_sse_response, sse_to_bytes
 from aegra_api.models import User
 from aegra_api.models.event_streaming import EventStreamRequest, ThreadCommand
@@ -48,20 +48,23 @@ async def _verify_thread_owned_or_new(session: AsyncSession, thread_id: str, use
         raise HTTPException(404, f"Thread '{thread_id}' not found")
 
 
-def _thread_run_lister(session: AsyncSession, thread_id: str, user: User) -> RunLister:
+def _thread_run_lister(thread_id: str, user: User) -> RunLister:
     """Async callable returning the thread's run ids (oldest first), user-scoped.
 
-    Called repeatedly while a stream is live so a run started after the
-    stream opened is picked up. Only the thread owner's runs are listed.
+    Called repeatedly while a stream is live so a run started after the stream
+    opened is picked up. Each tick uses a short-lived session so a connection
+    is not held for the whole SSE lifetime (see #423).
     """
 
     async def list_run_ids() -> list[str]:
-        rows = await session.scalars(
-            select(RunORM.run_id)
-            .where(RunORM.thread_id == thread_id, RunORM.user_id == user.identity)
-            .order_by(RunORM.created_at.asc())
-        )
-        return list(rows.all())
+        maker = _get_session_maker()
+        async with maker() as session:
+            rows = await session.scalars(
+                select(RunORM.run_id)
+                .where(RunORM.thread_id == thread_id, RunORM.user_id == user.identity)
+                .order_by(RunORM.created_at.asc())
+            )
+            return list(rows.all())
 
     return list_run_ids
 
@@ -93,7 +96,6 @@ async def stream_thread_events(
     thread_id: str,
     body: EventStreamRequest,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> EventSourceResponse:
     """Open a channel-filtered SSE stream of the thread's run events.
 
@@ -101,21 +103,27 @@ async def stream_thread_events(
     client can open the stream then issue ``run.start``. Each SSE frame's
     ``data:`` is a protocol event envelope; ``id:`` is the ``seq`` a client
     echoes back as ``since`` on resume.
+
+    DB work runs in short-lived sessions (the upfront ownership check here, and
+    each run-lister poll) so no connection is held for the SSE lifetime (#423).
     """
     _require_v2_enabled()
-    # The SDK opens the stream (lifecycle watcher) before run.start, against a
-    # thread it minted client-side — so a not-yet-existing thread is allowed;
-    # a thread owned by another user is not.
-    await _verify_thread_owned_or_new(session, thread_id, user)
 
     channels, invalid = validate_channels(body.channels)
     if invalid:
         raise HTTPException(400, f"Unsupported channels: {', '.join(invalid)}")
 
+    # The SDK opens the stream before run.start, against a thread it minted
+    # client-side — a not-yet-existing thread is allowed; one owned by another
+    # user is not.
+    maker = _get_session_maker()
+    async with maker() as session:
+        await _verify_thread_owned_or_new(session, thread_id, user)
+
     session_stream = ThreadEventSession(
         thread_id,
         channels=channels,
-        list_run_ids=_thread_run_lister(session, thread_id, user),
+        list_run_ids=_thread_run_lister(thread_id, user),
         since=body.since,
     )
     return make_sse_response(sse_to_bytes(_frame_events(session_stream)), headers=get_sse_headers())
@@ -126,15 +134,21 @@ async def post_thread_command(
     thread_id: str,
     body: ThreadCommand,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
-    """Run a single v2 command on the thread and return its response envelope."""
-    _require_v2_enabled()
-    # run.start may target a not-yet-created thread (the SDK mints the id and
-    # expects run preparation to create it); other ownership is enforced there.
-    await _verify_thread_owned_or_new(session, thread_id, user)
+    """Run a single v2 command on the thread and return its response envelope.
 
-    response, _run_id = await handle_command(body.model_dump(), session=session, thread_id=thread_id, user=user)
+    Uses a short-lived session (the run created by ``run.start`` executes on
+    the worker; the response returns before streaming begins).
+    """
+    _require_v2_enabled()
+
+    maker = _get_session_maker()
+    async with maker() as session:
+        # run.start may target a not-yet-created thread (the SDK mints the id and
+        # expects run preparation to create it); other ownership is enforced there.
+        await _verify_thread_owned_or_new(session, thread_id, user)
+        response, _run_id = await handle_command(body.model_dump(), session=session, thread_id=thread_id, user=user)
+
     status_code = 200 if response.get("type") == "success" else 400
     return JSONResponse(response, status_code=status_code)
 

--- a/libs/aegra-api/src/aegra_api/api/event_streaming.py
+++ b/libs/aegra-api/src/aegra_api/api/event_streaming.py
@@ -1,0 +1,130 @@
+"""Agent Protocol v2 event streaming endpoints.
+
+* ``POST /threads/{thread_id}/stream/events`` — SSE stream of a run's
+  events, filtered by channel. Body is an ``EventStreamRequest``.
+* ``POST /threads/{thread_id}/commands`` — run a thread command
+  (``run.start``, ``input.respond``) and get a JSON response envelope.
+
+Both gate on the ``FF_V2_EVENT_STREAMING`` flag + runtime capability, and
+verify thread (and run) ownership before doing anything.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sse_starlette import EventSourceResponse
+
+from aegra_api.core.auth_deps import auth_dependency, get_current_user
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.core.orm import get_session
+from aegra_api.core.sse import format_sse_message, get_sse_headers, make_sse_response, sse_to_bytes
+from aegra_api.models import User
+from aegra_api.models.event_streaming import EventStreamRequest, ThreadCommand
+from aegra_api.services.event_streaming.capabilities import get_v2_capabilities
+from aegra_api.services.event_streaming.commands import handle_command
+from aegra_api.services.event_streaming.session import RunLister, ThreadEventSession, validate_channels
+
+logger = structlog.getLogger(__name__)
+
+router = APIRouter(tags=["Event Streaming"], dependencies=auth_dependency)
+
+
+async def _verify_thread_owned_or_new(session: AsyncSession, thread_id: str, user: User) -> None:
+    """Allow a not-yet-existing thread; block one owned by someone else.
+
+    The SDK mints the thread id client-side and expects ``run.start`` to
+    create it (run preparation does, owned by the caller). So a missing
+    thread is fine here; an existing thread owned by another user is 404.
+    """
+    existing_owner = await session.scalar(select(ThreadORM.user_id).where(ThreadORM.thread_id == thread_id))
+    if existing_owner is not None and existing_owner != user.identity:
+        raise HTTPException(404, f"Thread '{thread_id}' not found")
+
+
+def _thread_run_lister(session: AsyncSession, thread_id: str, user: User) -> RunLister:
+    """Async callable returning the thread's run ids (oldest first), user-scoped.
+
+    Called repeatedly while a stream is live so a run started after the
+    stream opened is picked up. Only the thread owner's runs are listed.
+    """
+
+    async def list_run_ids() -> list[str]:
+        rows = await session.scalars(
+            select(RunORM.run_id)
+            .where(RunORM.thread_id == thread_id, RunORM.user_id == user.identity)
+            .order_by(RunORM.created_at.asc())
+        )
+        return list(rows.all())
+
+    return list_run_ids
+
+
+def _require_v2_enabled() -> None:
+    """503 with a clear reason when v2 is off or the runtime can't serve it."""
+    caps = get_v2_capabilities()
+    if not caps.ok:
+        raise HTTPException(503, caps.error_message)
+
+
+@router.post("/threads/{thread_id}/stream/events")
+async def stream_thread_events(
+    thread_id: str,
+    body: EventStreamRequest,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> EventSourceResponse:
+    """Open a channel-filtered SSE stream of the thread's run events.
+
+    Thread-scoped: events for any run on the thread flow through, so a
+    client can open the stream then issue ``run.start``. Each SSE frame's
+    ``data:`` is a protocol event envelope; ``id:`` is the ``seq`` a client
+    echoes back as ``since`` on resume.
+    """
+    _require_v2_enabled()
+    # The SDK opens the stream (lifecycle watcher) before run.start, against a
+    # thread it minted client-side — so a not-yet-existing thread is allowed;
+    # a thread owned by another user is not.
+    await _verify_thread_owned_or_new(session, thread_id, user)
+
+    channels, invalid = validate_channels(body.channels)
+    if invalid:
+        raise HTTPException(400, f"Unsupported channels: {', '.join(invalid)}")
+
+    session_stream = ThreadEventSession(
+        thread_id,
+        channels=channels,
+        list_run_ids=_thread_run_lister(session, thread_id, user),
+        since=body.since,
+    )
+    return make_sse_response(sse_to_bytes(_frame_events(session_stream)), headers=get_sse_headers())
+
+
+@router.post("/threads/{thread_id}/commands")
+async def post_thread_command(
+    thread_id: str,
+    body: ThreadCommand,
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> JSONResponse:
+    """Run a single v2 command on the thread and return its response envelope."""
+    _require_v2_enabled()
+    # run.start may target a not-yet-created thread (the SDK mints the id and
+    # expects run preparation to create it); other ownership is enforced there.
+    await _verify_thread_owned_or_new(session, thread_id, user)
+
+    response, _run_id = await handle_command(body.model_dump(), session=session, thread_id=thread_id, user=user)
+    status_code = 200 if response.get("type") == "success" else 400
+    return JSONResponse(response, status_code=status_code)
+
+
+async def _frame_events(session_stream: ThreadEventSession) -> AsyncGenerator[str, None]:
+    """Frame v2 event envelopes as SSE messages (event=method, data=envelope, id=seq)."""
+    async for envelope in session_stream.stream():
+        yield format_sse_message(envelope["method"], envelope, str(envelope["seq"]))

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -14,6 +14,7 @@ from fastapi.routing import APIRoute, APIRouter
 from aegra_api import __version__
 from aegra_api.api.assistants import router as assistants_router
 from aegra_api.api.crons import router as crons_router
+from aegra_api.api.event_streaming import router as event_streaming_router
 from aegra_api.api.runs import router as runs_router
 from aegra_api.api.stateless_runs import router as stateless_runs_router
 from aegra_api.api.store import router as store_router
@@ -48,6 +49,7 @@ OPENAPI_TAGS: list[dict[str, Any]] = [
     {"name": "Stateless Runs", "description": "Invoke a graph without state or memory persistence."},
     {"name": "Crons", "description": "Scheduled recurring runs on a cron schedule."},
     {"name": "Store", "description": "Persistent key-value and semantic storage available from any thread."},
+    {"name": "Event Streaming", "description": "Agent Protocol v2 thread event streaming and commands."},
     {"name": "Health", "description": "Server health checks and service information."},
 ]
 
@@ -308,6 +310,7 @@ def _include_core_routers(app: FastAPI) -> None:
     app.include_router(stateless_runs_router)
     app.include_router(crons_router)
     app.include_router(store_router)
+    app.include_router(event_streaming_router)
 
 
 def create_app() -> FastAPI:

--- a/libs/aegra-api/src/aegra_api/models/event_streaming.py
+++ b/libs/aegra-api/src/aegra_api/models/event_streaming.py
@@ -1,0 +1,32 @@
+"""Request models for Agent Protocol v2 event streaming endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class EventStreamRequest(BaseModel):
+    """Body for ``POST /threads/{thread_id}/stream/events``.
+
+    Thread-scoped, matching the LangGraph SDK: no run id — the stream
+    carries events for whatever run(s) execute on the thread.
+    """
+
+    channels: list[str] = Field(..., description="Channels to subscribe to (e.g. messages, values, lifecycle).")
+    namespaces: list[list[str]] | None = Field(None, description="Subgraph namespace prefixes to include.")
+    depth: int | None = Field(None, ge=0, description="Max subgraph nesting depth to include.")
+    since: int | None = Field(
+        None,
+        ge=0,
+        description="Last seq the client saw; events at or below it are skipped on resume.",
+    )
+
+
+class ThreadCommand(BaseModel):
+    """Body for ``POST /threads/{thread_id}/commands`` (JSON-RPC style)."""
+
+    id: int = Field(..., description="Client-assigned command id, echoed in the response.")
+    method: str = Field(..., description="Command method, e.g. run.start or input.respond.")
+    params: dict[str, Any] = Field(default_factory=dict, description="Method parameters.")

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -41,6 +41,8 @@ class RunExecution(BaseModel):
     stream_mode: str | list[str] | None = None
     checkpoint: dict[str, Any] | None = None
     command: dict[str, Any] | None = None
+    # When true, stream via the native v3 protocol producer for Agent Protocol v2.
+    event_streaming_v2: bool = False
 
 
 class RunBehavior(BaseModel):

--- a/libs/aegra-api/src/aegra_api/services/broker.py
+++ b/libs/aegra-api/src/aegra_api/services/broker.py
@@ -20,17 +20,19 @@ logger = structlog.getLogger(__name__)
 
 
 class RunBroker(BaseRunBroker):
-    """In-memory broker backed by asyncio.Queue + replay buffer.
+    """In-memory broker with per-subscriber fan-out + replay buffer.
 
-    The queue delivers events to live subscribers.
-    The replay buffer keeps a copy of resumable events for replay on reconnect.
+    Each ``aiter()`` caller gets its own queue fed by ``put`` — so multiple
+    concurrent SSE consumers on one run (e.g. the v2 SDK's main event stream and
+    its separate lifecycle-watcher) each receive every event, matching the Redis
+    pub/sub backend. The replay buffer keeps resumable events for reconnect.
     """
 
     def __init__(self, run_id: str) -> None:
         self.run_id = run_id
-        self.queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
         self.finished = asyncio.Event()
         self._replay_buffer: list[tuple[str, Any]] = []
+        self._subscribers: set[asyncio.Queue[tuple[str, Any]]] = set()
         self._created_at = asyncio.get_running_loop().time()
 
     async def put(self, event_id: str, payload: Any, *, resumable: bool = True) -> None:
@@ -41,24 +43,37 @@ class RunBroker(BaseRunBroker):
         if resumable:
             self._replay_buffer.append((event_id, payload))
 
-        await self.queue.put((event_id, payload))
+        for queue in list(self._subscribers):
+            queue.put_nowait((event_id, payload))
 
         # Check if this is an end event
         if isinstance(payload, tuple) and len(payload) >= 1 and payload[0] == "end":
             self.mark_finished()
 
     async def aiter(self) -> AsyncIterator[tuple[str, Any]]:
-        while True:
-            try:
-                event_id, payload = await asyncio.wait_for(self.queue.get(), timeout=0.1)
+        queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+        # Register, then replay the buffer into this iterator: any event put
+        # between a caller's separate replay() and this registration is still in
+        # the buffer, so nothing is dropped. Callers dedup the overlap by event_id.
+        self._subscribers.add(queue)
+        backlog = list(self._replay_buffer)
+        try:
+            for event_id, payload in backlog:
                 yield event_id, payload
-
+                if isinstance(payload, tuple) and len(payload) >= 1 and payload[0] == "end":
+                    return
+            while True:
+                try:
+                    event_id, payload = await asyncio.wait_for(queue.get(), timeout=0.1)
+                except TimeoutError:
+                    if self.finished.is_set() and queue.empty():
+                        break
+                    continue
+                yield event_id, payload
                 if isinstance(payload, tuple) and len(payload) >= 1 and payload[0] == "end":
                     break
-            except TimeoutError:
-                if self.finished.is_set() and self.queue.empty():
-                    break
-                continue
+        finally:
+            self._subscribers.discard(queue)
 
     async def replay(self, last_event_id: str | None) -> list[tuple[str, Any]]:
         if not self._replay_buffer:
@@ -83,7 +98,7 @@ class RunBroker(BaseRunBroker):
         return self.finished.is_set()
 
     def is_empty(self) -> bool:
-        return self.queue.empty()
+        return all(queue.empty() for queue in self._subscribers)
 
     def get_age(self) -> float:
         return asyncio.get_running_loop().time() - self._created_at

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/__init__.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/__init__.py
@@ -1,0 +1,6 @@
+"""Agent Protocol v2 event streaming.
+
+Thread-scoped SSE streaming and command transport, layered over the
+existing run broker. Isolated from the legacy ``runs/stream`` path so the
+v2 logic can be reviewed and feature-flagged on its own.
+"""

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/capabilities.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/capabilities.py
@@ -1,0 +1,90 @@
+"""Runtime probe for Agent Protocol v2 streaming support.
+
+The installed ``langgraph`` / ``langchain-core`` must be new enough to emit
+native content-block message events. Rather than let a too-old runtime
+surface as a mid-stream ImportError or a silently-empty message stream, we
+probe the required symbols once and reject up front with a clear message.
+
+Capability (can the runtime serve v2?) is separate from the feature flag
+(is v2 turned on?) — they produce different remediation: "upgrade deps" vs
+"flip FF_V2_EVENT_STREAMING".
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from functools import lru_cache
+
+from aegra_api.settings import settings
+
+# (module, attribute) pairs that a v2 run depends on. Submodule paths are
+# intentional — these are not re-exported from the package top level.
+_REQUIRED_SYMBOLS: tuple[tuple[str, str], ...] = (
+    ("langgraph.pregel._messages", "StreamMessagesHandlerV2"),
+    ("langgraph.pregel._tools", "StreamToolCallHandler"),
+    ("langgraph.stream._mux", "StreamMux"),
+    ("langgraph.stream.transformers", "LifecycleTransformer"),
+    ("langchain_core.language_models.chat_model_stream", "ChatModelStream"),
+    ("langchain_core.language_models.chat_model_stream", "AsyncChatModelStream"),
+    ("langchain_core.language_models._compat_bridge", "message_to_events"),
+)
+
+
+@dataclass(frozen=True)
+class V2Capabilities:
+    """Outcome of the runtime + flag probe for v2 event streaming."""
+
+    ok: bool
+    missing: tuple[str, ...] = ()
+    disabled_by_flag: bool = False
+
+    @property
+    def error_message(self) -> str:
+        """Human-readable reason, suitable for an error envelope or 400 body."""
+        if self.ok:
+            return ""
+        if self.disabled_by_flag:
+            return (
+                "Agent Protocol v2 event streaming is disabled on this server "
+                "(FF_V2_EVENT_STREAMING=false). Set FF_V2_EVENT_STREAMING=true to enable."
+            )
+        return (
+            "Agent Protocol v2 event streaming is not supported by the installed "
+            "langgraph/langchain-core version. Missing symbol(s): "
+            + ", ".join(self.missing)
+            + ". Upgrade langgraph and langchain-core to releases that ship the "
+            "new streaming framework."
+        )
+
+
+@lru_cache(maxsize=1)
+def _probe_runtime_symbols() -> tuple[str, ...]:
+    """Return the missing required symbols (empty tuple means supported).
+
+    Memoised: the installed packages can't change without a process restart.
+    """
+    missing: list[str] = []
+    for module_path, attr in _REQUIRED_SYMBOLS:
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError:
+            missing.append(f"{module_path}.{attr}")
+            continue
+        if not hasattr(module, attr):
+            missing.append(f"{module_path}.{attr}")
+    return tuple(missing)
+
+
+def get_v2_capabilities() -> V2Capabilities:
+    """Resolve whether v2 event streaming can be served right now.
+
+    Checks the feature flag first, then the runtime symbols. The flag is
+    read live (not cached) so it stays honest under settings overrides in
+    tests; the symbol probe is memoised.
+    """
+    if not settings.event_streaming.FF_V2_EVENT_STREAMING:
+        return V2Capabilities(ok=False, disabled_by_flag=True)
+
+    missing = _probe_runtime_symbols()
+    return V2Capabilities(ok=not missing, missing=missing)

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/channels.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/channels.py
@@ -1,0 +1,34 @@
+"""Channel constants for Agent Protocol v2 event streaming.
+
+A channel is a top-level event stream a client subscribes to (the
+``method`` of a server event). These mirror the protocol's channel set;
+``custom:<name>`` is also accepted for user-defined custom events.
+"""
+
+from __future__ import annotations
+
+# Channels a client may request on the SSE filter / subscribe.
+SUPPORTED_CHANNELS: frozenset[str] = frozenset(
+    {
+        "values",
+        "updates",
+        "messages",
+        "tools",
+        "lifecycle",
+        "input",
+        "checkpoints",
+        "tasks",
+        "custom",
+    }
+)
+
+_CUSTOM_CHANNEL_PREFIX = "custom:"
+
+
+def is_supported_channel(channel: str) -> bool:
+    """True for a known channel or a non-empty ``custom:<name>`` channel."""
+    if channel in SUPPORTED_CHANNELS:
+        return True
+    if channel.startswith(_CUSTOM_CHANNEL_PREFIX):
+        return len(channel) > len(_CUSTOM_CHANNEL_PREFIX)
+    return False

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
@@ -9,6 +9,7 @@ identical; only the transport differs.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import structlog
@@ -18,6 +19,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.models import User
 from aegra_api.models.runs import RunCreate
 from aegra_api.services.event_streaming.protocol import ErrorCode, build_error, build_success
@@ -64,6 +66,7 @@ async def handle_command(
     # Run preparation raises HTTPException (unknown assistant/graph, bad resume)
     # and RunCreate raises ValidationError on malformed params. Map both to a
     # protocol error envelope so the client never sees FastAPI's {detail: ...}.
+    # Anything else becomes unknown_error — an RPC response must stay an envelope.
     try:
         if method == "run.start":
             return await _run_start(command_id, params, session=session, thread_id=thread_id, user=user)
@@ -73,8 +76,14 @@ async def handle_command(
         return build_error(command_id, _status_to_error_code(exc.status_code), str(exc.detail)), None
     except ValidationError as exc:
         return build_error(command_id, "invalid_argument", str(exc.errors()[0].get("msg", "invalid params"))), None
+    except Exception:
+        logger.exception("Unhandled error dispatching v2 command", method=method, thread_id=thread_id)
+        return build_error(command_id, "unknown_error", f"Command {method!r} failed unexpectedly."), None
 
-    return build_error(command_id, "not_supported", f"Command {method!r} is not supported."), None
+    return build_error(command_id, "unknown_command", f"Unknown command {method!r}."), None
+
+
+_MULTITASK_STRATEGIES = frozenset({"reject", "rollback", "interrupt", "enqueue"})
 
 
 async def _run_start(
@@ -90,19 +99,47 @@ async def _run_start(
     if not isinstance(assistant_id, str) or not assistant_id:
         return build_error(command_id, "invalid_argument", "run.start requires a string assistant_id."), None
 
+    multitask = params.get("multitaskStrategy", params.get("multitask_strategy"))
+    if multitask is not None and multitask not in _MULTITASK_STRATEGIES:
+        return build_error(command_id, "invalid_argument", f"Unknown multitaskStrategy {multitask!r}."), None
+
+    # run.start with input on an interrupted thread means "answer the pending
+    # interrupt" — resume with the input instead of starting a fresh turn that
+    # would discard the pending tasks.
+    input_data = params.get("input")
+    command: dict[str, Any] | None = None
+    if input_data is not None and await _thread_is_interrupted(session, thread_id, user):
+        command = {"resume": input_data}
+        input_data = None
+
     # No stream_mode: v2 runs stream via the native v3 path, which selects
     # channels through transformers, not stream_mode. interrupt_before/after are
     # forwarded so v2 clients can set node-level HITL breakpoints like v1.
+    # applied_through_seq is 0 on this stateless POST transport (no stream binding).
     request = RunCreate(
         assistant_id=assistant_id,
-        input=params.get("input"),
+        input=input_data,
+        command=command,
         config=params.get("config") or {},
         metadata=params.get("metadata"),
         interrupt_before=params.get("interrupt_before"),
         interrupt_after=params.get("interrupt_after"),
+        multitask_strategy=multitask,
     )
     run_id = await _start(session, thread_id, request, user)
-    return build_success(command_id, {"run_id": run_id}), run_id
+    return build_success(command_id, {"run_id": run_id}, applied_through_seq=0), run_id
+
+
+async def _thread_is_interrupted(session: AsyncSession, thread_id: str, user: User) -> bool:
+    status = await session.scalar(
+        select(ThreadORM.status).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
+    )
+    return status == "interrupted"
+
+
+# langgraph interrupt ids are xxh3-128 hexdigests; a resume map is only
+# recognized as id-targeted when every key matches this shape.
+_INTERRUPT_ID_PATTERN = re.compile(r"[0-9a-f]{32}")
 
 
 async def _input_respond(
@@ -117,10 +154,15 @@ async def _input_respond(
 
     The stock SDK's ``input.respond`` sends only ``{interrupt_id, namespace,
     response}`` — no assistant. Recover the assistant from the thread's most
-    recent run so a resume works without the client re-supplying it.
+    recent run so a resume works without the client re-supplying it. A supplied
+    ``interrupt_id`` targets that interrupt via an id-keyed resume map (the only
+    form that works with multiple pending interrupts); the batch ``responses``
+    form merges several targets into one resume.
     """
-    if "response" not in params:
-        return build_error(command_id, "invalid_argument", "input.respond requires a response value."), None
+    resume, error = _build_resume(params)
+    if error is not None:
+        code, message = error
+        return build_error(command_id, code, message), None
 
     assistant_id = params.get("assistant_id")
     if not isinstance(assistant_id, str) or not assistant_id:
@@ -131,10 +173,42 @@ async def _input_respond(
     request = RunCreate(
         assistant_id=assistant_id,
         config=params.get("config") or {},
-        command={"resume": params["response"]},
+        metadata=params.get("metadata"),
+        command={"resume": resume},
     )
     run_id = await _start(session, thread_id, request, user)
-    return build_success(command_id, {"run_id": run_id}), run_id
+    return build_success(command_id, {"run_id": run_id}, applied_through_seq=0), run_id
+
+
+def _build_resume(params: dict[str, Any]) -> tuple[Any, tuple[ErrorCode, str] | None]:
+    """Build the resume value from single or batch input.respond params.
+
+    Returns ``(resume, None)`` or ``(None, (error_code, message))``.
+    """
+    responses = params.get("responses")
+    if isinstance(responses, list):
+        resume_map: dict[str, Any] = {}
+        for entry in responses:
+            if not isinstance(entry, dict) or "response" not in entry:
+                return None, ("invalid_argument", "Each responses entry requires interrupt_id and response.")
+            interrupt_id = entry.get("interrupt_id")
+            if not isinstance(interrupt_id, str) or not _INTERRUPT_ID_PATTERN.fullmatch(interrupt_id):
+                return None, ("no_such_interrupt", f"Unknown interrupt id {interrupt_id!r}.")
+            resume_map[interrupt_id] = entry["response"]
+        if not resume_map:
+            return None, ("invalid_argument", "responses must be a non-empty array.")
+        return resume_map, None
+
+    if "response" not in params:
+        return None, ("invalid_argument", "input.respond requires a response value.")
+
+    interrupt_id = params.get("interrupt_id")
+    if interrupt_id is None:
+        # Untargeted resume: valid only while a single interrupt is pending.
+        return params["response"], None
+    if not isinstance(interrupt_id, str) or not _INTERRUPT_ID_PATTERN.fullmatch(interrupt_id):
+        return None, ("no_such_interrupt", f"Unknown interrupt id {interrupt_id!r}.")
+    return {interrupt_id: params["response"]}, None
 
 
 async def _thread_assistant_id(session: AsyncSession, thread_id: str, user: User) -> str | None:

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
@@ -91,12 +91,15 @@ async def _run_start(
         return build_error(command_id, "invalid_argument", "run.start requires a string assistant_id."), None
 
     # No stream_mode: v2 runs stream via the native v3 path, which selects
-    # channels through transformers, not stream_mode.
+    # channels through transformers, not stream_mode. interrupt_before/after are
+    # forwarded so v2 clients can set node-level HITL breakpoints like v1.
     request = RunCreate(
         assistant_id=assistant_id,
         input=params.get("input"),
         config=params.get("config") or {},
         metadata=params.get("metadata"),
+        interrupt_before=params.get("interrupt_before"),
+        interrupt_after=params.get("interrupt_after"),
     )
     run_id = await _start(session, thread_id, request, user)
     return build_success(command_id, {"run_id": run_id}), run_id

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
@@ -14,8 +14,10 @@ from typing import Any
 import structlog
 from fastapi import HTTPException
 from pydantic import ValidationError
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from aegra_api.core.orm import Run as RunORM
 from aegra_api.models import User
 from aegra_api.models.runs import RunCreate
 from aegra_api.services.event_streaming.protocol import ErrorCode, build_error, build_success
@@ -108,12 +110,20 @@ async def _input_respond(
     thread_id: str,
     user: User,
 ) -> tuple[dict[str, Any], str | None]:
-    """Resume an interrupted run by replaying a HITL response as a command."""
-    assistant_id = params.get("assistant_id")
-    if not isinstance(assistant_id, str) or not assistant_id:
-        return build_error(command_id, "invalid_argument", "input.respond requires a string assistant_id."), None
+    """Resume an interrupted run by replaying a HITL response as a command.
+
+    The stock SDK's ``input.respond`` sends only ``{interrupt_id, namespace,
+    response}`` — no assistant. Recover the assistant from the thread's most
+    recent run so a resume works without the client re-supplying it.
+    """
     if "response" not in params:
         return build_error(command_id, "invalid_argument", "input.respond requires a response value."), None
+
+    assistant_id = params.get("assistant_id")
+    if not isinstance(assistant_id, str) or not assistant_id:
+        assistant_id = await _thread_assistant_id(session, thread_id, user)
+    if not assistant_id:
+        return build_error(command_id, "no_such_run", "No run on this thread to resume."), None
 
     request = RunCreate(
         assistant_id=assistant_id,
@@ -122,6 +132,16 @@ async def _input_respond(
     )
     run_id = await _start(session, thread_id, request, user)
     return build_success(command_id, {"run_id": run_id}), run_id
+
+
+async def _thread_assistant_id(session: AsyncSession, thread_id: str, user: User) -> str | None:
+    """The assistant bound to the thread's most recent run, user-scoped."""
+    return await session.scalar(
+        select(RunORM.assistant_id)
+        .where(RunORM.thread_id == thread_id, RunORM.user_id == user.identity)
+        .order_by(RunORM.created_at.desc())
+        .limit(1)
+    )
 
 
 async def _start(session: AsyncSession, thread_id: str, request: RunCreate, user: User) -> str:

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
@@ -1,0 +1,132 @@
+"""Dispatch Agent Protocol v2 thread commands.
+
+Commands are JSON-RPC-style: ``{id, method, params}`` in, a success or
+error envelope out. They re-front the existing run machinery — ``run.start``
+and ``input.respond`` both build a ``RunCreate`` and go through the same
+``_prepare_run`` path the legacy endpoints use, so execution semantics are
+identical; only the transport differs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from fastapi import HTTPException
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aegra_api.models import User
+from aegra_api.models.runs import RunCreate
+from aegra_api.services.event_streaming.protocol import ErrorCode, build_error, build_success
+from aegra_api.services.run_preparation import _prepare_run
+
+logger = structlog.getLogger(__name__)
+
+
+def _status_to_error_code(status_code: int) -> ErrorCode:
+    """Map an HTTP status from run preparation to a protocol error code."""
+    if status_code == 404:
+        return "no_such_run"
+    if status_code == 403:
+        return "permission_denied"
+    return "invalid_argument"
+
+
+async def handle_command(
+    payload: dict[str, Any],
+    *,
+    session: AsyncSession,
+    thread_id: str,
+    user: User,
+) -> tuple[dict[str, Any], str | None]:
+    """Dispatch one command. Returns ``(response_envelope, started_run_id)``.
+
+    ``started_run_id`` is the run a ``run.start`` / ``input.respond`` created,
+    so the caller can open a stream for it; ``None`` for other commands.
+    """
+    command_id = payload.get("id")
+    method = payload.get("method")
+    params = payload.get("params")
+
+    if not isinstance(command_id, int) or not isinstance(method, str):
+        return build_error(
+            command_id if isinstance(command_id, int) else None,
+            "invalid_argument",
+            "Commands must include an integer id and string method.",
+        ), None
+
+    if not isinstance(params, dict):
+        return build_error(command_id, "invalid_argument", "params must be an object."), None
+
+    # Run preparation raises HTTPException (unknown assistant/graph, bad resume)
+    # and RunCreate raises ValidationError on malformed params. Map both to a
+    # protocol error envelope so the client never sees FastAPI's {detail: ...}.
+    try:
+        if method == "run.start":
+            return await _run_start(command_id, params, session=session, thread_id=thread_id, user=user)
+        if method == "input.respond":
+            return await _input_respond(command_id, params, session=session, thread_id=thread_id, user=user)
+    except HTTPException as exc:
+        return build_error(command_id, _status_to_error_code(exc.status_code), str(exc.detail)), None
+    except ValidationError as exc:
+        return build_error(command_id, "invalid_argument", str(exc.errors()[0].get("msg", "invalid params"))), None
+
+    return build_error(command_id, "not_supported", f"Command {method!r} is not supported."), None
+
+
+async def _run_start(
+    command_id: int,
+    params: dict[str, Any],
+    *,
+    session: AsyncSession,
+    thread_id: str,
+    user: User,
+) -> tuple[dict[str, Any], str | None]:
+    """Start a run on the thread from ``RunStartParams``."""
+    assistant_id = params.get("assistant_id")
+    if not isinstance(assistant_id, str) or not assistant_id:
+        return build_error(command_id, "invalid_argument", "run.start requires a string assistant_id."), None
+
+    # No stream_mode: v2 runs stream via the native v3 path, which selects
+    # channels through transformers, not stream_mode.
+    request = RunCreate(
+        assistant_id=assistant_id,
+        input=params.get("input"),
+        config=params.get("config") or {},
+        metadata=params.get("metadata"),
+    )
+    run_id = await _start(session, thread_id, request, user)
+    return build_success(command_id, {"run_id": run_id}), run_id
+
+
+async def _input_respond(
+    command_id: int,
+    params: dict[str, Any],
+    *,
+    session: AsyncSession,
+    thread_id: str,
+    user: User,
+) -> tuple[dict[str, Any], str | None]:
+    """Resume an interrupted run by replaying a HITL response as a command."""
+    assistant_id = params.get("assistant_id")
+    if not isinstance(assistant_id, str) or not assistant_id:
+        return build_error(command_id, "invalid_argument", "input.respond requires a string assistant_id."), None
+    if "response" not in params:
+        return build_error(command_id, "invalid_argument", "input.respond requires a response value."), None
+
+    request = RunCreate(
+        assistant_id=assistant_id,
+        config=params.get("config") or {},
+        command={"resume": params["response"]},
+    )
+    run_id = await _start(session, thread_id, request, user)
+    return build_success(command_id, {"run_id": run_id}), run_id
+
+
+async def _start(session: AsyncSession, thread_id: str, request: RunCreate, user: User) -> str:
+    """Persist + enqueue a run via the shared preparation path (native v3 stream)."""
+    run_id, _run, _job = await _prepare_run(
+        session, thread_id, request, user, initial_status="pending", event_streaming_v2=True
+    )
+    return run_id

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/native_stream.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/native_stream.py
@@ -18,25 +18,24 @@ from collections.abc import AsyncIterator
 from functools import lru_cache
 from typing import Any
 
-import structlog
-
-logger = structlog.getLogger(__name__)
-
 
 @lru_cache(maxsize=1)
 def _extra_transformers() -> list[Any]:
-    """Transformers that enable the non-default v3 channels.
+    """Transformers enabling the non-default v3 channels (updates/custom/checkpoints/tasks).
 
-    The v3 mux ships values/messages/lifecycle/subgraph by default; these add
-    updates/custom/checkpoints/tasks so every protocol channel can carry data.
-    Imported lazily so a too-old langgraph fails the capability probe, not here.
+    The default v3 mux ships only values/messages/lifecycle/subgraph.
     """
-    from langgraph.stream.transformers import (
-        CheckpointsTransformer,
-        CustomTransformer,
-        TasksTransformer,
-        UpdatesTransformer,
-    )
+    # Optional-dep guard: a too-old langgraph should fail the capability probe,
+    # but if it's bypassed surface a clean error, not a raw ImportError mid-run.
+    try:
+        from langgraph.stream.transformers import (
+            CheckpointsTransformer,
+            CustomTransformer,
+            TasksTransformer,
+            UpdatesTransformer,
+        )
+    except ImportError as exc:
+        raise RuntimeError("langgraph.stream.transformers unavailable; run the v2 capability probe first.") from exc
 
     return [UpdatesTransformer, CustomTransformer, CheckpointsTransformer, TasksTransformer]
 

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/native_stream.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/native_stream.py
@@ -1,0 +1,90 @@
+"""Drive a run through langgraph's native v3 stream for Agent Protocol v2.
+
+``astream_events(version="v3")`` emits events already in protocol shape —
+``{type:"event", method, params:{data, namespace, ...}}`` — including the
+content-block message lifecycle, tool-call blocks, token usage, and
+``params.interrupts``. We forward those into the broker verbatim; the
+session restamps seq/event_id and filters by channel. This is the v2
+counterpart to the legacy ``stream_graph_events`` (v1) producer and does
+not touch it.
+
+The only reshaping here: ``messages`` events arrive as ``[event, metadata]``
+tuples, so we unwrap element 0 into ``params.data``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from functools import lru_cache
+from typing import Any
+
+import structlog
+
+logger = structlog.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _extra_transformers() -> list[Any]:
+    """Transformers that enable the non-default v3 channels.
+
+    The v3 mux ships values/messages/lifecycle/subgraph by default; these add
+    updates/custom/checkpoints/tasks so every protocol channel can carry data.
+    Imported lazily so a too-old langgraph fails the capability probe, not here.
+    """
+    from langgraph.stream.transformers import (
+        CheckpointsTransformer,
+        CustomTransformer,
+        TasksTransformer,
+        UpdatesTransformer,
+    )
+
+    return [UpdatesTransformer, CustomTransformer, CheckpointsTransformer, TasksTransformer]
+
+
+def unwrap_message_event(data: Any) -> dict[str, Any] | None:
+    """Return the content-block event dict from a v3 ``messages`` payload.
+
+    v3 ``messages`` data is ``[event_dict, metadata]`` where the event dict
+    carries the ``event`` discriminator (``message-start`` etc.). Accepts a
+    bare event dict too. Returns ``None`` for anything not v2-message-shaped.
+    """
+    if isinstance(data, dict) and isinstance(data.get("event"), str):
+        return data
+    if isinstance(data, (list, tuple)) and len(data) == 2:
+        head = data[0]
+        if isinstance(head, dict) and isinstance(head.get("event"), str):
+            return head
+    return None
+
+
+async def stream_native_v3_events(
+    *,
+    graph: Any,
+    input_data: Any,
+    config: dict[str, Any],
+    context: dict[str, Any] | None = None,
+) -> AsyncIterator[tuple[str, dict[str, Any]]]:
+    """Yield ``(method, protocol_event)`` pairs from a native v3 run.
+
+    Each pair goes into the broker as one raw event; the session re-envelopes
+    it. ``messages`` payloads are unwrapped to their event dict; a message
+    event we can't reconstruct is dropped rather than forwarded malformed.
+    """
+    run_stream = await graph.astream_events(
+        input_data, config, version="v3", context=context, transformers=_extra_transformers()
+    )
+    async with run_stream as stream:
+        async for event in stream:
+            if not isinstance(event, dict) or event.get("type") != "event":
+                continue
+            method = event.get("method")
+            if not isinstance(method, str):
+                continue
+
+            if method == "messages":
+                unwrapped = unwrap_message_event(event.get("params", {}).get("data"))
+                if unwrapped is None:
+                    continue
+                event = {**event, "params": {**event["params"], "data": unwrapped}}
+
+            yield method, event

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/normalizers.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/normalizers.py
@@ -1,0 +1,203 @@
+"""Normalize raw v3 stream payloads into Agent Protocol v2 shapes.
+
+The native v3 stream hands messages already content-block-shaped, but
+``values`` / ``updates`` payloads still carry raw langchain message dicts
+and ``__interrupt__`` markers. These helpers project those into the
+protocol's state-message shape, split interrupts onto the input channel,
+and map run status to a lifecycle status.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_STATE_MESSAGE_TYPES = frozenset({"human", "user", "ai", "assistant", "system", "tool", "function", "remove"})
+
+_CONTENT_BLOCK_TYPES = frozenset(
+    {
+        "text",
+        "reasoning",
+        "tool_call",
+        "tool_call_chunk",
+        "invalid_tool_call",
+        "image",
+        "audio",
+        "video",
+        "file",
+        "non_standard",
+    }
+)
+
+
+def lifecycle_status(run_status: str) -> str:
+    """Map a persisted run status to a protocol lifecycle status."""
+    if run_status == "success":
+        return "completed"
+    if run_status == "error":
+        return "failed"
+    if run_status == "interrupted":
+        return "interrupted"
+    return "running"
+
+
+def normalize_updates(payload: Any) -> dict[str, Any]:
+    """Extract ``node`` + ``values`` from an updates payload (``{node: values}``)."""
+    if isinstance(payload, dict) and len(payload) == 1:
+        node, values = next(iter(payload.items()))
+        return {"node": node, "values": _as_values(values)}
+    return {"values": _as_values(payload)}
+
+
+def _as_values(value: Any) -> Any:
+    return value if isinstance(value, dict) else {"value": value}
+
+
+def normalize_input_requested(payload: Any) -> list[dict[str, Any]]:
+    """Project interrupt entries into ``{interrupt_id, payload?}`` requests."""
+    requests: list[dict[str, Any]] = []
+    for entry in _interrupt_array(payload):
+        if not isinstance(entry, dict) or not isinstance(entry.get("id"), str):
+            continue
+        request: dict[str, Any] = {"interrupt_id": entry["id"]}
+        if "value" in entry:
+            request["payload"] = entry["value"]
+        requests.append(request)
+    return requests
+
+
+def _interrupt_array(payload: Any) -> list[Any]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and isinstance(payload.get("__interrupt__"), list):
+        return payload["__interrupt__"]
+    return []
+
+
+def strip_interrupts(payload: Any) -> tuple[list[dict[str, Any]], Any]:
+    """Split ``__interrupt__`` off a values payload: ``(input_requests, cleaned)``."""
+    requests = normalize_input_requested(payload)
+    if not isinstance(payload, dict) or "__interrupt__" not in payload:
+        return requests, payload
+    cleaned = {key: value for key, value in payload.items() if key != "__interrupt__"}
+    return requests, cleaned
+
+
+def normalize_state_payload(value: Any) -> Any:
+    """Recursively normalize a state payload: message shapes in, ``__interrupt__`` out."""
+    if isinstance(value, list):
+        return [
+            _normalize_message(item) if _is_state_message(item) else normalize_state_payload(item) for item in value
+        ]
+    if not isinstance(value, dict):
+        return value
+    out: dict[str, Any] = {}
+    for key, entry in value.items():
+        if key == "__interrupt__":
+            continue
+        if key == "messages" and isinstance(entry, list):
+            out[key] = [_normalize_message(item) if _is_state_message(item) else item for item in entry]
+            continue
+        out[key] = normalize_state_payload(entry)
+    return out
+
+
+def _message_type(value: Any) -> str | None:
+    if value == "assistant":
+        return "ai"
+    if value == "user":
+        return "human"
+    return value if isinstance(value, str) else None
+
+
+def _is_state_message(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    msg_type = _message_type(value.get("type"))
+    return msg_type is not None and msg_type in _STATE_MESSAGE_TYPES
+
+
+def _normalize_message(value: dict[str, Any]) -> dict[str, Any]:
+    msg_type = _message_type(value.get("type"))
+    if msg_type is None:
+        return value
+
+    message: dict[str, Any] = {"type": msg_type, "content": _normalize_content(value.get("content", ""))}
+    if isinstance(value.get("id"), str):
+        message["id"] = value["id"]
+    if isinstance(value.get("name"), str):
+        message["name"] = value["name"]
+
+    if msg_type == "tool":
+        if isinstance(value.get("tool_call_id"), str):
+            message["tool_call_id"] = value["tool_call_id"]
+        if value.get("status") in ("success", "error"):
+            message["status"] = value["status"]
+
+    if msg_type == "ai":
+        tool_calls, invalid = _split_tool_calls(value.get("tool_calls"))
+        if tool_calls:
+            message["tool_calls"] = tool_calls
+        if invalid:
+            message["invalid_tool_calls"] = invalid
+
+    return message
+
+
+def _normalize_content(content: Any) -> Any:
+    if isinstance(content, str) or not isinstance(content, list):
+        return content
+    blocks: list[Any] = []
+    for entry in content:
+        if isinstance(entry, str):
+            blocks.append({"type": "text", "text": entry})
+        elif isinstance(entry, dict) and entry.get("type") in _CONTENT_BLOCK_TYPES:
+            blocks.append(entry)
+    return blocks or content
+
+
+def _split_tool_calls(raw: Any) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if not isinstance(raw, list):
+        return [], []
+    valid: list[dict[str, Any]] = []
+    invalid: list[dict[str, Any]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name") if isinstance(entry.get("name"), str) else None
+        args = _coerce_args(entry.get("args"))
+        if name is None:
+            invalid.append(_invalid_call(entry, "Incomplete tool call."))
+            continue
+        if not args["valid"]:
+            invalid.append(_invalid_call(entry, "Malformed args.", name=name))
+            continue
+        call: dict[str, Any] = {"type": "tool_call", "name": name, "args": args["args"]}
+        if isinstance(entry.get("id"), str):
+            call["id"] = entry["id"]
+        valid.append(call)
+    return valid, invalid
+
+
+def _coerce_args(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict) or value is None:
+        return {"valid": True, "args": value or {}}
+    if isinstance(value, str):
+        if not value:
+            return {"valid": True, "args": {}}
+        try:
+            return {"valid": True, "args": json.loads(value)}
+        except (json.JSONDecodeError, ValueError):
+            return {"valid": False, "args": value}
+    return {"valid": True, "args": value}
+
+
+def _invalid_call(entry: dict[str, Any], error: str, *, name: str | None = None) -> dict[str, Any]:
+    out: dict[str, Any] = {"type": "invalid_tool_call", "error": error}
+    if name is not None:
+        out["name"] = name
+    if isinstance(entry.get("id"), str):
+        out["id"] = entry["id"]
+    if isinstance(entry.get("args"), str):
+        out["args"] = entry["args"]
+    return out

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/normalizers.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/normalizers.py
@@ -54,14 +54,18 @@ def _as_values(value: Any) -> Any:
 
 
 def normalize_input_requested(payload: Any) -> list[dict[str, Any]]:
-    """Project interrupt entries into ``{interrupt_id, payload?}`` requests."""
+    """Project interrupt entries into ``{interrupt_id, value?}`` requests.
+
+    ``value`` (not ``payload``) is the SDK's ``InterruptPayload`` field — it is
+    what ``thread.interrupts[].value`` surfaces to the client.
+    """
     requests: list[dict[str, Any]] = []
     for entry in _interrupt_array(payload):
         if not isinstance(entry, dict) or not isinstance(entry.get("id"), str):
             continue
         request: dict[str, Any] = {"interrupt_id": entry["id"]}
         if "value" in entry:
-            request["payload"] = entry["value"]
+            request["value"] = entry["value"]
         requests.append(request)
     return requests
 

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/normalizers.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/normalizers.py
@@ -34,7 +34,7 @@ def lifecycle_status(run_status: str) -> str:
     """Map a persisted run status to a protocol lifecycle status."""
     if run_status == "success":
         return "completed"
-    if run_status == "error":
+    if run_status in ("error", "timeout"):
         return "failed"
     if run_status == "interrupted":
         return "interrupted"

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/normalizers.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/normalizers.py
@@ -21,6 +21,9 @@ _CONTENT_BLOCK_TYPES = frozenset(
         "tool_call",
         "tool_call_chunk",
         "invalid_tool_call",
+        "server_tool_call",
+        "server_tool_call_chunk",
+        "server_tool_call_result",
         "image",
         "audio",
         "video",
@@ -28,6 +31,16 @@ _CONTENT_BLOCK_TYPES = frozenset(
         "non_standard",
     }
 )
+
+_MIME_TYPE_BY_AUDIO_FORMAT: dict[str, str] = {
+    "mp3": "audio/mpeg",
+    "wav": "audio/wav",
+    "pcm16": "audio/wav",
+    "pcm": "audio/wav",
+    "opus": "audio/opus",
+    "aac": "audio/aac",
+    "flac": "audio/flac",
+}
 
 
 def lifecycle_status(run_status: str) -> str:
@@ -126,20 +139,43 @@ def _normalize_message(value: dict[str, Any]) -> dict[str, Any]:
     if msg_type is None:
         return value
 
-    message: dict[str, Any] = {"type": msg_type, "content": _normalize_content(value.get("content", ""))}
+    additional_kwargs = value["additional_kwargs"] if isinstance(value.get("additional_kwargs"), dict) else None
+
+    message: dict[str, Any] = {
+        "type": msg_type,
+        # Audio rides additional_kwargs on ai messages only (voice model outputs).
+        "content": _normalize_content(
+            value.get("content", ""), additional_kwargs=additional_kwargs if msg_type == "ai" else None
+        ),
+    }
     if isinstance(value.get("id"), str):
         message["id"] = value["id"]
     if isinstance(value.get("name"), str):
         message["name"] = value["name"]
+    if msg_type in ("ai", "human") and isinstance(value.get("example"), bool):
+        message["example"] = value["example"]
 
     if msg_type == "tool":
         if isinstance(value.get("tool_call_id"), str):
             message["tool_call_id"] = value["tool_call_id"]
         if value.get("status") in ("success", "error"):
             message["status"] = value["status"]
+        if "artifact" in value:
+            message["artifact"] = value["artifact"]
 
     if msg_type == "ai":
-        tool_calls, invalid = _split_tool_calls(value.get("tool_calls"))
+        # OpenAI-shaped payloads may carry tool calls only in additional_kwargs.
+        raw_tool_calls = value.get("tool_calls") if isinstance(value.get("tool_calls"), list) else None
+        if not raw_tool_calls and additional_kwargs and isinstance(additional_kwargs.get("tool_calls"), list):
+            raw_tool_calls = additional_kwargs["tool_calls"]
+        tool_calls, invalid_from_valid = _split_tool_calls(raw_tool_calls)
+        # An explicit invalid_tool_calls field wins over ones derived from tool_calls.
+        raw_invalid = value.get("invalid_tool_calls")
+        invalid = (
+            _normalize_invalid_tool_calls(raw_invalid)
+            if isinstance(raw_invalid, list) and raw_invalid
+            else invalid_from_valid
+        )
         if tool_calls:
             message["tool_calls"] = tool_calls
         if invalid:
@@ -148,16 +184,110 @@ def _normalize_message(value: dict[str, Any]) -> dict[str, Any]:
     return message
 
 
-def _normalize_content(content: Any) -> Any:
-    if isinstance(content, str) or not isinstance(content, list):
-        return content
-    blocks: list[Any] = []
+def _normalize_content(content: Any, additional_kwargs: dict[str, Any] | None = None) -> Any:
+    audio_block = _audio_block_from_additional_kwargs(additional_kwargs)
+    if isinstance(content, str):
+        if audio_block is None:
+            return content
+        blocks: list[Any] = [{"type": "text", "text": content}] if content else []
+        blocks.append(audio_block)
+        return blocks
+    if not isinstance(content, list):
+        return [audio_block] if audio_block is not None else content
+
+    blocks = []
     for entry in content:
         if isinstance(entry, str):
             blocks.append({"type": "text", "text": entry})
-        elif isinstance(entry, dict) and entry.get("type") in _CONTENT_BLOCK_TYPES:
-            blocks.append(entry)
-    return blocks or content
+            continue
+        normalized = _normalize_block(entry)
+        if normalized is not None:
+            blocks.append(normalized)
+    if audio_block is not None and not any(b.get("type") == "audio" for b in blocks):
+        blocks.append(audio_block)
+    return blocks if blocks else content
+
+
+def _normalize_block(value: Any) -> dict[str, Any] | None:
+    """Normalize one raw content block into a protocol block.
+
+    Known types pass through; provider shapes (``image_url``, ``input_audio``)
+    convert; anything else typed wraps as ``non_standard`` rather than dropping.
+    """
+    if not isinstance(value, dict) or not isinstance(value.get("type"), str):
+        return None
+    if value["type"] in _CONTENT_BLOCK_TYPES:
+        return value
+
+    if value["type"] == "image_url":
+        raw_image = value.get("image_url")
+        if isinstance(raw_image, str):
+            return {"type": "image", "url": raw_image}
+        if isinstance(raw_image, dict) and isinstance(raw_image.get("url"), str):
+            return {"type": "image", "url": raw_image["url"]}
+        return None
+
+    if value["type"] == "input_audio":
+        raw_audio = value.get("input_audio") if isinstance(value.get("input_audio"), dict) else None
+        if raw_audio is None:
+            return None
+        block: dict[str, Any] = {"type": "audio"}
+        if isinstance(raw_audio.get("data"), str):
+            block["data"] = raw_audio["data"]
+        if isinstance(raw_audio.get("mime_type"), str):
+            block["mime_type"] = raw_audio["mime_type"]
+        return block
+
+    return {"type": "non_standard", "value": {**value}}
+
+
+def _audio_block_from_additional_kwargs(additional_kwargs: dict[str, Any] | None) -> dict[str, Any] | None:
+    if additional_kwargs is None:
+        return None
+    audio = additional_kwargs.get("audio")
+    if not isinstance(audio, dict):
+        return None
+    data = audio.get("data") if isinstance(audio.get("data"), str) else None
+    url = audio.get("url") if isinstance(audio.get("url"), str) else None
+    if data is None and url is None:
+        return None
+
+    fmt = (
+        audio["format"].lower()
+        if isinstance(audio.get("format"), str)
+        else (None if isinstance(audio.get("mime_type"), str) else "wav")
+    )
+    block: dict[str, Any] = {"type": "audio"}
+    if isinstance(audio.get("id"), str):
+        block["id"] = audio["id"]
+    if url is not None:
+        block["url"] = url
+    if data is not None:
+        block["data"] = data
+    if isinstance(audio.get("mime_type"), str):
+        block["mime_type"] = audio["mime_type"]
+    elif fmt is not None and fmt in _MIME_TYPE_BY_AUDIO_FORMAT:
+        block["mime_type"] = _MIME_TYPE_BY_AUDIO_FORMAT[fmt]
+    if isinstance(audio.get("transcript"), str):
+        block["transcript"] = audio["transcript"]
+    return block
+
+
+def _tool_call_identity(value: dict[str, Any]) -> tuple[str | None, str | None]:
+    """(id, name) for a tool call, reading the OpenAI nested function shape too."""
+    nested = value.get("function") if isinstance(value.get("function"), dict) else None
+    call_id = value["id"] if isinstance(value.get("id"), str) else None
+    name = value.get("name") if isinstance(value.get("name"), str) else None
+    if name is None and nested is not None and isinstance(nested.get("name"), str):
+        name = nested["name"]
+    return call_id, name
+
+
+def _tool_call_args(value: dict[str, Any]) -> Any:
+    if "args" in value:
+        return value["args"]
+    nested = value.get("function") if isinstance(value.get("function"), dict) else None
+    return nested.get("arguments") if nested else None
 
 
 def _split_tool_calls(raw: Any) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -168,19 +298,49 @@ def _split_tool_calls(raw: Any) -> tuple[list[dict[str, Any]], list[dict[str, An
     for entry in raw:
         if not isinstance(entry, dict):
             continue
-        name = entry.get("name") if isinstance(entry.get("name"), str) else None
-        args = _coerce_args(entry.get("args"))
+        call_id, name = _tool_call_identity(entry)
+        raw_args = _tool_call_args(entry)
+        args = _coerce_args(raw_args)
         if name is None:
-            invalid.append(_invalid_call(entry, "Incomplete tool call."))
+            item: dict[str, Any] = {"type": "invalid_tool_call", "error": "Incomplete tool call."}
+            if call_id is not None:
+                item["id"] = call_id
+            if isinstance(raw_args, str):
+                item["args"] = raw_args
+            invalid.append(item)
             continue
         if not args["valid"]:
-            invalid.append(_invalid_call(entry, "Malformed args.", name=name))
+            item = {"type": "invalid_tool_call", "name": name, "error": "Malformed args."}
+            if call_id is not None:
+                item["id"] = call_id
+            if isinstance(args["args"], str):
+                item["args"] = args["args"]
+            invalid.append(item)
             continue
         call: dict[str, Any] = {"type": "tool_call", "name": name, "args": args["args"]}
-        if isinstance(entry.get("id"), str):
-            call["id"] = entry["id"]
+        if call_id is not None:
+            call["id"] = call_id
         valid.append(call)
     return valid, invalid
+
+
+def _normalize_invalid_tool_calls(raw: list[Any]) -> list[dict[str, Any]]:
+    """Normalize a message's own invalid_tool_calls list, preserving its error strings."""
+    result: list[dict[str, Any]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        call_id, name = _tool_call_identity(entry)
+        item: dict[str, Any] = {"type": "invalid_tool_call"}
+        if call_id is not None:
+            item["id"] = call_id
+        if name is not None:
+            item["name"] = name
+        if isinstance(entry.get("args"), str):
+            item["args"] = entry["args"]
+        item["error"] = entry["error"] if isinstance(entry.get("error"), str) else "Malformed args."
+        result.append(item)
+    return result
 
 
 def _coerce_args(value: Any) -> dict[str, Any]:
@@ -194,14 +354,3 @@ def _coerce_args(value: Any) -> dict[str, Any]:
         except (json.JSONDecodeError, ValueError):
             return {"valid": False, "args": value}
     return {"valid": True, "args": value}
-
-
-def _invalid_call(entry: dict[str, Any], error: str, *, name: str | None = None) -> dict[str, Any]:
-    out: dict[str, Any] = {"type": "invalid_tool_call", "error": error}
-    if name is not None:
-        out["name"] = name
-    if isinstance(entry.get("id"), str):
-        out["id"] = entry["id"]
-    if isinstance(entry.get("args"), str):
-        out["args"] = entry["args"]
-    return out

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/protocol.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/protocol.py
@@ -8,6 +8,7 @@ place and stay exact (``event_id``, ``seq``, ``applied_through_seq``).
 
 from __future__ import annotations
 
+import time
 from typing import Any, Literal
 
 # Server event channels (the envelope ``method``).
@@ -45,11 +46,12 @@ def build_event(
 ) -> dict[str, Any]:
     """Build a server-push event envelope.
 
-    ``params`` wraps the per-channel payload as ``{data, namespace}`` — the
-    shape the LangGraph SDK reads (``params.data`` is the payload,
-    ``params.namespace`` the subgraph path, ``[]`` at the root).
+    ``params`` wraps the per-channel payload as ``{data, namespace,
+    timestamp}`` — the shape the LangGraph SDK reads (``params.data`` is the
+    payload, ``params.namespace`` the subgraph path, ``[]`` at the root,
+    ``params.timestamp`` ms-epoch server time).
     """
-    params: dict[str, Any] = {"data": data, "namespace": namespace or []}
+    params: dict[str, Any] = {"data": data, "namespace": namespace or [], "timestamp": time.time_ns() // 1_000_000}
     event: dict[str, Any] = {"type": "event", "seq": seq, "method": method, "params": params}
     if event_id is not None:
         event["event_id"] = event_id

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/protocol.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/protocol.py
@@ -1,0 +1,78 @@
+"""Wire builders for the Agent Protocol v2 envelope.
+
+The protocol types in ``langchain_protocol`` are plain ``TypedDict``s with
+no serialization behaviour — the wire form is a plain dict serialized with
+``json.dumps``. These helpers build those dicts so field names live in one
+place and stay exact (``event_id``, ``seq``, ``applied_through_seq``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+# Server event channels (the envelope ``method``).
+EventMethod = Literal[
+    "lifecycle",
+    "messages",
+    "tools",
+    "input.requested",
+    "values",
+    "updates",
+    "checkpoints",
+    "custom",
+    "tasks",
+]
+
+# Error codes a command response may carry.
+ErrorCode = Literal[
+    "invalid_argument",
+    "unknown_command",
+    "unknown_error",
+    "no_such_run",
+    "no_such_interrupt",
+    "permission_denied",
+    "not_supported",
+]
+
+
+def build_event(
+    method: EventMethod | str,
+    data: dict[str, Any],
+    *,
+    namespace: list[str] | None = None,
+    seq: int,
+    event_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a server-push event envelope.
+
+    ``params`` wraps the per-channel payload as ``{data, namespace}`` — the
+    shape the LangGraph SDK reads (``params.data`` is the payload,
+    ``params.namespace`` the subgraph path, ``[]`` at the root).
+    """
+    params: dict[str, Any] = {"data": data, "namespace": namespace or []}
+    event: dict[str, Any] = {"type": "event", "seq": seq, "method": method, "params": params}
+    if event_id is not None:
+        event["event_id"] = event_id
+    return event
+
+
+def build_success(
+    command_id: int,
+    result: dict[str, Any],
+    *,
+    applied_through_seq: int | None = None,
+) -> dict[str, Any]:
+    """Build a success command response."""
+    response: dict[str, Any] = {"type": "success", "id": command_id, "result": result}
+    if applied_through_seq is not None:
+        response["meta"] = {"applied_through_seq": applied_through_seq}
+    return response
+
+
+def build_error(
+    command_id: int | None,
+    error: ErrorCode,
+    message: str,
+) -> dict[str, Any]:
+    """Build an error command response."""
+    return {"type": "error", "id": command_id, "error": error, "message": message}

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -171,6 +171,8 @@ class ThreadEventSession:
             return self._values_events(data, params.get("interrupts"), namespace)
         if method == "updates":
             return self._updates_events(data, namespace)
+        if method == "lifecycle":
+            return self._native_lifecycle_events(data, namespace)
         return [(method, data if isinstance(data, dict) else {"value": data}, namespace)]
 
     def _values_events(self, data: Any, interrupts: Any, namespace: list[str]) -> list[_ChannelEvent]:
@@ -196,6 +198,32 @@ class ThreadEventSession:
         normalized = normalize_updates(data)
         normalized["values"] = normalize_state_payload(normalized["values"])
         return [("updates", normalized, namespace)]
+
+    def _native_lifecycle_events(self, data: Any, namespace: list[str]) -> list[_ChannelEvent]:
+        """Forward a per-subgraph lifecycle event from the native producer.
+
+        The producer's ``LifecycleTransformer`` emits one flat lifecycle stream
+        at the root scope (``params.namespace == []``) while the announced
+        subgraph identity lives in ``data.namespace``. Promote that deeper
+        namespace onto the wire so ``started``/``completed``/``failed`` land on
+        the subgraph, not the root. Root-scoped lifecycle is owned by the
+        terminal ``_lifecycle`` (it resolves interrupt/failure), so drop it here.
+        """
+        if not isinstance(data, dict) or not isinstance(data.get("event"), str):
+            return [("lifecycle", data if isinstance(data, dict) else {"value": data}, namespace)]
+
+        data_ns = data.get("namespace")
+        if isinstance(data_ns, list) and all(isinstance(seg, str) for seg in data_ns) and len(data_ns) > len(namespace):
+            namespace = list(data_ns)
+
+        if not namespace:
+            return []
+
+        forwarded: dict[str, Any] = {"event": data["event"]}
+        for key in ("graph_name", "trigger_call_id", "error", "cause"):
+            if key in data:
+                forwarded[key] = data[key]
+        return [("lifecycle", forwarded, namespace)]
 
     def _lifecycle(self, method: str, payload: Any) -> list[_ChannelEvent]:
         """Build a lifecycle event from a terminal broker payload.
@@ -236,11 +264,29 @@ class ThreadEventSession:
             return True
         if self._depth is not None and len(namespace) > self._depth:
             return False
-        if self._namespaces is not None:
-            ns = tuple(namespace)
-            if not any(ns[: len(prefix)] == prefix for prefix in self._namespaces):
-                return False
-        return True
+        if self._namespaces is None:
+            return True
+        return any(_prefix_matches(namespace, prefix) for prefix in self._namespaces)
+
+
+def _prefix_matches(namespace: list[str], prefix: tuple[str, ...]) -> bool:
+    """True if *namespace* starts with *prefix*, ignoring dynamic ``:task_id`` suffixes.
+
+    Subgraph namespace segments carry a runtime task id (``node:<uuid>``); a
+    client's include-list uses the clean node name (``node``). Compare literally
+    first, then against the suffix-stripped segment when the prefix has no ``:``.
+    """
+    if len(prefix) > len(namespace):
+        return False
+    for i, segment in enumerate(prefix):
+        candidate = namespace[i]
+        if candidate == segment:
+            continue
+        if ":" in segment:
+            return False
+        if candidate.split(":", 1)[0] != segment:
+            return False
+    return True
 
 
 def _is_terminal(raw_event: Any) -> bool:

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -316,7 +316,7 @@ class ThreadEventSession:
             status = "error"
 
         events: list[_ChannelEvent] = []
-        for namespace in sorted(self._open_namespaces.values(), key=lambda ns: len(ns), reverse=True):
+        for namespace in sorted(self._open_namespaces.values(), key=_namespace_depth, reverse=True):
             events.append(("lifecycle", {"event": "completed"}, namespace))
         self._open_namespaces = {}
 
@@ -364,6 +364,10 @@ class ThreadEventSession:
         if self._namespaces is None:
             return True
         return any(_prefix_matches(namespace, prefix) for prefix in self._namespaces)
+
+
+def _namespace_depth(namespace: list[str]) -> int:
+    return len(namespace)
 
 
 def _custom_events(method: str, data: Any, namespace: list[str]) -> list[_ChannelEvent]:

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -1,0 +1,273 @@
+"""Thread-scoped session that forwards a thread's native v3 events as v2 events.
+
+A v2 stream is scoped to a *thread*, not a run (matching the LangGraph SDK):
+the client opens the stream, issues ``run.start``, and the events of whatever
+run(s) execute on the thread flow through. The run's broker already holds
+native protocol events (the v3 producer wrote them) as ``(method, event)``
+pairs, plus a terminal ``("end"|"error", payload)``. The session re-envelopes
+each under one thread-monotonic ``seq``: it restamps seq/event_id, filters by
+channel, splits interrupts onto the ``input`` channel, normalizes state
+message payloads, and derives the terminal lifecycle event.
+
+``seq`` is the reconnect cursor: a client resends the last ``seq`` it saw as
+``since`` and the session skips anything at or below it. ``event_id`` is a
+distinct unique-per-event string used by the client for dedup.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any
+
+import structlog
+
+from aegra_api.services.broker import broker_manager
+from aegra_api.services.event_streaming.channels import is_supported_channel
+from aegra_api.services.event_streaming.normalizers import (
+    lifecycle_status,
+    normalize_input_requested,
+    normalize_state_payload,
+    strip_interrupts,
+)
+from aegra_api.services.event_streaming.protocol import build_event
+
+logger = structlog.getLogger(__name__)
+
+__all__ = ["RunLister", "ThreadEventSession", "validate_channels"]
+
+# How long to keep polling for a new run after the thread goes quiet before
+# closing the stream. Covers the SDK gap between opening the stream and the
+# run.start landing.
+_IDLE_GRACE_SECONDS = 30.0
+_POLL_INTERVAL_SECONDS = 0.25
+
+# Async callable returning the thread's run ids, oldest first.
+RunLister = Callable[[], Awaitable[list[str]]]
+
+# A projected channel event: (wire method, params.data, namespace).
+_ChannelEvent = tuple[str, dict[str, Any], list[str]]
+
+
+class ThreadEventSession:
+    """Forwards native v3 events for all runs on a thread, filtered to channels."""
+
+    def __init__(
+        self,
+        thread_id: str,
+        *,
+        channels: set[str],
+        list_run_ids: RunLister,
+        since: int | None = None,
+        idle_grace_seconds: float = _IDLE_GRACE_SECONDS,
+    ) -> None:
+        self._thread_id = thread_id
+        self._channels = channels
+        self._list_run_ids = list_run_ids
+        self._since = since
+        self._idle_grace = idle_grace_seconds
+        self._seq = 0
+        self._drained: set[str] = set()
+
+    @property
+    def applied_through_seq(self) -> int:
+        """The highest seq assigned so far (the SDK's initial cursor)."""
+        return self._seq
+
+    async def stream(self) -> AsyncIterator[dict[str, Any]]:
+        """Yield v2 envelopes for the thread's runs until they finish + idle."""
+        idle_deadline: float | None = None
+        drained_any = False
+        loop = asyncio.get_running_loop()
+
+        while True:
+            progressed = False
+            for run_id in await self._fresh_run_ids():
+                async for envelope in self._drain_run(run_id):
+                    progressed = True
+                    yield envelope
+                self._drained.add(run_id)
+                drained_any = True
+
+            if progressed:
+                idle_deadline = None
+                continue
+            if drained_any:
+                return
+
+            now = loop.time()
+            if idle_deadline is None:
+                idle_deadline = now + self._idle_grace
+            elif now >= idle_deadline:
+                return
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+
+    async def _fresh_run_ids(self) -> list[str]:
+        return [run_id for run_id in await self._list_run_ids() if run_id not in self._drained]
+
+    async def _drain_run(self, run_id: str) -> AsyncIterator[dict[str, Any]]:
+        """Replay then tail one run's broker, re-enveloping each native event."""
+        broker = broker_manager.get_or_create_broker(run_id)
+        seen: set[str] = set()
+
+        for event_id, raw_event in await broker.replay(None):
+            seen.add(event_id)
+            for envelope in self._project(event_id, raw_event):
+                yield envelope
+            if _is_terminal(raw_event):
+                return
+
+        async for event_id, raw_event in broker.aiter():
+            if event_id in seen:
+                continue
+            for envelope in self._project(event_id, raw_event):
+                yield envelope
+            if _is_terminal(raw_event):
+                return
+
+    def _project(self, event_id: str, raw_event: Any) -> list[dict[str, Any]]:
+        """Re-envelope one raw broker event into filtered, seq'd envelopes."""
+        method, payload = _unwrap(raw_event)
+        if method is None:
+            return []
+
+        channel_events = self._channel_events(method, payload)
+
+        envelopes: list[dict[str, Any]] = []
+        for index, (channel, data, namespace) in enumerate(channel_events):
+            # seq counts every projected event before channel filtering, so the
+            # cursor is absolute position in the thread's stream — a reconnect
+            # with a different channel set still resumes correctly.
+            self._seq += 1
+            if not self._wants(channel):
+                continue
+            if self._since is not None and self._seq <= self._since:
+                continue
+            envelopes.append(
+                build_event(
+                    channel,
+                    data,
+                    namespace=namespace,
+                    seq=self._seq,
+                    event_id=f"{event_id}:{index}",
+                )
+            )
+        return envelopes
+
+    def _channel_events(self, method: str, payload: Any) -> list[_ChannelEvent]:
+        """Map one raw broker event to zero or more (channel, data, namespace)."""
+        if method in ("end", "error"):
+            return self._lifecycle(payload)
+
+        # Native producer events: payload is a ProtocolEvent dict.
+        params = payload.get("params", {}) if isinstance(payload, dict) else {}
+        data = params.get("data")
+        namespace = params.get("namespace") or []
+
+        if method == "values":
+            return self._values_events(data, params.get("interrupts"), namespace)
+        if method == "updates":
+            return self._updates_events(data, namespace)
+        return [(method, data if isinstance(data, dict) else {"value": data}, namespace)]
+
+    def _values_events(self, data: Any, interrupts: Any, namespace: list[str]) -> list[_ChannelEvent]:
+        """Split interrupts onto the input channel; forward cleaned, normalized values."""
+        events: list[_ChannelEvent] = []
+        requests, cleaned = strip_interrupts(data)
+        if isinstance(interrupts, (list, tuple)) and interrupts:
+            requests = _dedupe_requests(requests + normalize_input_requested(_coerce_interrupts(interrupts)))
+        for request in requests:
+            events.append(("input.requested", request, namespace))
+        if _has_state(cleaned):
+            events.append(("values", normalize_state_payload(cleaned), namespace))
+        return events
+
+    def _updates_events(self, data: Any, namespace: list[str]) -> list[_ChannelEvent]:
+        """Forward updates, splitting any embedded interrupt onto the input channel."""
+        node = data.get("node") if isinstance(data, dict) else None
+        if node == "__interrupt__":
+            values = data.get("values") if isinstance(data, dict) else None
+            return [("input.requested", request, namespace) for request in normalize_input_requested(values)]
+        return [("updates", normalize_state_payload(data) if isinstance(data, dict) else {"value": data}, namespace)]
+
+    def _lifecycle(self, payload: Any) -> list[_ChannelEvent]:
+        """Build a lifecycle event from a terminal broker payload."""
+        status = payload.get("status") if isinstance(payload, dict) else None
+        data: dict[str, Any] = {"event": lifecycle_status(status or "")}
+        if isinstance(payload, dict) and (message := payload.get("message")):
+            data["error"] = message
+        return [("lifecycle", data, [])]
+
+    def _wants(self, channel: str) -> bool:
+        """True if the client subscribed to this channel.
+
+        The ``input.requested`` wire method maps to the ``input`` channel. A
+        custom subscription — plain ``custom`` or namespaced ``custom:<name>``
+        — matches the base ``custom`` channel. Named filtering is a follow-up.
+        """
+        if channel == "input.requested":
+            return "input" in self._channels
+        if channel == "custom":
+            return any(c == "custom" or c.startswith("custom:") for c in self._channels)
+        return channel in self._channels
+
+
+def _is_terminal(raw_event: Any) -> bool:
+    """True for a run's final ``end`` / ``error`` broker event."""
+    method, _ = _unwrap(raw_event)
+    return method in ("end", "error")
+
+
+def _unwrap(raw_event: Any) -> tuple[str | None, Any]:
+    """Pull ``(method, payload)`` out of a broker event; ``(None, None)`` if unknown."""
+    if isinstance(raw_event, (tuple, list)) and len(raw_event) == 2:
+        return raw_event[0], raw_event[1]
+    return None, None
+
+
+def _has_state(value: Any) -> bool:
+    """True if a values/updates payload carries forwardable state."""
+    if isinstance(value, dict):
+        return bool(value)
+    return value is not None
+
+
+def _coerce_interrupts(interrupts: Any) -> list[dict[str, Any]]:
+    """Coerce native Interrupt objects/dicts into ``{id, value}`` entries."""
+    out: list[dict[str, Any]] = []
+    for item in interrupts:
+        if isinstance(item, dict):
+            out.append(item)
+            continue
+        interrupt_id = getattr(item, "id", None)
+        if isinstance(interrupt_id, str):
+            out.append({"id": interrupt_id, "value": getattr(item, "value", None)})
+    return out
+
+
+def _dedupe_requests(requests: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop duplicate input requests by interrupt_id, preserving order."""
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+    for request in requests:
+        interrupt_id = request.get("interrupt_id")
+        if interrupt_id in seen:
+            continue
+        if isinstance(interrupt_id, str):
+            seen.add(interrupt_id)
+        out.append(request)
+    return out
+
+
+def validate_channels(channels: Any) -> tuple[set[str], list[str]]:
+    """Split a requested channel list into (valid set, invalid names)."""
+    if not isinstance(channels, list) or not channels:
+        return set(), ["channels must be a non-empty array"]
+    valid: set[str] = set()
+    invalid: list[str] = []
+    for channel in channels:
+        if isinstance(channel, str) and is_supported_channel(channel):
+            valid.add(channel)
+        else:
+            invalid.append(str(channel))
+    return valid, invalid

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -20,25 +20,20 @@ import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
-import structlog
-
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.event_streaming.channels import is_supported_channel
 from aegra_api.services.event_streaming.normalizers import (
     lifecycle_status,
     normalize_input_requested,
     normalize_state_payload,
+    normalize_updates,
     strip_interrupts,
 )
 from aegra_api.services.event_streaming.protocol import build_event
 
-logger = structlog.getLogger(__name__)
-
 __all__ = ["RunLister", "ThreadEventSession", "validate_channels"]
 
-# How long to keep polling for a new run after the thread goes quiet before
-# closing the stream. Covers the SDK gap between opening the stream and the
-# run.start landing.
+# Grace window covering the SDK gap between stream open and run.start landing.
 _IDLE_GRACE_SECONDS = 30.0
 _POLL_INTERVAL_SECONDS = 0.25
 
@@ -135,9 +130,8 @@ class ThreadEventSession:
 
         envelopes: list[dict[str, Any]] = []
         for index, (channel, data, namespace) in enumerate(channel_events):
-            # seq counts every projected event before channel filtering, so the
-            # cursor is absolute position in the thread's stream — a reconnect
-            # with a different channel set still resumes correctly.
+            # seq counts before channel filtering — absolute cursor, so a
+            # reconnect with a different channel set still resumes correctly.
             self._seq += 1
             if not self._wants(channel):
                 continue
@@ -183,12 +177,16 @@ class ThreadEventSession:
         return events
 
     def _updates_events(self, data: Any, namespace: list[str]) -> list[_ChannelEvent]:
-        """Forward updates, splitting any embedded interrupt onto the input channel."""
-        node = data.get("node") if isinstance(data, dict) else None
-        if node == "__interrupt__":
-            values = data.get("values") if isinstance(data, dict) else None
-            return [("input.requested", request, namespace) for request in normalize_input_requested(values)]
-        return [("updates", normalize_state_payload(data) if isinstance(data, dict) else {"value": data}, namespace)]
+        """Forward updates, splitting any embedded interrupt onto the input channel.
+
+        v3 emits updates as raw ``{node: values}``; an interrupt arrives as the
+        ``__interrupt__`` node whose values are the interrupt array.
+        """
+        if isinstance(data, dict) and "__interrupt__" in data:
+            return [("input.requested", req, namespace) for req in normalize_input_requested(data["__interrupt__"])]
+        normalized = normalize_updates(data)
+        normalized["values"] = normalize_state_payload(normalized["values"])
+        return [("updates", normalized, namespace)]
 
     def _lifecycle(self, payload: Any) -> list[_ChannelEvent]:
         """Build a lifecycle event from a terminal broker payload."""

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -154,7 +154,7 @@ class ThreadEventSession:
     def _channel_events(self, method: str, payload: Any) -> list[_ChannelEvent]:
         """Map one raw broker event to zero or more (channel, data, namespace)."""
         if method in ("end", "error"):
-            return self._lifecycle(payload)
+            return self._lifecycle(method, payload)
 
         # Native producer events: payload is a ProtocolEvent dict.
         params = payload.get("params", {}) if isinstance(payload, dict) else {}
@@ -191,9 +191,16 @@ class ThreadEventSession:
         normalized["values"] = normalize_state_payload(normalized["values"])
         return [("updates", normalized, namespace)]
 
-    def _lifecycle(self, payload: Any) -> list[_ChannelEvent]:
-        """Build a lifecycle event from a terminal broker payload."""
+    def _lifecycle(self, method: str, payload: Any) -> list[_ChannelEvent]:
+        """Build a lifecycle event from a terminal broker payload.
+
+        The ``error`` broker event carries ``{error, message}`` with no status —
+        it is terminal and drains the run before the trailing ``end`` event, so
+        the failed status comes from the method, not a status key.
+        """
         status = payload.get("status") if isinstance(payload, dict) else None
+        if method == "error":
+            status = "error"
         data: dict[str, Any] = {"event": lifecycle_status(status or "")}
         if isinstance(payload, dict) and (message := payload.get("message")):
             data["error"] = message

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -70,9 +70,15 @@ class ThreadEventSession:
         return self._seq
 
     async def stream(self) -> AsyncIterator[dict[str, Any]]:
-        """Yield v2 envelopes for the thread's runs until they finish + idle."""
+        """Yield v2 envelopes for the thread's runs until they finish + idle.
+
+        The stream stays open across the gap between runs so a HITL resume
+        (``input.respond`` starts a fresh run on the same thread) is delivered
+        on the same SSE connection the SDK holds open. An interrupted run keeps
+        the full grace window; a terminal run still waits one grace window so a
+        same-thread follow-up run is not dropped, but never blocks forever.
+        """
         idle_deadline: float | None = None
-        drained_any = False
         loop = asyncio.get_running_loop()
 
         while True:
@@ -82,13 +88,10 @@ class ThreadEventSession:
                     progressed = True
                     yield envelope
                 self._drained.add(run_id)
-                drained_any = True
 
             if progressed:
                 idle_deadline = None
                 continue
-            if drained_any:
-                return
 
             now = loop.time()
             if idle_deadline is None:

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -37,8 +37,12 @@ __all__ = ["RunLister", "ThreadEventSession", "validate_channels"]
 _IDLE_GRACE_SECONDS = 30.0
 _POLL_INTERVAL_SECONDS = 0.25
 
-# Async callable returning the thread's run ids, oldest first.
-RunLister = Callable[[], Awaitable[list[str]]]
+# Async callable returning the thread's (run_id, status, graph_name) rows,
+# oldest first. Status backstops runs whose broker events expired (see
+# _drain_run); graph_name feeds the run's root lifecycle events.
+RunLister = Callable[[], Awaitable[list[tuple[str, str | None, str | None]]]]
+
+_TERMINAL_RUN_STATUSES = frozenset({"success", "error", "timeout", "interrupted"})
 
 # A projected channel event: (wire method, params.data, namespace).
 _ChannelEvent = tuple[str, dict[str, Any], list[str]]
@@ -67,6 +71,14 @@ class ThreadEventSession:
         self._idle_grace = idle_grace_seconds
         self._seq = 0
         self._drained: set[str] = set()
+        # One input.requested per interrupt per session — the same interrupt can
+        # surface via updates (__interrupt__ node) AND the next values snapshot.
+        self._sent_interrupts: set[str] = set()
+        # Per-run lifecycle bookkeeping, reset by _drain_run: the run's root
+        # graph name and the subgraph namespaces still open (started, no
+        # completed/failed yet) so the terminal can cascade-close them.
+        self._current_graph: str | None = None
+        self._open_namespaces: dict[str, list[str]] = {}
 
     @property
     def applied_through_seq(self) -> int:
@@ -87,8 +99,8 @@ class ThreadEventSession:
 
         while True:
             progressed = False
-            for run_id in await self._fresh_run_ids():
-                async for envelope in self._drain_run(run_id):
+            for run_id, run_status, graph_name in await self._fresh_runs():
+                async for envelope in self._drain_run(run_id, run_status, graph_name):
                     progressed = True
                     yield envelope
                 self._drained.add(run_id)
@@ -104,20 +116,49 @@ class ThreadEventSession:
                 return
             await asyncio.sleep(_POLL_INTERVAL_SECONDS)
 
-    async def _fresh_run_ids(self) -> list[str]:
-        return [run_id for run_id in await self._list_run_ids() if run_id not in self._drained]
+    async def _fresh_runs(self) -> list[tuple[str, str | None, str | None]]:
+        return [row for row in await self._list_run_ids() if row[0] not in self._drained]
 
-    async def _drain_run(self, run_id: str) -> AsyncIterator[dict[str, Any]]:
-        """Replay then tail one run's broker, re-enveloping each native event."""
+    async def _drain_run(
+        self, run_id: str, run_status: str | None, graph_name: str | None
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Replay then tail one run's broker, re-enveloping each native event.
+
+        Each run's lifecycle tree is self-contained on the stream: a root
+        ``running`` seed opens it, per-subgraph events flow through, and the
+        terminal closes any still-open subgraph namespaces before the root
+        status (a cancel mid-subgraph otherwise leaves them started forever).
+
+        The persisted run status backstops runs whose broker events expired
+        (replay TTL / cleanup): without it, ``aiter`` on a recreated empty
+        broker waits forever for an end event nobody will publish — wedging
+        the whole thread stream on its first historical run. A terminal run
+        with no surviving events drains silently; one whose events survived
+        but whose end frame was lost gets a synthesized terminal.
+        """
         broker = broker_manager.get_or_create_broker(run_id)
         seen: set[str] = set()
+        self._current_graph = graph_name
+        self._open_namespaces = {}
 
-        for event_id, raw_event in await broker.replay(None):
+        replayed = await broker.replay(None)
+        if run_status in _TERMINAL_RUN_STATUSES and not replayed:
+            return
+
+        for envelope in self._emit([("lifecycle", self._root_lifecycle("running"), [])], f"{run_id}:running"):
+            yield envelope
+
+        for event_id, raw_event in replayed:
             seen.add(event_id)
             for envelope in self._project(event_id, raw_event):
                 yield envelope
             if _is_terminal(raw_event):
                 return
+
+        if run_status in _TERMINAL_RUN_STATUSES:
+            for envelope in self._project(f"{run_id}:status-end", ("end", {"status": run_status})):
+                yield envelope
+            return
 
         async for event_id, raw_event in broker.aiter():
             if event_id in seen:
@@ -132,15 +173,16 @@ class ThreadEventSession:
         method, payload = _unwrap(raw_event)
         if method is None:
             return []
+        return self._emit(self._channel_events(method, payload), event_id)
 
-        channel_events = self._channel_events(method, payload)
-
+    def _emit(self, channel_events: list[_ChannelEvent], event_id: str) -> list[dict[str, Any]]:
+        """Filter + seq a batch of channel events into wire envelopes."""
         envelopes: list[dict[str, Any]] = []
         for index, (channel, data, namespace) in enumerate(channel_events):
             # seq counts before channel filtering — absolute cursor, so a
             # reconnect with a different channel set still resumes correctly.
             self._seq += 1
-            if not self._wants(channel):
+            if not self._wants(channel, data):
                 continue
             if not self._wants_namespace(namespace):
                 continue
@@ -173,16 +215,16 @@ class ThreadEventSession:
             return self._updates_events(data, namespace)
         if method == "lifecycle":
             return self._native_lifecycle_events(data, namespace)
+        if method == "custom" or method.startswith("custom:"):
+            return _custom_events(method, data, namespace)
         return [(method, data if isinstance(data, dict) else {"value": data}, namespace)]
 
     def _values_events(self, data: Any, interrupts: Any, namespace: list[str]) -> list[_ChannelEvent]:
         """Split interrupts onto the input channel; forward cleaned, normalized values."""
-        events: list[_ChannelEvent] = []
         requests, cleaned = strip_interrupts(data)
         if isinstance(interrupts, (list, tuple)) and interrupts:
             requests = _dedupe_requests(requests + normalize_input_requested(_coerce_interrupts(interrupts)))
-        for request in requests:
-            events.append(("input.requested", request, namespace))
+        events = self._input_request_events(requests, namespace)
         if _has_state(cleaned):
             events.append(("values", normalize_state_payload(cleaned), namespace))
         return events
@@ -191,13 +233,38 @@ class ThreadEventSession:
         """Forward updates, splitting any embedded interrupt onto the input channel.
 
         v3 emits updates as raw ``{node: values}``; an interrupt arrives as the
-        ``__interrupt__`` node whose values are the interrupt array.
+        ``__interrupt__`` node whose values are the interrupt array. A sibling
+        node's update in the same chunk (parallel branches) must still forward,
+        and an interrupt nested inside a node's values must still surface.
         """
+        events: list[_ChannelEvent] = []
         if isinstance(data, dict) and "__interrupt__" in data:
-            return [("input.requested", req, namespace) for req in normalize_input_requested(data["__interrupt__"])]
+            events.extend(self._input_request_events(normalize_input_requested(data["__interrupt__"]), namespace))
+            data = {key: value for key, value in data.items() if key != "__interrupt__"}
+            if not data:
+                return events
+        if isinstance(data, dict):
+            for node_values in data.values():
+                if isinstance(node_values, dict) and "__interrupt__" in node_values:
+                    events.extend(
+                        self._input_request_events(normalize_input_requested(node_values["__interrupt__"]), namespace)
+                    )
         normalized = normalize_updates(data)
         normalized["values"] = normalize_state_payload(normalized["values"])
-        return [("updates", normalized, namespace)]
+        events.append(("updates", normalized, namespace))
+        return events
+
+    def _input_request_events(self, requests: list[dict[str, Any]], namespace: list[str]) -> list[_ChannelEvent]:
+        """input.requested events for *requests*, at most once per interrupt id."""
+        events: list[_ChannelEvent] = []
+        for request in requests:
+            interrupt_id = request.get("interrupt_id")
+            if isinstance(interrupt_id, str):
+                if interrupt_id in self._sent_interrupts:
+                    continue
+                self._sent_interrupts.add(interrupt_id)
+            events.append(("input.requested", request, namespace))
+        return events
 
     def _native_lifecycle_events(self, data: Any, namespace: list[str]) -> list[_ChannelEvent]:
         """Forward a per-subgraph lifecycle event from the native producer.
@@ -219,14 +286,26 @@ class ThreadEventSession:
         if not namespace:
             return []
 
-        forwarded: dict[str, Any] = {"event": data["event"]}
-        for key in ("graph_name", "trigger_call_id", "error", "cause"):
-            if key in data:
-                forwarded[key] = data[key]
+        event = data["event"]
+        key = "\0".join(namespace)
+        if event == "started":
+            self._open_namespaces[key] = list(namespace)
+        elif event in ("completed", "failed"):
+            self._open_namespaces.pop(key, None)
+
+        forwarded: dict[str, Any] = {"event": event}
+        for field in ("graph_name", "trigger_call_id", "error", "cause"):
+            if field in data:
+                forwarded[field] = data[field]
         return [("lifecycle", forwarded, namespace)]
 
     def _lifecycle(self, method: str, payload: Any) -> list[_ChannelEvent]:
-        """Build a lifecycle event from a terminal broker payload.
+        """Build the run's terminal lifecycle from a terminal broker payload.
+
+        Cascade-closes any still-open subgraph namespaces (deepest first) before
+        the root status — a cancel or crash mid-subgraph never sends the
+        producer's ``completed``, and clients must not see subgraphs stuck in
+        ``started`` after the run ended.
 
         The ``error`` broker event carries ``{error, message}`` with no status —
         it is terminal and drains the run before the trailing ``end`` event, so
@@ -235,22 +314,40 @@ class ThreadEventSession:
         status = payload.get("status") if isinstance(payload, dict) else None
         if method == "error":
             status = "error"
-        data: dict[str, Any] = {"event": lifecycle_status(status or "")}
+
+        events: list[_ChannelEvent] = []
+        for namespace in sorted(self._open_namespaces.values(), key=lambda ns: len(ns), reverse=True):
+            events.append(("lifecycle", {"event": "completed"}, namespace))
+        self._open_namespaces = {}
+
+        data = self._root_lifecycle(lifecycle_status(status or ""))
         if isinstance(payload, dict) and (message := payload.get("message")):
             data["error"] = message
-        return [("lifecycle", data, [])]
+        events.append(("lifecycle", data, []))
+        return events
 
-    def _wants(self, channel: str) -> bool:
+    def _root_lifecycle(self, status: str) -> dict[str, Any]:
+        """Root-namespace lifecycle data, carrying the run's graph name when known."""
+        data: dict[str, Any] = {"event": status}
+        if self._current_graph:
+            data["graph_name"] = self._current_graph
+        return data
+
+    def _wants(self, channel: str, data: dict[str, Any] | None = None) -> bool:
         """True if the client subscribed to this channel.
 
-        The ``input.requested`` wire method maps to the ``input`` channel. A
-        custom subscription — plain ``custom`` or namespaced ``custom:<name>``
-        — matches the base ``custom`` channel. Named filtering is a follow-up.
+        The ``input.requested`` wire method maps to the ``input`` channel.
+        Custom events: a plain ``custom`` subscription receives everything; a
+        ``custom:<name>`` subscription receives only events whose ``data.name``
+        matches.
         """
         if channel == "input.requested":
             return "input" in self._channels
         if channel == "custom":
-            return any(c == "custom" or c.startswith("custom:") for c in self._channels)
+            if "custom" in self._channels:
+                return True
+            name = data.get("name") if isinstance(data, dict) else None
+            return isinstance(name, str) and f"custom:{name}" in self._channels
         return channel in self._channels
 
     def _wants_namespace(self, namespace: list[str]) -> bool:
@@ -267,6 +364,18 @@ class ThreadEventSession:
         if self._namespaces is None:
             return True
         return any(_prefix_matches(namespace, prefix) for prefix in self._namespaces)
+
+
+def _custom_events(method: str, data: Any, namespace: list[str]) -> list[_ChannelEvent]:
+    """Wrap a custom payload in the wire CustomEvent shape: ``{name?, payload}``.
+
+    Named user stream channels arrive as ``custom:<name>`` source methods; the
+    wire method is always ``custom`` with the name inside the data.
+    """
+    wrapped: dict[str, Any] = {"payload": data}
+    if method.startswith("custom:"):
+        wrapped = {"name": method[len("custom:") :], "payload": data}
+    return [("custom", wrapped, namespace)]
 
 
 def _prefix_matches(namespace: list[str], prefix: tuple[str, ...]) -> bool:

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -54,12 +54,16 @@ class ThreadEventSession:
         channels: set[str],
         list_run_ids: RunLister,
         since: int | None = None,
+        namespaces: list[list[str]] | None = None,
+        depth: int | None = None,
         idle_grace_seconds: float = _IDLE_GRACE_SECONDS,
     ) -> None:
         self._thread_id = thread_id
         self._channels = channels
         self._list_run_ids = list_run_ids
         self._since = since
+        self._namespaces = [tuple(prefix) for prefix in namespaces] if namespaces else None
+        self._depth = depth
         self._idle_grace = idle_grace_seconds
         self._seq = 0
         self._drained: set[str] = set()
@@ -137,6 +141,8 @@ class ThreadEventSession:
             # reconnect with a different channel set still resumes correctly.
             self._seq += 1
             if not self._wants(channel):
+                continue
+            if not self._wants_namespace(namespace):
                 continue
             if self._since is not None and self._seq <= self._since:
                 continue
@@ -218,6 +224,23 @@ class ThreadEventSession:
         if channel == "custom":
             return any(c == "custom" or c.startswith("custom:") for c in self._channels)
         return channel in self._channels
+
+    def _wants_namespace(self, namespace: list[str]) -> bool:
+        """True if the event's namespace passes the subgraph and depth filters.
+
+        Thread-level events (empty namespace) always pass — lifecycle and other
+        terminal signals are not subgraph-scoped. ``namespaces`` is a prefix
+        include-list; ``depth`` caps subgraph nesting.
+        """
+        if not namespace:
+            return True
+        if self._depth is not None and len(namespace) > self._depth:
+            return False
+        if self._namespaces is not None:
+            ns = tuple(namespace)
+            if not any(ns[: len(prefix)] == prefix for prefix in self._namespaces):
+                return False
+        return True
 
 
 def _is_terminal(raw_event: Any) -> bool:

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -16,6 +16,7 @@ from aegra_api.core.auth_ctx import with_auth_ctx
 from aegra_api.core.redis_manager import redis_manager
 from aegra_api.models.run_job import RunJob
 from aegra_api.services.broker import broker_manager
+from aegra_api.services.event_streaming.native_stream import stream_native_v3_events
 from aegra_api.services.graph_streaming import stream_graph_events
 from aegra_api.services.langgraph_service import create_run_config, get_langgraph_service
 from aegra_api.services.run_status import finalize_run, update_run_status
@@ -126,7 +127,6 @@ class _GraphResult:
 
 async def _stream_graph(job: RunJob) -> _GraphResult:
     """Load the graph, stream events to the broker, return final output."""
-    run_id = job.identity.run_id
     run_config = _build_run_config(job)
     execution_input = _resolve_input(job)
     stream_modes = _resolve_stream_modes(job.execution.stream_mode)
@@ -144,25 +144,73 @@ async def _stream_graph(job: RunJob) -> _GraphResult:
         ) as graph,
         with_auth_ctx(job.user, job.user.permissions),  # type: ignore[arg-type]
     ):
-        async for event_type, event_data in stream_graph_events(
-            graph=graph,
-            input_data=execution_input,
-            config=run_config,
-            stream_mode=stream_modes,
-            context=job.execution.context,
-            subgraphs=job.behavior.subgraphs,
-            on_checkpoint=lambda _: None,
-            on_task_result=lambda _: None,
-        ):
-            event_id = await broker_manager.allocate_event_id(run_id)
-            await streaming_service.put_to_broker(run_id, event_id, (event_type, event_data))
-
-            if isinstance(event_data, dict) and "__interrupt__" in event_data:
-                result.has_interrupt = True
-            if event_type.startswith("values"):
-                result.data = event_data
+        if job.execution.event_streaming_v2:
+            await _stream_native_v2(job, graph, execution_input, run_config, result)
+        else:
+            await _stream_legacy(job, graph, execution_input, run_config, stream_modes, result)
 
     return result
+
+
+async def _stream_legacy(
+    job: RunJob,
+    graph: Any,
+    execution_input: Any,
+    run_config: dict[str, Any],
+    stream_modes: list[str],
+    result: _GraphResult,
+) -> None:
+    """Stream via the v1 producer (legacy SSE endpoints)."""
+    run_id = job.identity.run_id
+    async for event_type, event_data in stream_graph_events(
+        graph=graph,
+        input_data=execution_input,
+        config=run_config,
+        stream_mode=stream_modes,
+        context=job.execution.context,
+        subgraphs=job.behavior.subgraphs,
+        on_checkpoint=lambda _: None,
+        on_task_result=lambda _: None,
+    ):
+        event_id = await broker_manager.allocate_event_id(run_id)
+        await streaming_service.put_to_broker(run_id, event_id, (event_type, event_data))
+
+        if isinstance(event_data, dict) and "__interrupt__" in event_data:
+            result.has_interrupt = True
+        if event_type.startswith("values"):
+            result.data = event_data
+
+
+async def _stream_native_v2(
+    job: RunJob,
+    graph: Any,
+    execution_input: Any,
+    run_config: dict[str, Any],
+    result: _GraphResult,
+) -> None:
+    """Stream via the native v3 protocol producer (Agent Protocol v2).
+
+    Each native event goes into the broker as ``(method, protocol_event)``.
+    Interrupts ride on a ``values`` event's ``params.interrupts``; the final
+    state is the last ``values`` event's ``params.data``.
+    """
+    run_id = job.identity.run_id
+    async for method, event in stream_native_v3_events(
+        graph=graph,
+        input_data=execution_input,
+        config=run_config,
+        context=job.execution.context,
+    ):
+        event_id = await broker_manager.allocate_event_id(run_id)
+        await streaming_service.put_to_broker(run_id, event_id, (method, event))
+
+        if method == "values":
+            params = event.get("params", {})
+            if params.get("interrupts"):
+                result.has_interrupt = True
+            data = params.get("data")
+            if isinstance(data, dict):
+                result.data = data
 
 
 def _build_run_config(job: RunJob) -> dict[str, Any]:

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -204,13 +204,14 @@ async def _stream_native_v2(
         event_id = await broker_manager.allocate_event_id(run_id)
         await streaming_service.put_to_broker(run_id, event_id, (method, event))
 
-        if method == "values":
-            params = event.get("params", {})
-            if params.get("interrupts"):
-                result.has_interrupt = True
-            data = params.get("data")
-            if isinstance(data, dict):
-                result.data = data
+        params = event.get("params", {})
+        data = params.get("data")
+        # Interrupts ride on values.params.interrupts, or as an __interrupt__ key
+        # in a values/updates payload (the path session.py routes to input.requested).
+        if params.get("interrupts") or (isinstance(data, dict) and "__interrupt__" in data):
+            result.has_interrupt = True
+        if method == "values" and isinstance(data, dict):
+            result.data = data
 
 
 def _build_run_config(job: RunJob) -> dict[str, Any]:

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -164,6 +164,7 @@ async def _prepare_run(
     user: User,
     *,
     initial_status: str,
+    event_streaming_v2: bool = False,
 ) -> tuple[str, Run, RunJob]:
     """Shared run-creation logic used by create, stream, and wait endpoints.
 
@@ -231,6 +232,7 @@ async def _prepare_run(
             stream_mode=request.stream_mode,
             checkpoint=request.checkpoint,
             command=request.command,
+            event_streaming_v2=event_streaming_v2,
         ),
         behavior=RunBehavior(
             interrupt_before=request.interrupt_before,

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -29,8 +29,13 @@ logger = structlog.getLogger(__name__)
 
 
 async def _validate_resume_command(session: AsyncSession, thread_id: str, command: dict[str, Any] | None) -> None:
-    """Validate resume command requirements."""
-    if command and command.get("resume") is not None:
+    """Validate resume command requirements.
+
+    Guard on the presence of the ``resume`` key, not a non-None value: ``None``
+    is a valid resume payload, and a ``{"resume": None}`` command must still be
+    rejected against a thread that is not interrupted.
+    """
+    if command and "resume" in command:
         # Check if thread exists and is in interrupted state
         thread_stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id)
         thread = await session.scalar(thread_stmt)

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -4,6 +4,7 @@ Contains the shared run-creation helper, thread metadata updates,
 resume-command validation, and config/context merging logic.
 """
 
+import asyncio
 from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
@@ -17,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from aegra_api.core.orm import Assistant as AssistantORM
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.core.orm import _get_session_maker
 from aegra_api.models import Run, RunCreate, User
 from aegra_api.models.run_job import RunBehavior, RunExecution, RunIdentity, RunJob
 from aegra_api.services.executor import executor
@@ -28,6 +30,15 @@ from aegra_api.utils.run_utils import _merge_jsonb
 logger = structlog.getLogger(__name__)
 
 
+# The interrupt reaches the client (via the broker/SSE) before the run executor
+# commits thread_status="interrupted" in finalize_run. A client that resumes the
+# instant it sees the interrupt can beat that commit, so after the first read poll
+# a few times on FRESH sessions (each a new snapshot that sees the commit) before
+# rejecting — otherwise a valid resume races to a spurious 400.
+_RESUME_SETTLE_ATTEMPTS = 10
+_RESUME_SETTLE_INTERVAL_SECONDS = 0.1
+
+
 async def _validate_resume_command(session: AsyncSession, thread_id: str, command: dict[str, Any] | None) -> None:
     """Validate resume command requirements.
 
@@ -35,14 +46,27 @@ async def _validate_resume_command(session: AsyncSession, thread_id: str, comman
     is a valid resume payload, and a ``{"resume": None}`` command must still be
     rejected against a thread that is not interrupted.
     """
-    if command and "resume" in command:
-        # Check if thread exists and is in interrupted state
-        thread_stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id)
-        thread = await session.scalar(thread_stmt)
-        if not thread:
-            raise HTTPException(404, f"Thread '{thread_id}' not found")
-        if thread.status != "interrupted":
-            raise HTTPException(400, "Cannot resume: thread is not in interrupted state")
+    if not command or "resume" not in command:
+        return
+
+    thread_stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id)
+    thread = await session.scalar(thread_stmt)
+    if not thread:
+        raise HTTPException(404, f"Thread '{thread_id}' not found")
+    if thread.status == "interrupted":
+        return
+
+    # Not interrupted on the request session's snapshot — poll fresh sessions in
+    # case finalize_run's commit is still in flight.
+    maker = _get_session_maker()
+    for _ in range(_RESUME_SETTLE_ATTEMPTS):
+        await asyncio.sleep(_RESUME_SETTLE_INTERVAL_SECONDS)
+        async with maker() as fresh:
+            fresh_thread = await fresh.scalar(thread_stmt)
+        if fresh_thread is not None and fresh_thread.status == "interrupted":
+            return
+
+    raise HTTPException(400, "Cannot resume: thread is not in interrupted state")
 
 
 _THREAD_NAME_MAX_LENGTH = 100

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -432,10 +432,10 @@ class EventStreamingSettings(EnvBase):
     """Agent Protocol v2 event streaming (/threads/{id}/stream/events + /commands).
 
     On by default — it's a new endpoint set the LangGraph SDK targets and
-    has no v1 to break. The flag is a kill switch: set false to unregister
-    the routes (clients then get 404) and roll back without a redeploy.
-    Requires a langgraph/langchain-core new enough to emit native v3 events
-    (enforced by event_streaming.capabilities; otherwise 503).
+    has no v1 to break. The flag is a kill switch: set false to disable v2
+    serving (requests return 503 with an enable hint) and roll back without
+    a redeploy. Also requires a langgraph/langchain-core new enough to emit
+    native v3 events (enforced by event_streaming.capabilities; otherwise 503).
     """
 
     FF_V2_EVENT_STREAMING: bool = True

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -428,6 +428,19 @@ class CronSettings(EnvBase):
         return self
 
 
+class EventStreamingSettings(EnvBase):
+    """Agent Protocol v2 event streaming (/threads/{id}/stream/events + /commands).
+
+    On by default — it's a new endpoint set the LangGraph SDK targets and
+    has no v1 to break. The flag is a kill switch: set false to unregister
+    the routes (clients then get 404) and roll back without a redeploy.
+    Requires a langgraph/langchain-core new enough to emit native v3 events
+    (enforced by event_streaming.capabilities; otherwise 503).
+    """
+
+    FF_V2_EVENT_STREAMING: bool = True
+
+
 class Settings:
     """Container object that instantiates all application settings groups."""
 
@@ -440,6 +453,7 @@ class Settings:
         self.redis = RedisSettings()
         self.worker = WorkerSettings()
         self.cron = CronSettings()
+        self.event_streaming = EventStreamingSettings()
 
 
 settings = Settings()

--- a/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
@@ -345,6 +345,48 @@ async def test_reconnect_with_since_resumes_without_replaying_seen_events() -> N
     )
 
 
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_sdk_subgraph_emits_nested_lifecycle_events() -> None:
+    """A subgraph run emits per-subgraph lifecycle (started + completed) on the
+    child namespace, plus the root terminal lifecycle. Nested agents get the full
+    lifecycle tree, not just one root frame."""
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    assistant_id = await _ensure_graph("subgraph_agent")
+    client = get_client(url=_base_url())
+
+    nested_started: list[tuple[str, str]] = []
+    nested_completed: list[str] = []
+    root_terminal: list[str] = []
+    async with client.threads.stream(assistant_id=assistant_id) as ts:
+        await ts.run.start(input={"messages": [{"role": "user", "content": "say hello briefly"}]})
+        async for event in ts.events:
+            if event.get("method") != "lifecycle":
+                continue
+            params = event.get("params", {}) or {}
+            data = params.get("data") or {}
+            namespace = params.get("namespace") or []
+            kind = data.get("event")
+            if namespace:
+                if kind == "started":
+                    nested_started.append((tuple(namespace), data.get("graph_name")))
+                elif kind in ("completed", "failed"):
+                    nested_completed.append(tuple(namespace))
+            elif kind in ("completed", "failed"):
+                root_terminal.append(kind)
+                break
+
+    elog("subgraph nested started", nested_started)
+    elog("subgraph nested completed", nested_completed)
+    elog("subgraph root terminal", root_terminal)
+    assert nested_started, "no subgraph lifecycle: started on a child namespace"
+    assert all(gname for _, gname in nested_started), "subgraph started missing graph_name"
+    assert nested_completed, "no subgraph lifecycle: completed on a child namespace"
+    assert root_terminal == ["completed"], f"run did not reach root completed; got {root_terminal}"
+
+
 async def _resume_via_sdk(ts: object, interrupt_id: str, response: object = {"action": "approve"}) -> None:  # noqa: B006
     """Call ``ts.run.respond`` once the SDK's lifecycle watcher has registered the
     interrupt. The watcher runs on a separate SSE, so the main stream can surface

--- a/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
@@ -216,6 +216,135 @@ async def test_sdk_hitl_interrupt_surfaces_on_input_channel_and_resumes() -> Non
     )
 
 
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_sdk_graph_error_surfaces_as_lifecycle_failed() -> None:
+    """A graph that raises ends the stream with lifecycle: failed carrying the error."""
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    assistant_id = await _ensure_graph("stress_test")
+    client = get_client(url=_base_url())
+
+    lifecycle_events: list[dict] = []
+    async with client.threads.stream(assistant_id=assistant_id) as ts:
+        # stress_test raises RuntimeError when {"fail": true} reaches the target step.
+        await ts.run.start(
+            input={"messages": [{"role": "user", "content": json.dumps({"delay": 0.0, "steps": 1, "fail": True})}]}
+        )
+        async for event in ts.events:
+            if event.get("method") == "lifecycle":
+                data = event.get("params", {}).get("data") or {}
+                lifecycle_events.append(data)
+                if data.get("event") in ("completed", "failed"):
+                    break
+
+    elog("error lifecycle", lifecycle_events)
+    failed = [e for e in lifecycle_events if e.get("event") == "failed"]
+    assert failed, f"graph error did not surface as lifecycle: failed; got {lifecycle_events}"
+    assert isinstance(failed[0].get("error"), str) and failed[0]["error"], "failed lifecycle missing error string"
+
+
+def _parse_sse_frames(buffer: str) -> tuple[list[dict], str]:
+    """Parse complete SSE frames from ``buffer``; return (frames, leftover).
+
+    The leftover is any trailing partial frame (no terminating blank line yet),
+    carried into the next read so a frame split across chunks is not dropped.
+    """
+    *complete, leftover = buffer.split("\n\n")
+    frames: list[dict] = []
+    for block in complete:
+        if not block.strip():
+            continue
+        frame: dict = {}
+        for line in block.splitlines():
+            if line.startswith("event:"):
+                frame["event"] = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                frame["data"] = json.loads(line[len("data:") :].strip())
+            elif line.startswith("id:"):
+                frame["id"] = line[len("id:") :].strip()
+        if "data" in frame:
+            frames.append(frame)
+    return frames, leftover
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_reconnect_with_since_resumes_without_replaying_seen_events() -> None:
+    """Reconnecting with ``since=<last seq>`` resumes past seen events, no duplicates.
+
+    Drives the raw wire (the SDK hides reconnect): open, read a few frames, note the
+    last seq, close, reopen with that seq as ``since``. The server must only send
+    events with a strictly greater seq, and the run still reaches a terminal lifecycle.
+    """
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    client = get_client(url=_base_url())
+    assistant_id = await _ensure_graph("stress_test")
+    thread = await client.threads.create()
+    thread_id = thread["thread_id"]
+    body = {"channels": ["values", "messages", "lifecycle"]}
+
+    # Start a multi-step run so there are several events to split across two connects.
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=30.0) as http:
+        await http.post(
+            f"/threads/{thread_id}/commands",
+            json={
+                "id": 1,
+                "method": "run.start",
+                "params": {
+                    "assistant_id": assistant_id,
+                    "input": {"messages": [{"role": "user", "content": json.dumps({"delay": 0.2, "steps": 3})}]},
+                },
+            },
+        )
+
+        # First connect: collect a couple of frames, then bail with the last seq seen.
+        first_seqs: list[int] = []
+        last_seq = 0
+        async with http.stream("POST", f"/threads/{thread_id}/stream/events", json=body) as resp:
+            assert resp.status_code == 200
+            buffer = ""
+            async for chunk in resp.aiter_text():
+                buffer += chunk
+                parsed, buffer = _parse_sse_frames(buffer)
+                for frame in parsed:
+                    seq = frame["data"].get("seq")
+                    if isinstance(seq, int):
+                        first_seqs.append(seq)
+                        last_seq = max(last_seq, seq)
+                if len(first_seqs) >= 2:
+                    break
+
+        assert last_seq > 0, "no seq'd events on first connect"
+
+        # Second connect with since=last_seq: must not replay anything <= last_seq.
+        second_seqs: list[int] = []
+        terminal: list[str] = []
+        async with http.stream("POST", f"/threads/{thread_id}/stream/events", json={**body, "since": last_seq}) as resp:
+            assert resp.status_code == 200
+            buffer = ""
+            async for chunk in resp.aiter_text():
+                buffer += chunk
+                parsed, buffer = _parse_sse_frames(buffer)
+                for frame in parsed:
+                    seq = frame["data"].get("seq")
+                    if isinstance(seq, int):
+                        second_seqs.append(seq)
+                    if frame.get("event") == "lifecycle":
+                        terminal.append(frame["data"].get("params", {}).get("data", {}).get("event"))
+                if any(t in ("completed", "failed") for t in terminal):
+                    break
+
+    elog("reconnect first/second seqs", {"first": first_seqs, "last": last_seq, "second": second_seqs[:10]})
+    assert second_seqs, "no events on reconnect"
+    assert all(s > last_seq for s in second_seqs), (
+        f"reconnect replayed events at/below since={last_seq}: {[s for s in second_seqs if s <= last_seq]}"
+    )
+
+
 async def _resume_via_sdk(ts: object, interrupt_id: str) -> None:
     """Call ``ts.run.respond`` once the SDK's lifecycle watcher has registered the
     interrupt. The watcher runs on a separate SSE, so the main stream can surface

--- a/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
@@ -8,6 +8,7 @@ Skipped unless the server has ``FF_V2_EVENT_STREAMING=true`` (else 503).
 Uses the ``stress_test`` graph (no LLM) so the run is hermetic.
 """
 
+import asyncio
 import json
 
 import httpx
@@ -151,7 +152,7 @@ async def test_sdk_tool_agent_streams_content_blocks_and_tool_calls() -> None:
         await ts.run.start(input={"messages": [{"role": "user", "content": "Process steps 1 and 2."}]})
         async for event in ts.events:
             events.append(event)
-            data = event.get("params", {}).get("data")
+            data = event.get("params", {}).get("data") or {}
             if isinstance(data, dict) and "tool_call" in json.dumps(data):
                 tool_call_seen = True
             if event.get("method") == "lifecycle" and data.get("event") in ("completed", "failed"):
@@ -180,6 +181,8 @@ async def test_sdk_hitl_interrupt_surfaces_on_input_channel_and_resumes() -> Non
     client = get_client(url=_base_url())
 
     input_requested: list[dict] = []
+    resumed = False
+    lifecycle_after_resume: list[str] = []
     async with client.threads.stream(assistant_id=assistant_id) as ts:
         # A search request makes the agent call a tool, which the graph gates
         # behind a human-approval interrupt.
@@ -187,15 +190,38 @@ async def test_sdk_hitl_interrupt_surfaces_on_input_channel_and_resumes() -> Non
             input={"messages": [{"role": "user", "content": "Search the web for the latest LangGraph release."}]}
         )
         async for event in ts.events:
-            if event.get("method") == "input.requested":
-                input_requested.append(event["params"]["data"])
             method = event.get("method")
-            data = event.get("params", {}).get("data", {})
-            if input_requested:
-                break
-            if method == "lifecycle" and data.get("event") in ("completed", "failed"):
-                break
+            data = event.get("params", {}).get("data") or {}
+            if method == "input.requested" and not resumed:
+                input_requested.append(data)
+                # Resume on the SAME open stream — the SDK does not reopen it.
+                # Proves the session keeps the stream alive across the run gap
+                # and that resume works without re-supplying an assistant.
+                await _resume_via_sdk(ts, data["interrupt_id"])
+                resumed = True
+                continue
+            if resumed and method == "lifecycle":
+                lifecycle_after_resume.append(data.get("event"))
+                if data.get("event") in ("completed", "failed"):
+                    break
 
     elog("hitl input.requested", input_requested)
+    elog("hitl lifecycle after resume", lifecycle_after_resume)
     assert input_requested, "interrupt did not surface on the input channel"
     assert isinstance(input_requested[0].get("interrupt_id"), str)
+    # value (not payload) is the SDK's InterruptPayload field.
+    assert "value" in input_requested[0], "interrupt value missing from input.requested"
+    assert "completed" in lifecycle_after_resume, (
+        f"resume did not run to completion on the same stream; got {lifecycle_after_resume}"
+    )
+
+
+async def _resume_via_sdk(ts: object, interrupt_id: str) -> None:
+    """Call ``ts.run.respond`` once the SDK's lifecycle watcher has registered the
+    interrupt. The watcher runs on a separate SSE, so the main stream can surface
+    ``input.requested`` a beat before ``ts.interrupts`` is populated."""
+    for _ in range(50):
+        if any(p.get("interrupt_id") == interrupt_id for p in ts.interrupts):  # type: ignore[attr-defined]
+            break
+        await asyncio.sleep(0.1)
+    await ts.run.respond({"action": "approve"}, interrupt_id=interrupt_id)  # type: ignore[attr-defined]

--- a/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
@@ -1,0 +1,201 @@
+"""E2E tests driving v2 streaming through the real langgraph-sdk client.
+
+The point of these is fidelity: they use ``client.threads.stream`` exactly
+as an application (or the Vue/React ``useStream``) would, so passing them
+proves wire compatibility with the stock SDK, not just our own wire shape.
+
+Skipped unless the server has ``FF_V2_EVENT_STREAMING=true`` (else 503).
+Uses the ``stress_test`` graph (no LLM) so the run is hermetic.
+"""
+
+import json
+
+import httpx
+import pytest
+from langgraph_sdk import get_client
+
+from aegra_api.settings import settings
+from tests.e2e._utils import elog
+
+
+def _base_url() -> str:
+    url = settings.app.SERVER_URL
+    assert url is not None
+    return url
+
+
+async def _v2_enabled() -> bool:
+    """True if the server has v2 streaming on (a thread command returns non-503)."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=10.0) as http:
+        client = get_client(url=_base_url())
+        thread = await client.threads.create()
+        resp = await http.post(
+            f"/threads/{thread['thread_id']}/commands",
+            json={"id": 0, "method": "run.start", "params": {}},
+        )
+        return resp.status_code != 503
+
+
+async def _ensure_assistant() -> str:
+    client = get_client(url=_base_url())
+    assistant = await client.assistants.create(graph_id="stress_test", if_exists="do_nothing")
+    return assistant["assistant_id"]
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_sdk_thread_stream_run_start_and_events() -> None:
+    """The stock SDK starts a run and receives v2 events over the thread stream."""
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    assistant_id = await _ensure_assistant()
+    client = get_client(url=_base_url())
+
+    methods: list[str] = []
+    lifecycle_events: list[str] = []
+    async with client.threads.stream(assistant_id=assistant_id) as ts:
+        await ts.run.start(input={"messages": [{"role": "user", "content": json.dumps({"delay": 0.1, "steps": 1})}]})
+        async for event in ts.events:
+            method = event.get("method")
+            methods.append(method)
+            if method == "lifecycle":
+                lifecycle_events.append(event["params"]["data"]["event"])
+            if "completed" in lifecycle_events or "failed" in lifecycle_events:
+                break
+
+    elog("sdk thread stream methods", methods)
+    assert "lifecycle" in methods, f"no lifecycle event received; got {methods}"
+    assert "completed" in lifecycle_events, f"run did not complete; lifecycle={lifecycle_events}"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_sdk_receives_values_events() -> None:
+    """The SDK receives values-channel events carrying the run's state."""
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    assistant_id = await _ensure_assistant()
+    client = get_client(url=_base_url())
+
+    value_payloads: list[dict] = []
+    async with client.threads.stream(assistant_id=assistant_id) as ts:
+        await ts.run.start(input={"messages": [{"role": "user", "content": json.dumps({"delay": 0.1, "steps": 1})}]})
+        async for event in ts.events:
+            if event.get("method") == "values":
+                value_payloads.append(event["params"]["data"])
+            if event.get("method") == "lifecycle" and event["params"]["data"]["event"] in ("completed", "failed"):
+                break
+
+    elog("sdk values events", value_payloads)
+    assert value_payloads, "no values events received"
+    assert any("messages" in payload for payload in value_payloads)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_raw_wire_body_matches_sdk_contract() -> None:
+    """The stream endpoint accepts the exact body the SDK sends: {channels} only."""
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    client = get_client(url=_base_url())
+    thread = await client.threads.create()
+    thread_id = thread["thread_id"]
+
+    # No run started and no run_id in the body — must open (200), not 4xx.
+    async with (
+        httpx.AsyncClient(base_url=_base_url(), timeout=15.0) as http,
+        http.stream("POST", f"/threads/{thread_id}/stream/events", json={"channels": ["lifecycle"]}) as resp,
+    ):
+        assert resp.status_code == 200, f"SDK-shaped body rejected: {resp.status_code}"
+        await resp.aclose()
+
+
+async def _ensure_graph(graph_id: str) -> str:
+    client = get_client(url=_base_url())
+    assistant = await client.assistants.create(graph_id=graph_id, if_exists="do_nothing")
+    return assistant["assistant_id"]
+
+
+def _content_block_events(events: list[dict]) -> set[str]:
+    """The set of message content-block lifecycle events seen on the stream."""
+    seen: set[str] = set()
+    for event in events:
+        if event.get("method") != "messages":
+            continue
+        data = event["params"]["data"]
+        if isinstance(data, dict) and isinstance(data.get("event"), str):
+            seen.add(data["event"])
+    return seen
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_sdk_tool_agent_streams_content_blocks_and_tool_calls() -> None:
+    """A tool-calling agent streams the full content-block lifecycle incl. tool-call blocks.
+
+    This is the path that was invisible before going native — tool calls now
+    arrive as ``content-block-*`` events on the messages channel.
+    """
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    assistant_id = await _ensure_graph("stress_tool_agent")
+    client = get_client(url=_base_url())
+
+    events: list[dict] = []
+    tool_call_seen = False
+    async with client.threads.stream(assistant_id=assistant_id) as ts:
+        await ts.run.start(input={"messages": [{"role": "user", "content": "Process steps 1 and 2."}]})
+        async for event in ts.events:
+            events.append(event)
+            data = event.get("params", {}).get("data")
+            if isinstance(data, dict) and "tool_call" in json.dumps(data):
+                tool_call_seen = True
+            if event.get("method") == "lifecycle" and data.get("event") in ("completed", "failed"):
+                break
+
+    blocks = _content_block_events(events)
+    elog("tool agent content-block events", sorted(blocks))
+    assert "message-start" in blocks
+    assert "content-block-delta" in blocks
+    assert "message-finish" in blocks
+    assert tool_call_seen, "no tool-call content reached the stream"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_sdk_hitl_interrupt_surfaces_on_input_channel_and_resumes() -> None:
+    """A HITL interrupt surfaces as input.requested; input.respond resumes the run.
+
+    This is the path that was broken before going native — the SDK could not
+    learn the interrupt id, so it could not resume.
+    """
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    assistant_id = await _ensure_graph("agent_hitl")
+    client = get_client(url=_base_url())
+
+    input_requested: list[dict] = []
+    async with client.threads.stream(assistant_id=assistant_id) as ts:
+        # A search request makes the agent call a tool, which the graph gates
+        # behind a human-approval interrupt.
+        await ts.run.start(
+            input={"messages": [{"role": "user", "content": "Search the web for the latest LangGraph release."}]}
+        )
+        async for event in ts.events:
+            if event.get("method") == "input.requested":
+                input_requested.append(event["params"]["data"])
+            method = event.get("method")
+            data = event.get("params", {}).get("data", {})
+            if input_requested:
+                break
+            if method == "lifecycle" and data.get("event") in ("completed", "failed"):
+                break
+
+    elog("hitl input.requested", input_requested)
+    assert input_requested, "interrupt did not surface on the input channel"
+    assert isinstance(input_requested[0].get("interrupt_id"), str)

--- a/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
@@ -224,4 +224,6 @@ async def _resume_via_sdk(ts: object, interrupt_id: str) -> None:
         if any(p.get("interrupt_id") == interrupt_id for p in ts.interrupts):  # type: ignore[attr-defined]
             break
         await asyncio.sleep(0.1)
+    else:
+        raise AssertionError(f"SDK never registered interrupt {interrupt_id}: {ts.interrupts!r}")  # type: ignore[attr-defined]
     await ts.run.respond({"action": "approve"}, interrupt_id=interrupt_id)  # type: ignore[attr-defined]

--- a/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
@@ -345,7 +345,7 @@ async def test_reconnect_with_since_resumes_without_replaying_seen_events() -> N
     )
 
 
-async def _resume_via_sdk(ts: object, interrupt_id: str) -> None:
+async def _resume_via_sdk(ts: object, interrupt_id: str, response: object = {"action": "approve"}) -> None:  # noqa: B006
     """Call ``ts.run.respond`` once the SDK's lifecycle watcher has registered the
     interrupt. The watcher runs on a separate SSE, so the main stream can surface
     ``input.requested`` a beat before ``ts.interrupts`` is populated."""
@@ -355,4 +355,91 @@ async def _resume_via_sdk(ts: object, interrupt_id: str) -> None:
         await asyncio.sleep(0.1)
     else:
         raise AssertionError(f"SDK never registered interrupt {interrupt_id}: {ts.interrupts!r}")  # type: ignore[attr-defined]
-    await ts.run.respond({"action": "approve"}, interrupt_id=interrupt_id)  # type: ignore[attr-defined]
+    await ts.run.respond(response, interrupt_id=interrupt_id)  # type: ignore[attr-defined]
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_hitl_ignore_resume_runs_to_completion() -> None:
+    """An 'ignore' resume (cancels the tool call, routes to END) completes on the
+    same open stream. Covers a non-approve resume payload shape and confirms the
+    resume-settle fix (the interrupt-status race) holds under a real resume."""
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    assistant_id = await _ensure_graph("agent_hitl")
+    client = get_client(url=_base_url())
+    resumed = False
+    lifecycle_after_resume: list[str] = []
+    async with client.threads.stream(assistant_id=assistant_id) as ts:
+        await ts.run.start(
+            input={"messages": [{"role": "user", "content": "Search the web for the latest LangGraph release."}]}
+        )
+        async for event in ts.events:
+            method = event.get("method")
+            data = event.get("params", {}).get("data") or {}
+            if method == "input.requested" and not resumed:
+                await _resume_via_sdk(ts, data["interrupt_id"], [{"type": "ignore"}])
+                resumed = True
+                continue
+            if resumed and method == "lifecycle":
+                lifecycle_after_resume.append(data.get("event"))
+                if data.get("event") in ("completed", "failed"):
+                    break
+
+    elog("hitl ignore lifecycle", lifecycle_after_resume)
+    assert "completed" in lifecycle_after_resume, f"ignore resume did not complete; got {lifecycle_after_resume}"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_cancel_run_closes_v2_stream_with_terminal_lifecycle() -> None:
+    """Cancelling a v2 run ends its open stream with a terminal lifecycle event.
+
+    A client must not hang after a cancel: the session has to see the terminal
+    broker event and emit a lifecycle so ts.events stops.
+    """
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    assistant_id = await _ensure_graph("stress_test")
+    client = get_client(url=_base_url())
+    thread = await client.threads.create()
+    thread_id = thread["thread_id"]
+
+    # Long-running run so there is a window to cancel mid-flight.
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=30.0) as http:
+        resp = await http.post(
+            f"/threads/{thread_id}/commands",
+            json={
+                "id": 1,
+                "method": "run.start",
+                "params": {
+                    "assistant_id": assistant_id,
+                    "input": {"messages": [{"role": "user", "content": json.dumps({"delay": 1.0, "steps": 10})}]},
+                },
+            },
+        )
+        run_id = resp.json()["result"]["run_id"]
+
+    lifecycle_events: list[str] = []
+    cancelled = False
+    async with client.threads.stream(assistant_id=assistant_id, thread_id=thread_id) as ts:
+        async for event in ts.events:
+            method = event.get("method")
+            data = event.get("params", {}).get("data") or {}
+            if not cancelled and method in ("values", "messages"):
+                # Seen live output — cancel now, mid-stream.
+                await client.runs.cancel(thread_id, run_id)
+                cancelled = True
+            if method == "lifecycle":
+                lifecycle_events.append(data.get("event"))
+                if data.get("event") in ("completed", "failed", "interrupted"):
+                    break
+
+    elog("cancel lifecycle", lifecycle_events)
+    assert cancelled, "never saw live output to cancel against"
+    assert lifecycle_events, "stream did not emit a terminal lifecycle after cancel — client would hang"
+    assert lifecycle_events[-1] in ("interrupted", "failed"), (
+        f"cancelled run should end interrupted/failed, got {lifecycle_events}"
+    )

--- a/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
+++ b/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
@@ -1,0 +1,158 @@
+"""Integration tests for the v2 event streaming routes."""
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aegra_api.api import event_streaming as es_module
+from aegra_api.core.auth_deps import get_current_user, require_auth
+from aegra_api.core.orm import get_session
+from aegra_api.models.auth import User
+from aegra_api.services.broker import broker_manager
+from aegra_api.services.event_streaming import capabilities as caps
+from aegra_api.services.event_streaming import commands as cmd_module
+
+_USER = "test-user"
+
+
+class _Session:
+    """Test session: scalar() returns the thread's owner id, scalars() lists runs.
+
+    ``owner`` is the existing thread's user_id, or None when the thread does
+    not exist yet (the run.start-creates-it path the SDK relies on).
+    """
+
+    def __init__(self, *, owner: str | None, run_ids: list[str] | None = None) -> None:
+        self._owner = owner
+        self._run_ids = run_ids or []
+
+    async def scalar(self, _stmt: Any) -> Any:
+        return self._owner
+
+    async def scalars(self, _stmt: Any) -> Any:
+        run_ids = self._run_ids
+
+        class _Result:
+            def all(self) -> list[str]:
+                return run_ids
+
+        return _Result()
+
+
+def _make_app(*, owner: str | None = _USER, run_ids: list[str] | None = None) -> FastAPI:
+    app = FastAPI()
+    user = User(identity=_USER)
+    app.dependency_overrides[require_auth] = lambda: user
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_session] = lambda: _Session(owner=owner, run_ids=run_ids)
+    app.include_router(es_module.router)
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _v2_enabled(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Turn the flag on and clear the capability cache for each test."""
+    monkeypatch.setattr(caps.settings.event_streaming, "FF_V2_EVENT_STREAMING", True)
+    caps._probe_runtime_symbols.cache_clear()
+    yield
+    caps._probe_runtime_symbols.cache_clear()
+
+
+class TestCommandRoute:
+    def test_run_start_returns_success_envelope(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fake_prepare(*_args: Any, **_kwargs: Any) -> tuple[str, object, object]:
+            return "run-1", object(), object()
+
+        monkeypatch.setattr(cmd_module, "_prepare_run", fake_prepare)
+        client = TestClient(_make_app())
+
+        resp = client.post(
+            "/threads/t1/commands",
+            json={"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "input": {"messages": []}}},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"type": "success", "id": 1, "result": {"run_id": "run-1"}}
+
+    def test_unknown_command_returns_400_error_envelope(self) -> None:
+        client = TestClient(_make_app())
+        resp = client.post("/threads/t1/commands", json={"id": 1, "method": "agent.getTree", "params": {}})
+        assert resp.status_code == 400
+        assert resp.json()["error"] == "not_supported"
+
+    def test_cross_tenant_thread_is_404(self) -> None:
+        client = TestClient(_make_app(owner="other-user"))
+        resp = client.post("/threads/t1/commands", json={"id": 1, "method": "run.start", "params": {}})
+        assert resp.status_code == 404
+
+    def test_new_thread_is_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """run.start against a not-yet-created thread is allowed (the SDK path)."""
+
+        async def fake_prepare(*_args: Any, **_kwargs: Any) -> tuple[str, object, object]:
+            return "run-1", object(), object()
+
+        monkeypatch.setattr(cmd_module, "_prepare_run", fake_prepare)
+        client = TestClient(_make_app(owner=None))  # thread does not exist yet
+        resp = client.post(
+            "/threads/new-thread/commands",
+            json={"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "input": {"messages": []}}},
+        )
+        assert resp.status_code == 200
+
+    def test_disabled_flag_returns_503(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(caps.settings.event_streaming, "FF_V2_EVENT_STREAMING", False)
+        client = TestClient(_make_app())
+        resp = client.post("/threads/t1/commands", json={"id": 1, "method": "run.start", "params": {}})
+        assert resp.status_code == 503
+        assert "FF_V2_EVENT_STREAMING" in resp.json()["detail"]
+
+
+class TestStreamRoute:
+    def test_missing_channels_is_422(self) -> None:
+        client = TestClient(_make_app())
+        resp = client.post("/threads/t1/stream/events", json={})
+        assert resp.status_code == 422
+
+    def test_unknown_channel_is_400(self) -> None:
+        client = TestClient(_make_app())
+        resp = client.post("/threads/t1/stream/events", json={"channels": ["bogus"]})
+        assert resp.status_code == 400
+
+    def test_cross_tenant_thread_is_404(self) -> None:
+        client = TestClient(_make_app(owner="other-user"))
+        resp = client.post("/threads/t1/stream/events", json={"channels": ["messages"]})
+        assert resp.status_code == 404
+
+    def test_stream_emits_v2_frames(self) -> None:
+        """A run on the thread streams content-block frames over SSE."""
+        run_id = f"run-{uuid.uuid4().hex[:8]}"
+
+        def _msg(event_kind: str, **extra: Any) -> tuple[str, dict[str, Any]]:
+            data = {"event": event_kind, **extra}
+            return ("messages", {"type": "event", "method": "messages", "params": {"namespace": [], "data": data}})
+
+        async def seed() -> None:
+            broker = broker_manager.get_or_create_broker(run_id)
+            await broker.put(f"{run_id}_event_1", _msg("message-start", role="ai", id="m1"))
+            await broker.put(
+                f"{run_id}_event_2", _msg("content-block-delta", index=0, delta={"type": "text-delta", "text": "hi"})
+            )
+            await broker.put(f"{run_id}_event_3", _msg("message-finish"))
+            await broker.put(f"{run_id}_event_4", ("end", {"status": "success"}))
+
+        asyncio.run(seed())
+        client = TestClient(_make_app(run_ids=[run_id]))
+
+        with client.stream("POST", "/threads/t1/stream/events", json={"channels": ["messages", "lifecycle"]}) as resp:
+            assert resp.status_code == 200
+            body = "".join(resp.iter_text())
+
+        assert "event: messages" in body
+        assert "message-start" in body
+        assert "content-block-delta" in body
+        assert "event: lifecycle" in body
+        assert "completed" in body

--- a/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
+++ b/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
@@ -51,14 +51,16 @@ class _Session:
         return _Result()
 
 
-def _make_app(*, owner: str | None = _USER, run_ids: list[str] | None = None) -> FastAPI:
+def _make_app(
+    monkeypatch: pytest.MonkeyPatch, *, owner: str | None = _USER, run_ids: list[str] | None = None
+) -> FastAPI:
     app = FastAPI()
     user = User(identity=_USER)
     app.dependency_overrides[require_auth] = lambda: user
     app.dependency_overrides[get_current_user] = lambda: user
-    # Routes open short-lived sessions via _get_session_maker(); patch it to
-    # return a maker yielding the in-memory test session.
-    es_module._get_session_maker = lambda: lambda: _Session(owner=owner, run_ids=run_ids)  # type: ignore[attr-defined]
+    # Routes open short-lived sessions via _get_session_maker(); patch it (per
+    # test, auto-restored) to return a maker yielding the in-memory test session.
+    monkeypatch.setattr(es_module, "_get_session_maker", lambda: lambda: _Session(owner=owner, run_ids=run_ids))
     app.include_router(es_module.router)
     return app
 
@@ -78,7 +80,7 @@ class TestCommandRoute:
             return "run-1", object(), object()
 
         monkeypatch.setattr(cmd_module, "_prepare_run", fake_prepare)
-        client = TestClient(_make_app())
+        client = TestClient(_make_app(monkeypatch))
 
         resp = client.post(
             "/threads/t1/commands",
@@ -87,14 +89,14 @@ class TestCommandRoute:
         assert resp.status_code == 200
         assert resp.json() == {"type": "success", "id": 1, "result": {"run_id": "run-1"}}
 
-    def test_unknown_command_returns_400_error_envelope(self) -> None:
-        client = TestClient(_make_app())
+    def test_unknown_command_returns_400_error_envelope(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = TestClient(_make_app(monkeypatch))
         resp = client.post("/threads/t1/commands", json={"id": 1, "method": "agent.getTree", "params": {}})
         assert resp.status_code == 400
         assert resp.json()["error"] == "not_supported"
 
-    def test_cross_tenant_thread_is_404(self) -> None:
-        client = TestClient(_make_app(owner="other-user"))
+    def test_cross_tenant_thread_is_404(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = TestClient(_make_app(monkeypatch, owner="other-user"))
         resp = client.post("/threads/t1/commands", json={"id": 1, "method": "run.start", "params": {}})
         assert resp.status_code == 404
 
@@ -105,7 +107,7 @@ class TestCommandRoute:
             return "run-1", object(), object()
 
         monkeypatch.setattr(cmd_module, "_prepare_run", fake_prepare)
-        client = TestClient(_make_app(owner=None))  # thread does not exist yet
+        client = TestClient(_make_app(monkeypatch, owner=None))  # thread does not exist yet
         resp = client.post(
             "/threads/new-thread/commands",
             json={"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "input": {"messages": []}}},
@@ -114,29 +116,29 @@ class TestCommandRoute:
 
     def test_disabled_flag_returns_503(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(caps.settings.event_streaming, "FF_V2_EVENT_STREAMING", False)
-        client = TestClient(_make_app())
+        client = TestClient(_make_app(monkeypatch))
         resp = client.post("/threads/t1/commands", json={"id": 1, "method": "run.start", "params": {}})
         assert resp.status_code == 503
         assert "FF_V2_EVENT_STREAMING" in resp.json()["detail"]
 
 
 class TestStreamRoute:
-    def test_missing_channels_is_422(self) -> None:
-        client = TestClient(_make_app())
+    def test_missing_channels_is_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = TestClient(_make_app(monkeypatch))
         resp = client.post("/threads/t1/stream/events", json={})
         assert resp.status_code == 422
 
-    def test_unknown_channel_is_400(self) -> None:
-        client = TestClient(_make_app())
+    def test_unknown_channel_is_400(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = TestClient(_make_app(monkeypatch))
         resp = client.post("/threads/t1/stream/events", json={"channels": ["bogus"]})
         assert resp.status_code == 400
 
-    def test_cross_tenant_thread_is_404(self) -> None:
-        client = TestClient(_make_app(owner="other-user"))
+    def test_cross_tenant_thread_is_404(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = TestClient(_make_app(monkeypatch, owner="other-user"))
         resp = client.post("/threads/t1/stream/events", json={"channels": ["messages"]})
         assert resp.status_code == 404
 
-    def test_stream_emits_v2_frames(self) -> None:
+    def test_stream_emits_v2_frames(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A run on the thread streams content-block frames over SSE."""
         run_id = f"run-{uuid.uuid4().hex[:8]}"
 
@@ -154,7 +156,7 @@ class TestStreamRoute:
             await broker.put(f"{run_id}_event_4", ("end", {"status": "success"}))
 
         asyncio.run(seed())
-        client = TestClient(_make_app(run_ids=[run_id]))
+        client = TestClient(_make_app(monkeypatch, run_ids=[run_id]))
 
         with client.stream("POST", "/threads/t1/stream/events", json={"channels": ["messages", "lifecycle"]}) as resp:
             assert resp.status_code == 200

--- a/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
+++ b/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
@@ -1,5 +1,7 @@
 """Integration tests for the v2 event streaming routes."""
 
+from __future__ import annotations
+
 import asyncio
 import uuid
 from collections.abc import Iterator
@@ -11,7 +13,6 @@ from fastapi.testclient import TestClient
 
 from aegra_api.api import event_streaming as es_module
 from aegra_api.core.auth_deps import get_current_user, require_auth
-from aegra_api.core.orm import get_session
 from aegra_api.models.auth import User
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.event_streaming import capabilities as caps
@@ -31,6 +32,12 @@ class _Session:
         self._owner = owner
         self._run_ids = run_ids or []
 
+    async def __aenter__(self) -> _Session:
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
     async def scalar(self, _stmt: Any) -> Any:
         return self._owner
 
@@ -49,7 +56,9 @@ def _make_app(*, owner: str | None = _USER, run_ids: list[str] | None = None) ->
     user = User(identity=_USER)
     app.dependency_overrides[require_auth] = lambda: user
     app.dependency_overrides[get_current_user] = lambda: user
-    app.dependency_overrides[get_session] = lambda: _Session(owner=owner, run_ids=run_ids)
+    # Routes open short-lived sessions via _get_session_maker(); patch it to
+    # return a maker yielding the in-memory test session.
+    es_module._get_session_maker = lambda: lambda: _Session(owner=owner, run_ids=run_ids)  # type: ignore[attr-defined]
     app.include_router(es_module.router)
     return app
 

--- a/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
+++ b/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
@@ -22,10 +22,12 @@ _USER = "test-user"
 
 
 class _Session:
-    """Test session: scalar() returns the thread's owner id, scalars() lists runs.
+    """Test session: scalar() returns the thread's owner id, execute() lists runs.
 
     ``owner`` is the existing thread's user_id, or None when the thread does
-    not exist yet (the run.start-creates-it path the SDK relies on).
+    not exist yet (the run.start-creates-it path the SDK relies on). The run
+    lister selects (run_id, status) rows; status stays "running" so tests
+    exercise the live-tail path.
     """
 
     def __init__(self, *, owner: str | None, run_ids: list[str] | None = None) -> None:
@@ -41,12 +43,12 @@ class _Session:
     async def scalar(self, _stmt: Any) -> Any:
         return self._owner
 
-    async def scalars(self, _stmt: Any) -> Any:
-        run_ids = self._run_ids
+    async def execute(self, _stmt: Any) -> Any:
+        rows = [(run_id, "running", "test_graph") for run_id in self._run_ids]
 
         class _Result:
-            def all(self) -> list[str]:
-                return run_ids
+            def all(self) -> list[tuple[str, str, str]]:
+                return rows
 
         return _Result()
 
@@ -87,13 +89,19 @@ class TestCommandRoute:
             json={"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "input": {"messages": []}}},
         )
         assert resp.status_code == 200
-        assert resp.json() == {"type": "success", "id": 1, "result": {"run_id": "run-1"}}
+        assert resp.json() == {
+            "type": "success",
+            "id": 1,
+            "result": {"run_id": "run-1"},
+            "meta": {"applied_through_seq": 0},
+        }
 
-    def test_unknown_command_returns_400_error_envelope(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_unknown_command_returns_error_envelope_on_200(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Protocol errors ride HTTP 200 so envelope-parsing clients see the code."""
         client = TestClient(_make_app(monkeypatch))
         resp = client.post("/threads/t1/commands", json={"id": 1, "method": "agent.getTree", "params": {}})
-        assert resp.status_code == 400
-        assert resp.json()["error"] == "not_supported"
+        assert resp.status_code == 200
+        assert resp.json()["error"] == "unknown_command"
 
     def test_cross_tenant_thread_is_404(self, monkeypatch: pytest.MonkeyPatch) -> None:
         client = TestClient(_make_app(monkeypatch, owner="other-user"))

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -685,7 +685,16 @@ class TestWaitForRun:
         override_session_dependency(app, Session)
         client = make_client(app)
 
-        with patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(Session())):
+        # Resume validation polls fresh sessions via run_preparation._get_session_maker
+        # when the first read is not interrupted; keep those returning idle too, and
+        # collapse the settle backoff so the reject path does not wait.
+        maker = _make_session_maker(Session())
+        with (
+            patch("aegra_api.api.runs._get_session_maker", return_value=maker),
+            patch("aegra_api.services.run_preparation._get_session_maker", return_value=maker),
+            patch("aegra_api.services.run_preparation._RESUME_SETTLE_ATTEMPTS", 1),
+            patch("aegra_api.services.run_preparation._RESUME_SETTLE_INTERVAL_SECONDS", 0),
+        ):
             resp = client.post(
                 "/threads/test-thread-123/runs/wait",
                 json={

--- a/libs/aegra-api/tests/unit/test_services/test_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_broker.py
@@ -16,7 +16,7 @@ class TestRunBroker:
         broker = RunBroker("run-123")
 
         assert broker.run_id == "run-123"
-        assert broker.queue is not None
+        assert broker._subscribers == set()
         assert not broker.finished.is_set()
 
     @pytest.mark.asyncio
@@ -26,10 +26,9 @@ class TestRunBroker:
 
         await broker.put("evt-1", {"data": "test"})
 
-        # Event should be in queue
-        event_id, payload = await asyncio.wait_for(broker.queue.get(), timeout=1.0)
-        assert event_id == "evt-1"
-        assert payload == {"data": "test"}
+        # Event is buffered for replay and delivered to a subscriber's aiter.
+        replayed = await broker.replay(None)
+        assert replayed == [("evt-1", {"data": "test"})]
 
     @pytest.mark.asyncio
     async def test_put_end_event_marks_finished(self):
@@ -51,8 +50,8 @@ class TestRunBroker:
         # Should not raise, just log warning
         await broker.put("evt-1", {"data": "test"})
 
-        # Queue should be empty
-        assert broker.queue.empty()
+        # Event is dropped (broker finished) — nothing buffered.
+        assert await broker.replay(None) == []
 
     @pytest.mark.asyncio
     async def test_mark_finished(self):
@@ -99,6 +98,35 @@ class TestRunBroker:
 
         # Should get both events including end
         assert len(events) == 2
+
+    @pytest.mark.asyncio
+    async def test_two_concurrent_aiters_each_receive_every_live_event(self):
+        """Regression: the v2 SDK opens two SSE on one run (main + lifecycle watcher).
+
+        Both must receive every event. A single shared queue would split events
+        between the two consumers, so the watcher would miss the interrupt.
+        """
+        broker = RunBroker("run-123")
+
+        async def drain() -> list[tuple[str, object]]:
+            out: list[tuple[str, object]] = []
+            async for event_id, payload in broker.aiter():
+                out.append((event_id, payload))
+                if event_id == "evt-end":
+                    break
+            return out
+
+        a = asyncio.create_task(drain())
+        b = asyncio.create_task(drain())
+        await asyncio.sleep(0.05)  # let both register their subscriber queues
+
+        await broker.put("evt-1", {"data": "first"})
+        await broker.put("evt-2", {"data": "second"})
+        await broker.put("evt-end", ("end", {}))
+
+        got_a, got_b = await asyncio.gather(a, b)
+        assert got_a == got_b
+        assert [eid for eid, _ in got_a] == ["evt-1", "evt-2", "evt-end"]
 
 
 class TestBrokerManager:

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_capabilities.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_capabilities.py
@@ -1,0 +1,63 @@
+"""Tests for the v2 event streaming capability probe and feature flag."""
+
+from collections.abc import Iterator
+
+import pytest
+
+from aegra_api.services.event_streaming import capabilities as caps
+
+
+@pytest.fixture(autouse=True)
+def _clear_probe_cache() -> Iterator[None]:
+    """Reset the memoised symbol probe around each test."""
+    caps._probe_runtime_symbols.cache_clear()
+    yield
+    caps._probe_runtime_symbols.cache_clear()
+
+
+def test_disabled_by_flag_when_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With the flag off, capabilities report disabled regardless of runtime."""
+    monkeypatch.setattr(caps.settings.event_streaming, "FF_V2_EVENT_STREAMING", False)
+    result = caps.get_v2_capabilities()
+    assert result.ok is False
+    assert result.disabled_by_flag is True
+    assert "FF_V2_EVENT_STREAMING" in result.error_message
+
+
+def test_supported_when_flag_on_and_symbols_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On our pinned stack the required symbols exist, so v2 is supported."""
+    monkeypatch.setattr(caps.settings.event_streaming, "FF_V2_EVENT_STREAMING", True)
+    result = caps.get_v2_capabilities()
+    assert result.ok is True
+    assert result.missing == ()
+    assert result.error_message == ""
+
+
+def test_unsupported_when_symbol_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing runtime symbol yields an unsupported result with an upgrade hint."""
+    monkeypatch.setattr(caps.settings.event_streaming, "FF_V2_EVENT_STREAMING", True)
+    monkeypatch.setattr(
+        caps,
+        "_REQUIRED_SYMBOLS",
+        (("langgraph.pregel._messages", "ThisSymbolDoesNotExist"),),
+    )
+    caps._probe_runtime_symbols.cache_clear()
+    result = caps.get_v2_capabilities()
+    assert result.ok is False
+    assert result.disabled_by_flag is False
+    assert "ThisSymbolDoesNotExist" in result.error_message
+    assert "Upgrade" in result.error_message
+
+
+def test_unsupported_when_module_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing module is reported the same as a missing attribute."""
+    monkeypatch.setattr(caps.settings.event_streaming, "FF_V2_EVENT_STREAMING", True)
+    monkeypatch.setattr(
+        caps,
+        "_REQUIRED_SYMBOLS",
+        (("langgraph.this_module_is_not_real", "X"),),
+    )
+    caps._probe_runtime_symbols.cache_clear()
+    result = caps.get_v2_capabilities()
+    assert result.ok is False
+    assert "langgraph.this_module_is_not_real.X" in result.missing

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
@@ -51,6 +51,25 @@ class TestRunStart:
         # v2 runs are flagged for the native v3 stream path.
         assert prepared_run.call_args.kwargs["event_streaming_v2"] is True
 
+    async def test_run_start_forwards_interrupt_breakpoints(self, prepared_run: AsyncMock, user: User) -> None:
+        """interrupt_before/after must reach RunCreate so v2 clients can set HITL breakpoints."""
+        await _dispatch(
+            {
+                "id": 1,
+                "method": "run.start",
+                "params": {
+                    "assistant_id": "agent",
+                    "input": {"x": 1},
+                    "interrupt_before": ["node_a"],
+                    "interrupt_after": "node_b",
+                },
+            },
+            user,
+        )
+        request = prepared_run.call_args.args[2]
+        assert request.interrupt_before == ["node_a"]
+        assert request.interrupt_after == "node_b"
+
     async def test_run_start_missing_assistant_id_is_invalid(self, prepared_run: AsyncMock, user: User) -> None:
         resp, run_id = await _dispatch({"id": 1, "method": "run.start", "params": {"input": {}}}, user)
         assert resp["type"] == "error"

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
@@ -32,7 +32,12 @@ class TestRunStart:
             {"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "input": {"messages": []}}},
             user,
         )
-        assert resp == {"type": "success", "id": 1, "result": {"run_id": "run-xyz"}}
+        assert resp == {
+            "type": "success",
+            "id": 1,
+            "result": {"run_id": "run-xyz"},
+            "meta": {"applied_through_seq": 0},
+        }
         assert run_id == "run-xyz"
 
     async def test_run_start_builds_runcreate(self, prepared_run: AsyncMock, user: User) -> None:
@@ -77,6 +82,45 @@ class TestRunStart:
         assert run_id is None
         prepared_run.assert_not_called()
 
+    async def test_run_start_forwards_multitask_strategy(self, prepared_run: AsyncMock, user: User) -> None:
+        await _dispatch(
+            {
+                "id": 1,
+                "method": "run.start",
+                "params": {"assistant_id": "agent", "input": {"x": 1}, "multitaskStrategy": "reject"},
+            },
+            user,
+        )
+        assert prepared_run.call_args.args[2].multitask_strategy == "reject"
+
+    async def test_run_start_unknown_multitask_strategy_is_invalid(self, prepared_run: AsyncMock, user: User) -> None:
+        resp, _ = await _dispatch(
+            {
+                "id": 1,
+                "method": "run.start",
+                "params": {"assistant_id": "agent", "input": {"x": 1}, "multitaskStrategy": "yolo"},
+            },
+            user,
+        )
+        assert resp["error"] == "invalid_argument"
+        prepared_run.assert_not_called()
+
+    async def test_run_start_on_interrupted_thread_resumes_with_input(
+        self, prepared_run: AsyncMock, user: User
+    ) -> None:
+        """Input sent to an interrupted thread answers the interrupt instead of
+        starting a fresh turn that would discard pending tasks."""
+        session = AsyncMock()
+        session.scalar = AsyncMock(return_value="interrupted")
+        await _dispatch(
+            {"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "input": {"answer": 42}}},
+            user,
+            session=session,
+        )
+        request = prepared_run.call_args.args[2]
+        assert request.command == {"resume": {"answer": 42}}
+        assert request.input is None
+
 
 class TestInputRespond:
     async def test_input_respond_resumes_with_command(self, prepared_run: AsyncMock, user: User) -> None:
@@ -92,26 +136,40 @@ class TestInputRespond:
         resp, _ = await _dispatch({"id": 2, "method": "input.respond", "params": {"assistant_id": "agent"}}, user)
         assert resp["error"] == "invalid_argument"
 
+    async def test_input_respond_forwards_metadata(self, prepared_run: AsyncMock, user: User) -> None:
+        await _dispatch(
+            {
+                "id": 2,
+                "method": "input.respond",
+                "params": {"assistant_id": "agent", "response": "yes", "metadata": {"source": "review-ui"}},
+            },
+            user,
+        )
+        request = prepared_run.call_args.args[2]
+        assert request.metadata == {"source": "review-ui"}
+
     async def test_input_respond_recovers_assistant_from_thread(self, prepared_run: AsyncMock, user: User) -> None:
         """The stock SDK sends no assistant_id; recover it from the thread's last run."""
+        interrupt_id = "a" * 32
         session = AsyncMock()
         session.scalar = AsyncMock(return_value="bound-agent")
         resp, run_id = await _dispatch(
-            {"id": 2, "method": "input.respond", "params": {"interrupt_id": "i1", "response": "yes"}},
+            {"id": 2, "method": "input.respond", "params": {"interrupt_id": interrupt_id, "response": "yes"}},
             user,
             session=session,
         )
         assert resp["type"] == "success"
         request = prepared_run.call_args.args[2]
         assert request.assistant_id == "bound-agent"
-        assert request.command == {"resume": "yes"}
+        # Targeted resume: id-keyed map so multiple pending interrupts route correctly.
+        assert request.command == {"resume": {interrupt_id: "yes"}}
 
     async def test_input_respond_no_run_to_resume_is_error(self, prepared_run: AsyncMock, user: User) -> None:
         """No assistant_id and no prior run on the thread → on-protocol error, no run started."""
         session = AsyncMock()
         session.scalar = AsyncMock(return_value=None)
         resp, run_id = await _dispatch(
-            {"id": 2, "method": "input.respond", "params": {"interrupt_id": "i1", "response": "yes"}},
+            {"id": 2, "method": "input.respond", "params": {"interrupt_id": "b" * 32, "response": "yes"}},
             user,
             session=session,
         )
@@ -119,11 +177,79 @@ class TestInputRespond:
         assert run_id is None
         prepared_run.assert_not_called()
 
+    async def test_input_respond_without_interrupt_id_resumes_untargeted(
+        self, prepared_run: AsyncMock, user: User
+    ) -> None:
+        resp, _ = await _dispatch(
+            {"id": 2, "method": "input.respond", "params": {"assistant_id": "agent", "response": "yes"}}, user
+        )
+        assert resp["type"] == "success"
+        assert prepared_run.call_args.args[2].command == {"resume": "yes"}
+
+    async def test_input_respond_malformed_interrupt_id_is_no_such_interrupt(
+        self, prepared_run: AsyncMock, user: User
+    ) -> None:
+        """A non-interrupt-shaped id can never target a resume; erroring beats silently
+        resuming whatever happens to be pending."""
+        resp, run_id = await _dispatch(
+            {"id": 2, "method": "input.respond", "params": {"interrupt_id": "garbage", "response": "yes"}}, user
+        )
+        assert resp["error"] == "no_such_interrupt"
+        assert run_id is None
+        prepared_run.assert_not_called()
+
+    async def test_input_respond_batch_responses_merge_into_one_resume(
+        self, prepared_run: AsyncMock, user: User
+    ) -> None:
+        """Parallel interrupts resume in a single command via the responses array."""
+        id_a, id_b = "a" * 32, "b" * 32
+        resp, _ = await _dispatch(
+            {
+                "id": 2,
+                "method": "input.respond",
+                "params": {
+                    "assistant_id": "agent",
+                    "responses": [
+                        {"interrupt_id": id_a, "response": {"action": "approve"}},
+                        {"interrupt_id": id_b, "response": [{"type": "ignore"}]},
+                    ],
+                },
+            },
+            user,
+        )
+        assert resp["type"] == "success"
+        assert prepared_run.call_args.args[2].command == {
+            "resume": {id_a: {"action": "approve"}, id_b: [{"type": "ignore"}]}
+        }
+
+    async def test_input_respond_empty_batch_is_invalid(self, prepared_run: AsyncMock, user: User) -> None:
+        resp, _ = await _dispatch(
+            {"id": 2, "method": "input.respond", "params": {"assistant_id": "agent", "responses": []}}, user
+        )
+        assert resp["error"] == "invalid_argument"
+        prepared_run.assert_not_called()
+
 
 class TestErrors:
-    async def test_unknown_method_is_not_supported(self, user: User) -> None:
+    async def test_unknown_method_is_unknown_command(self, user: User) -> None:
         resp, run_id = await _dispatch({"id": 3, "method": "agent.getTree", "params": {}}, user)
-        assert resp["error"] == "not_supported"
+        assert resp["error"] == "unknown_command"
+        assert run_id is None
+
+    async def test_unexpected_exception_wraps_as_unknown_error(
+        self, monkeypatch: pytest.MonkeyPatch, user: User
+    ) -> None:
+        """A non-HTTP, non-validation crash must stay an on-protocol envelope, not a 500."""
+
+        async def boom(*_a: Any, **_k: Any) -> None:
+            raise RuntimeError("db exploded")
+
+        monkeypatch.setattr(cmd, "_prepare_run", boom)
+        resp, run_id = await _dispatch(
+            {"id": 9, "method": "run.start", "params": {"assistant_id": "x", "input": {}}}, user
+        )
+        assert resp["type"] == "error"
+        assert resp["error"] == "unknown_error"
         assert run_id is None
 
     async def test_non_integer_id_is_invalid(self, user: User) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
@@ -1,0 +1,122 @@
+"""Tests for v2 command dispatch (run.start, input.respond, errors)."""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aegra_api.models import User
+from aegra_api.services.event_streaming import commands as cmd
+
+
+@pytest.fixture
+def user() -> User:
+    return User(identity="u1")
+
+
+@pytest.fixture
+def prepared_run(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Stub _prepare_run to return a fixed run_id without touching the DB."""
+    mock = AsyncMock(return_value=("run-xyz", object(), object()))
+    monkeypatch.setattr(cmd, "_prepare_run", mock)
+    return mock
+
+
+async def _dispatch(payload: dict[str, Any], user: User) -> tuple[dict, str | None]:
+    return await cmd.handle_command(payload, session=AsyncMock(), thread_id="t1", user=user)
+
+
+class TestRunStart:
+    async def test_run_start_returns_run_id(self, prepared_run: AsyncMock, user: User) -> None:
+        resp, run_id = await _dispatch(
+            {"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "input": {"messages": []}}},
+            user,
+        )
+        assert resp == {"type": "success", "id": 1, "result": {"run_id": "run-xyz"}}
+        assert run_id == "run-xyz"
+
+    async def test_run_start_builds_runcreate(self, prepared_run: AsyncMock, user: User) -> None:
+        await _dispatch(
+            {
+                "id": 1,
+                "method": "run.start",
+                "params": {"assistant_id": "agent", "input": {"x": 1}, "config": {"c": 2}},
+            },
+            user,
+        )
+        request = prepared_run.call_args.args[2]
+        assert request.assistant_id == "agent"
+        assert request.input == {"x": 1}
+        assert request.config == {"c": 2}
+        # v2 runs are flagged for the native v3 stream path.
+        assert prepared_run.call_args.kwargs["event_streaming_v2"] is True
+
+    async def test_run_start_missing_assistant_id_is_invalid(self, prepared_run: AsyncMock, user: User) -> None:
+        resp, run_id = await _dispatch({"id": 1, "method": "run.start", "params": {"input": {}}}, user)
+        assert resp["type"] == "error"
+        assert resp["error"] == "invalid_argument"
+        assert run_id is None
+        prepared_run.assert_not_called()
+
+
+class TestInputRespond:
+    async def test_input_respond_resumes_with_command(self, prepared_run: AsyncMock, user: User) -> None:
+        resp, run_id = await _dispatch(
+            {"id": 2, "method": "input.respond", "params": {"assistant_id": "agent", "response": "yes"}},
+            user,
+        )
+        assert resp["type"] == "success"
+        request = prepared_run.call_args.args[2]
+        assert request.command == {"resume": "yes"}
+
+    async def test_input_respond_missing_response_is_invalid(self, prepared_run: AsyncMock, user: User) -> None:
+        resp, _ = await _dispatch({"id": 2, "method": "input.respond", "params": {"assistant_id": "agent"}}, user)
+        assert resp["error"] == "invalid_argument"
+
+
+class TestErrors:
+    async def test_unknown_method_is_not_supported(self, user: User) -> None:
+        resp, run_id = await _dispatch({"id": 3, "method": "agent.getTree", "params": {}}, user)
+        assert resp["error"] == "not_supported"
+        assert run_id is None
+
+    async def test_non_integer_id_is_invalid(self, user: User) -> None:
+        resp, _ = await _dispatch({"id": "x", "method": "run.start", "params": {}}, user)
+        assert resp == {"type": "error", "id": None, "error": "invalid_argument", "message": resp["message"]}
+
+    async def test_non_dict_params_is_invalid(self, user: User) -> None:
+        resp, _ = await _dispatch({"id": 1, "method": "run.start", "params": "nope"}, user)
+        assert resp["error"] == "invalid_argument"
+
+    async def test_prepare_http_404_maps_to_protocol_error(self, monkeypatch: pytest.MonkeyPatch, user: User) -> None:
+        """An HTTPException from run prep returns an on-protocol error, not FastAPI's detail."""
+        from fastapi import HTTPException
+
+        async def boom(*_a: Any, **_k: Any) -> None:
+            raise HTTPException(404, "Assistant 'x' not found")
+
+        monkeypatch.setattr(cmd, "_prepare_run", boom)
+        resp, run_id = await _dispatch(
+            {"id": 5, "method": "run.start", "params": {"assistant_id": "x", "input": {}}}, user
+        )
+        assert resp == {"type": "error", "id": 5, "error": "no_such_run", "message": "Assistant 'x' not found"}
+        assert run_id is None
+
+    async def test_prepare_http_403_maps_to_permission_denied(
+        self, monkeypatch: pytest.MonkeyPatch, user: User
+    ) -> None:
+        from fastapi import HTTPException
+
+        async def boom(*_a: Any, **_k: Any) -> None:
+            raise HTTPException(403, "nope")
+
+        monkeypatch.setattr(cmd, "_prepare_run", boom)
+        resp, _ = await _dispatch({"id": 6, "method": "run.start", "params": {"assistant_id": "x", "input": {}}}, user)
+        assert resp["error"] == "permission_denied"
+
+    async def test_malformed_runcreate_params_map_to_invalid_argument(self, user: User) -> None:
+        """RunCreate validation failure (no input/command/checkpoint) is on-protocol."""
+        resp, run_id = await _dispatch({"id": 7, "method": "run.start", "params": {"assistant_id": "x"}}, user)
+        assert resp["type"] == "error"
+        assert resp["error"] == "invalid_argument"
+        assert run_id is None

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
@@ -22,8 +22,8 @@ def prepared_run(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     return mock
 
 
-async def _dispatch(payload: dict[str, Any], user: User) -> tuple[dict, str | None]:
-    return await cmd.handle_command(payload, session=AsyncMock(), thread_id="t1", user=user)
+async def _dispatch(payload: dict[str, Any], user: User, *, session: Any = None) -> tuple[dict, str | None]:
+    return await cmd.handle_command(payload, session=session or AsyncMock(), thread_id="t1", user=user)
 
 
 class TestRunStart:
@@ -72,6 +72,33 @@ class TestInputRespond:
     async def test_input_respond_missing_response_is_invalid(self, prepared_run: AsyncMock, user: User) -> None:
         resp, _ = await _dispatch({"id": 2, "method": "input.respond", "params": {"assistant_id": "agent"}}, user)
         assert resp["error"] == "invalid_argument"
+
+    async def test_input_respond_recovers_assistant_from_thread(self, prepared_run: AsyncMock, user: User) -> None:
+        """The stock SDK sends no assistant_id; recover it from the thread's last run."""
+        session = AsyncMock()
+        session.scalar = AsyncMock(return_value="bound-agent")
+        resp, run_id = await _dispatch(
+            {"id": 2, "method": "input.respond", "params": {"interrupt_id": "i1", "response": "yes"}},
+            user,
+            session=session,
+        )
+        assert resp["type"] == "success"
+        request = prepared_run.call_args.args[2]
+        assert request.assistant_id == "bound-agent"
+        assert request.command == {"resume": "yes"}
+
+    async def test_input_respond_no_run_to_resume_is_error(self, prepared_run: AsyncMock, user: User) -> None:
+        """No assistant_id and no prior run on the thread → on-protocol error, no run started."""
+        session = AsyncMock()
+        session.scalar = AsyncMock(return_value=None)
+        resp, run_id = await _dispatch(
+            {"id": 2, "method": "input.respond", "params": {"interrupt_id": "i1", "response": "yes"}},
+            user,
+            session=session,
+        )
+        assert resp["error"] == "no_such_run"
+        assert run_id is None
+        prepared_run.assert_not_called()
 
 
 class TestErrors:

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_native_stream.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_native_stream.py
@@ -1,0 +1,105 @@
+"""Tests for the native v3 stream producer (forwarding + message-tuple unwrap)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aegra_api.services.event_streaming.native_stream import (
+    stream_native_v3_events,
+    unwrap_message_event,
+)
+
+
+class _FakeRunStream:
+    """Mimics langgraph's AsyncGraphRunStream: async-iterable + async context."""
+
+    def __init__(self, events: list[Any]) -> None:
+        self._events = events
+
+    async def __aenter__(self) -> _FakeRunStream:
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+    def __aiter__(self) -> _FakeRunStream:
+        self._it = iter(self._events)
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+class _FakeGraph:
+    def __init__(self, events: list[Any]) -> None:
+        self._events = events
+        self.calls: list[dict[str, Any]] = []
+
+    async def astream_events(self, input_data: Any, config: Any, **kwargs: Any) -> _FakeRunStream:
+        self.calls.append({"input": input_data, "config": config, **kwargs})
+        return _FakeRunStream(self._events)
+
+
+def _event(method: str, data: Any, *, namespace: list[str] | None = None) -> dict[str, Any]:
+    return {"type": "event", "method": method, "params": {"namespace": namespace or [], "data": data}}
+
+
+class TestUnwrapMessageEvent:
+    def test_unwraps_event_meta_tuple(self) -> None:
+        """v3 message data arrives as [event_dict, metadata]; element 0 is the event."""
+        data = [{"event": "content-block-delta", "index": 0, "delta": {"type": "text-delta", "text": "hi"}}, {"m": 1}]
+        assert unwrap_message_event(data) == {
+            "event": "content-block-delta",
+            "index": 0,
+            "delta": {"type": "text-delta", "text": "hi"},
+        }
+
+    def test_bare_event_dict_passes_through(self) -> None:
+        data = {"event": "message-start", "id": "m1"}
+        assert unwrap_message_event(data) == data
+
+    def test_non_event_tuple_returns_none(self) -> None:
+        assert unwrap_message_event([{"no_event_key": 1}, {}]) is None
+
+    def test_non_message_shape_returns_none(self) -> None:
+        assert unwrap_message_event("nonsense") is None
+
+
+@pytest.mark.asyncio
+class TestStreamNativeV3Events:
+    async def test_drives_v3_and_forwards_method_event_pairs(self) -> None:
+        events = [
+            _event("values", {"messages": []}),
+            _event("messages", [{"event": "message-start", "id": "m1"}, {}]),
+        ]
+        graph = _FakeGraph(events)
+
+        out: list[tuple[str, Any]] = []
+        async for method, payload in stream_native_v3_events(graph=graph, input_data={"x": 1}, config={"c": 2}):
+            out.append((method, payload))
+
+        # v3 is requested with version="v3"
+        assert graph.calls[0]["version"] == "v3"
+        # values forwarded as-is
+        assert out[0][0] == "values"
+        assert out[0][1]["params"]["data"] == {"messages": []}
+        # messages: tuple unwrapped so params.data is the event dict
+        assert out[1][0] == "messages"
+        assert out[1][1]["params"]["data"] == {"event": "message-start", "id": "m1"}
+
+    async def test_skips_non_event_dicts(self) -> None:
+        graph = _FakeGraph([{"not": "an event"}, _event("values", {"a": 1})])
+        out = [pair async for pair in stream_native_v3_events(graph=graph, input_data={}, config={})]
+        assert len(out) == 1
+        assert out[0][0] == "values"
+
+    async def test_drops_unreconstructable_message_events(self) -> None:
+        """A messages event whose data isn't an event tuple/dict is dropped, not forwarded raw."""
+        graph = _FakeGraph([_event("messages", [{"no_event": 1}, {}])])
+        out = [pair async for pair in stream_native_v3_events(graph=graph, input_data={}, config={})]
+        assert out == []

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_normalizers.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_normalizers.py
@@ -111,3 +111,100 @@ class TestNormalizeStatePayload:
 
     def test_non_message_values_untouched(self) -> None:
         assert normalize_state_payload({"count": 3, "flag": True}) == {"count": 3, "flag": True}
+
+
+class TestContentBlockCoverage:
+    def _content(self, content: object) -> object:
+        out = normalize_state_payload({"messages": [{"type": "ai", "content": content, "id": "m1"}]})
+        return out["messages"][0]["content"]
+
+    def test_server_tool_call_blocks_pass_through(self) -> None:
+        blocks = [
+            {"type": "server_tool_call", "name": "search", "args": {}},
+            {"type": "server_tool_call_result", "output": "x"},
+        ]
+        assert self._content(blocks) == blocks
+
+    def test_image_url_string_converts_to_image(self) -> None:
+        assert self._content([{"type": "image_url", "image_url": "https://x/img.png"}]) == [
+            {"type": "image", "url": "https://x/img.png"}
+        ]
+
+    def test_image_url_object_converts_to_image(self) -> None:
+        assert self._content([{"type": "image_url", "image_url": {"url": "https://x/img.png"}}]) == [
+            {"type": "image", "url": "https://x/img.png"}
+        ]
+
+    def test_input_audio_converts_to_audio(self) -> None:
+        blocks = self._content([{"type": "input_audio", "input_audio": {"data": "b64", "mime_type": "audio/wav"}}])
+        assert blocks == [{"type": "audio", "data": "b64", "mime_type": "audio/wav"}]
+
+    def test_unknown_typed_block_wraps_as_non_standard(self) -> None:
+        blocks = self._content([{"type": "provider_widget", "payload": 1}])
+        assert blocks == [{"type": "non_standard", "value": {"type": "provider_widget", "payload": 1}}]
+
+    def test_audio_synthesized_from_additional_kwargs_on_ai(self) -> None:
+        msg = {
+            "type": "ai",
+            "content": "listen",
+            "id": "m1",
+            "additional_kwargs": {"audio": {"data": "b64", "format": "mp3", "transcript": "hi"}},
+        }
+        out = normalize_state_payload({"messages": [msg]})
+        content = out["messages"][0]["content"]
+        assert content == [
+            {"type": "text", "text": "listen"},
+            {"type": "audio", "data": "b64", "mime_type": "audio/mpeg", "transcript": "hi"},
+        ]
+
+
+class TestToolCallShapes:
+    def test_openai_nested_function_shape_extracted(self) -> None:
+        msg = {
+            "type": "ai",
+            "content": "",
+            "id": "m1",
+            "tool_calls": [{"id": "c1", "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'}}],
+        }
+        out = normalize_state_payload({"messages": [msg]})
+        assert out["messages"][0]["tool_calls"] == [
+            {"type": "tool_call", "name": "get_weather", "args": {"city": "Paris"}, "id": "c1"}
+        ]
+
+    def test_tool_calls_fall_back_to_additional_kwargs(self) -> None:
+        msg = {
+            "type": "ai",
+            "content": "",
+            "id": "m1",
+            "additional_kwargs": {"tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "{}"}}]},
+        }
+        out = normalize_state_payload({"messages": [msg]})
+        assert out["messages"][0]["tool_calls"][0]["name"] == "f"
+
+    def test_explicit_invalid_tool_calls_preserved_with_error(self) -> None:
+        msg = {
+            "type": "ai",
+            "content": "",
+            "id": "m1",
+            "invalid_tool_calls": [{"id": "c9", "name": "f", "args": "{broken", "error": "model hiccup"}],
+        }
+        out = normalize_state_payload({"messages": [msg]})
+        invalid = out["messages"][0]["invalid_tool_calls"]
+        assert invalid == [
+            {"type": "invalid_tool_call", "id": "c9", "name": "f", "args": "{broken", "error": "model hiccup"}
+        ]
+
+
+class TestMessageFieldPreservation:
+    def test_tool_artifact_preserved(self) -> None:
+        msg = {"type": "tool", "content": "ok", "id": "m1", "tool_call_id": "c1", "artifact": {"rows": [1, 2]}}
+        out = normalize_state_payload({"messages": [msg]})
+        assert out["messages"][0]["artifact"] == {"rows": [1, 2]}
+
+    def test_example_flag_preserved_on_ai_and_human(self) -> None:
+        msgs = [
+            {"type": "human", "content": "q", "id": "m1", "example": True},
+            {"type": "ai", "content": "a", "id": "m2", "example": True},
+        ]
+        out = normalize_state_payload({"messages": msgs})
+        assert all(m["example"] is True for m in out["messages"])

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_normalizers.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_normalizers.py
@@ -15,6 +15,10 @@ class TestLifecycleStatus:
         assert lifecycle_status("error") == "failed"
         assert lifecycle_status("interrupted") == "interrupted"
 
+    def test_timeout_is_terminal_failed(self) -> None:
+        """timeout is a terminal RunStatus, not an in-progress one."""
+        assert lifecycle_status("timeout") == "failed"
+
     def test_unknown_status_defaults_running(self) -> None:
         """An in-progress/unknown status maps to running, never completed."""
         assert lifecycle_status("pending") == "running"

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_normalizers.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_normalizers.py
@@ -43,9 +43,9 @@ class TestNormalizeUpdates:
 class TestNormalizeInputRequested:
     def test_interrupt_entry_to_request(self) -> None:
         entries = [{"id": "int-1", "value": {"question": "ok?"}}]
-        assert normalize_input_requested(entries) == [{"interrupt_id": "int-1", "payload": {"question": "ok?"}}]
+        assert normalize_input_requested(entries) == [{"interrupt_id": "int-1", "value": {"question": "ok?"}}]
 
-    def test_entry_without_value_omits_payload(self) -> None:
+    def test_entry_without_value_omits_value(self) -> None:
         assert normalize_input_requested([{"id": "int-2"}]) == [{"interrupt_id": "int-2"}]
 
     def test_entry_without_string_id_skipped(self) -> None:
@@ -53,7 +53,7 @@ class TestNormalizeInputRequested:
 
     def test_dunder_interrupt_wrapper_accepted(self) -> None:
         wrapped = {"__interrupt__": [{"id": "int-3", "value": "v"}]}
-        assert normalize_input_requested(wrapped) == [{"interrupt_id": "int-3", "payload": "v"}]
+        assert normalize_input_requested(wrapped) == [{"interrupt_id": "int-3", "value": "v"}]
 
     def test_non_interrupt_value_yields_nothing(self) -> None:
         assert normalize_input_requested({"messages": []}) == []
@@ -63,7 +63,7 @@ class TestStripInterrupts:
     def test_separates_interrupt_from_values(self) -> None:
         payload = {"messages": [], "__interrupt__": [{"id": "int-1", "value": "v"}]}
         requests, cleaned = strip_interrupts(payload)
-        assert requests == [{"interrupt_id": "int-1", "payload": "v"}]
+        assert requests == [{"interrupt_id": "int-1", "value": "v"}]
         assert cleaned == {"messages": []}
         assert "__interrupt__" not in cleaned
 

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_normalizers.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_normalizers.py
@@ -1,0 +1,109 @@
+"""Tests for v2 payload normalizers (interrupts, updates, state messages, lifecycle)."""
+
+from aegra_api.services.event_streaming.normalizers import (
+    lifecycle_status,
+    normalize_input_requested,
+    normalize_state_payload,
+    normalize_updates,
+    strip_interrupts,
+)
+
+
+class TestLifecycleStatus:
+    def test_known_statuses_map(self) -> None:
+        assert lifecycle_status("success") == "completed"
+        assert lifecycle_status("error") == "failed"
+        assert lifecycle_status("interrupted") == "interrupted"
+
+    def test_unknown_status_defaults_running(self) -> None:
+        """An in-progress/unknown status maps to running, never completed."""
+        assert lifecycle_status("pending") == "running"
+        assert lifecycle_status("anything") == "running"
+
+
+class TestNormalizeUpdates:
+    def test_single_node_extracts_node_and_values(self) -> None:
+        assert normalize_updates({"agent": {"x": 1}}) == {"node": "agent", "values": {"x": 1}}
+
+    def test_multi_node_keeps_whole_dict_as_values(self) -> None:
+        out = normalize_updates({"a": {"x": 1}, "b": {"y": 2}})
+        assert out == {"values": {"a": {"x": 1}, "b": {"y": 2}}}
+
+    def test_non_dict_node_values_wrapped(self) -> None:
+        assert normalize_updates({"agent": "done"}) == {"node": "agent", "values": {"value": "done"}}
+
+    def test_non_dict_payload_wrapped(self) -> None:
+        assert normalize_updates("x") == {"values": {"value": "x"}}
+
+
+class TestNormalizeInputRequested:
+    def test_interrupt_entry_to_request(self) -> None:
+        entries = [{"id": "int-1", "value": {"question": "ok?"}}]
+        assert normalize_input_requested(entries) == [{"interrupt_id": "int-1", "payload": {"question": "ok?"}}]
+
+    def test_entry_without_value_omits_payload(self) -> None:
+        assert normalize_input_requested([{"id": "int-2"}]) == [{"interrupt_id": "int-2"}]
+
+    def test_entry_without_string_id_skipped(self) -> None:
+        assert normalize_input_requested([{"value": "x"}, {"id": 5}]) == []
+
+    def test_dunder_interrupt_wrapper_accepted(self) -> None:
+        wrapped = {"__interrupt__": [{"id": "int-3", "value": "v"}]}
+        assert normalize_input_requested(wrapped) == [{"interrupt_id": "int-3", "payload": "v"}]
+
+    def test_non_interrupt_value_yields_nothing(self) -> None:
+        assert normalize_input_requested({"messages": []}) == []
+
+
+class TestStripInterrupts:
+    def test_separates_interrupt_from_values(self) -> None:
+        payload = {"messages": [], "__interrupt__": [{"id": "int-1", "value": "v"}]}
+        requests, cleaned = strip_interrupts(payload)
+        assert requests == [{"interrupt_id": "int-1", "payload": "v"}]
+        assert cleaned == {"messages": []}
+        assert "__interrupt__" not in cleaned
+
+    def test_no_interrupt_passes_through(self) -> None:
+        requests, cleaned = strip_interrupts({"messages": []})
+        assert requests == []
+        assert cleaned == {"messages": []}
+
+
+class TestNormalizeStatePayload:
+    def test_strips_interrupt_key_recursively(self) -> None:
+        out = normalize_state_payload({"a": 1, "__interrupt__": ["x"]})
+        assert out == {"a": 1}
+
+    def test_assistant_role_normalized_to_ai(self) -> None:
+        out = normalize_state_payload({"messages": [{"type": "assistant", "content": "hi", "id": "m1"}]})
+        assert out["messages"][0]["type"] == "ai"
+
+    def test_user_role_normalized_to_human(self) -> None:
+        out = normalize_state_payload({"messages": [{"type": "user", "content": "hi", "id": "m1"}]})
+        assert out["messages"][0]["type"] == "human"
+
+    def test_tool_calls_split_valid(self) -> None:
+        msg = {
+            "type": "ai",
+            "content": "",
+            "id": "m1",
+            "tool_calls": [{"id": "c1", "name": "get_weather", "args": {"city": "Paris"}}],
+        }
+        out = normalize_state_payload({"messages": [msg]})
+        tcs = out["messages"][0]["tool_calls"]
+        assert tcs == [{"type": "tool_call", "name": "get_weather", "args": {"city": "Paris"}, "id": "c1"}]
+
+    def test_malformed_tool_call_args_marked_invalid(self) -> None:
+        msg = {
+            "type": "ai",
+            "content": "",
+            "id": "m1",
+            "tool_calls": [{"id": "c1", "name": "f", "args": "{not json"}],
+        }
+        out = normalize_state_payload({"messages": [msg]})
+        invalid = out["messages"][0]["invalid_tool_calls"]
+        assert invalid[0]["type"] == "invalid_tool_call"
+        assert invalid[0]["error"] == "Malformed args."
+
+    def test_non_message_values_untouched(self) -> None:
+        assert normalize_state_payload({"count": 3, "flag": True}) == {"count": 3, "flag": True}

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_protocol.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_protocol.py
@@ -13,13 +13,12 @@ class TestBuildEvent:
         evt = build_event(
             "messages", {"event": "message-start", "role": "ai", "id": "m1"}, seq=7, event_id="run_event_7"
         )
-        assert evt == {
-            "type": "event",
-            "seq": 7,
-            "method": "messages",
-            "event_id": "run_event_7",
-            "params": {"data": {"event": "message-start", "role": "ai", "id": "m1"}, "namespace": []},
-        }
+        assert evt["type"] == "event"
+        assert evt["seq"] == 7
+        assert evt["method"] == "messages"
+        assert evt["event_id"] == "run_event_7"
+        assert evt["params"]["data"] == {"event": "message-start", "role": "ai", "id": "m1"}
+        assert evt["params"]["namespace"] == []
 
     def test_namespace_is_carried(self) -> None:
         evt = build_event("values", {"x": 1}, namespace=["sub", "graph"], seq=2)
@@ -30,7 +29,13 @@ class TestBuildEvent:
         assert "event_id" not in evt
         assert evt["seq"] == 1
         assert evt["method"] == "values"
-        assert evt["params"] == {"data": {"x": 1}, "namespace": []}
+        assert evt["params"]["data"] == {"x": 1}
+
+    def test_timestamp_is_ms_epoch(self) -> None:
+        evt = build_event("values", {"x": 1}, seq=1)
+        ts = evt["params"]["timestamp"]
+        assert isinstance(ts, int)
+        assert ts > 1_600_000_000_000  # sanity: after 2020, in milliseconds not seconds
 
 
 class TestBuildSuccess:

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_protocol.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_protocol.py
@@ -1,0 +1,70 @@
+"""Tests for the v2 wire envelope builders."""
+
+from aegra_api.services.event_streaming.channels import is_supported_channel
+from aegra_api.services.event_streaming.protocol import (
+    build_error,
+    build_event,
+    build_success,
+)
+
+
+class TestBuildEvent:
+    def test_event_nests_payload_under_params_data(self) -> None:
+        evt = build_event(
+            "messages", {"event": "message-start", "role": "ai", "id": "m1"}, seq=7, event_id="run_event_7"
+        )
+        assert evt == {
+            "type": "event",
+            "seq": 7,
+            "method": "messages",
+            "event_id": "run_event_7",
+            "params": {"data": {"event": "message-start", "role": "ai", "id": "m1"}, "namespace": []},
+        }
+
+    def test_namespace_is_carried(self) -> None:
+        evt = build_event("values", {"x": 1}, namespace=["sub", "graph"], seq=2)
+        assert evt["params"]["namespace"] == ["sub", "graph"]
+
+    def test_event_id_omitted_when_none(self) -> None:
+        evt = build_event("values", {"x": 1}, seq=1)
+        assert "event_id" not in evt
+        assert evt["seq"] == 1
+        assert evt["method"] == "values"
+        assert evt["params"] == {"data": {"x": 1}, "namespace": []}
+
+
+class TestBuildSuccess:
+    def test_success_without_meta(self) -> None:
+        assert build_success(3, {"run_id": "r1"}) == {"type": "success", "id": 3, "result": {"run_id": "r1"}}
+
+    def test_success_with_applied_through_seq(self) -> None:
+        resp = build_success(3, {}, applied_through_seq=42)
+        assert resp["meta"] == {"applied_through_seq": 42}
+
+
+class TestBuildError:
+    def test_error_shape(self) -> None:
+        assert build_error(5, "not_supported", "nope") == {
+            "type": "error",
+            "id": 5,
+            "error": "not_supported",
+            "message": "nope",
+        }
+
+    def test_error_allows_null_id(self) -> None:
+        assert build_error(None, "invalid_argument", "bad")["id"] is None
+
+
+class TestChannels:
+    def test_known_channels_supported(self) -> None:
+        for ch in ("values", "updates", "messages", "tools", "lifecycle", "custom"):
+            assert is_supported_channel(ch)
+
+    def test_custom_namespaced_channel_supported(self) -> None:
+        assert is_supported_channel("custom:my_event")
+
+    def test_empty_custom_channel_rejected(self) -> None:
+        assert not is_supported_channel("custom:")
+
+    def test_unknown_channel_rejected(self) -> None:
+        assert not is_supported_channel("bogus")

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -22,9 +22,11 @@ def manager(monkeypatch: pytest.MonkeyPatch) -> Iterator[BrokerManager]:
     yield mgr
 
 
-def _lister(*run_ids: str):
-    async def list_run_ids() -> list[str]:
-        return list(run_ids)
+def _lister(*run_ids: str, statuses: dict[str, str] | None = None, graph: str | None = None):
+    """Run lister returning (run_id, status, graph_name) rows; status defaults to running."""
+
+    async def list_run_ids() -> list[tuple[str, str | None, str | None]]:
+        return [(run_id, (statuses or {}).get(run_id, "running"), graph) for run_id in run_ids]
 
     return list_run_ids
 
@@ -56,11 +58,13 @@ def _make_session(
     since: int | None = None,
     namespaces: list[list[str]] | None = None,
     depth: int | None = None,
+    statuses: dict[str, str] | None = None,
+    graph: str | None = None,
 ) -> ThreadEventSession:
     return ThreadEventSession(
         thread_id,
         channels=channels,
-        list_run_ids=_lister(*run_ids),
+        list_run_ids=_lister(*run_ids, statuses=statuses, graph=graph),
         since=since,
         namespaces=namespaces,
         depth=depth,
@@ -87,6 +91,7 @@ class TestForwarding:
         events = await _collect(_make_session("t1", channels={"messages", "lifecycle"}, run_ids=("run-1",)))
         kinds = [(e["method"], e["params"]["data"].get("event")) for e in events]
         assert kinds == [
+            ("lifecycle", "running"),
             ("messages", "message-start"),
             ("messages", "content-block-delta"),
             ("messages", "message-finish"),
@@ -150,13 +155,14 @@ class TestSeqAndFilter:
     async def test_seq_monotonic_from_one(self, manager: BrokerManager) -> None:
         await _seed(manager, "run-1", [("values", _protocol_event("values", {"a": 1})), ("end", {"status": "success"})])
         events = await _collect(_make_session("t1", channels={"values", "lifecycle"}, run_ids=("run-1",)))
-        assert [e["seq"] for e in events] == [1, 2]
+        # seq 1 = the run's root lifecycle running seed.
+        assert [e["seq"] for e in events] == [1, 2, 3]
 
     async def test_seq_spans_multiple_runs(self, manager: BrokerManager) -> None:
         await _seed(manager, "run-1", [("values", _protocol_event("values", {"a": 1})), ("end", {"status": "success"})])
         await _seed(manager, "run-2", [("values", _protocol_event("values", {"a": 2})), ("end", {"status": "success"})])
         events = await _collect(_make_session("t1", channels={"values", "lifecycle"}, run_ids=("run-1", "run-2")))
-        assert [e["seq"] for e in events] == [1, 2, 3, 4]
+        assert [e["seq"] for e in events] == [1, 2, 3, 4, 5, 6]
 
     async def test_channel_filter_drops_unsubscribed(self, manager: BrokerManager) -> None:
         await _seed(
@@ -182,7 +188,8 @@ class TestSeqAndFilter:
             ],
         )
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
-        assert [(e["method"], e["seq"]) for e in events] == [("lifecycle", 3)]
+        # running seed = seq 1; values/updates burn 2-3 unsubscribed; terminal = 4.
+        assert [(e["method"], e["seq"]) for e in events] == [("lifecycle", 1), ("lifecycle", 4)]
 
     async def test_since_skips_already_seen(self, manager: BrokerManager) -> None:
         await _seed(
@@ -195,13 +202,13 @@ class TestSeqAndFilter:
             ],
         )
         events = await _collect(_make_session("t1", channels={"values", "lifecycle"}, run_ids=("run-1",), since=1))
-        assert [e["seq"] for e in events] == [2, 3]
+        assert [e["seq"] for e in events] == [2, 3, 4]
 
     async def test_applied_through_seq_tracks_max(self, manager: BrokerManager) -> None:
         await _seed(manager, "run-1", [("values", _protocol_event("values", {"a": 1})), ("end", {"status": "success"})])
         session = _make_session("t1", channels={"values", "lifecycle"}, run_ids=("run-1",))
         await _collect(session)
-        assert session.applied_through_seq == 2
+        assert session.applied_through_seq == 3
 
 
 class TestInterruptsToInputChannel:
@@ -244,33 +251,79 @@ class TestInterruptsToInputChannel:
 
 
 class TestLifecycle:
+    async def test_running_seed_opens_each_run(self, manager: BrokerManager) -> None:
+        await _seed(manager, "run-1", [("end", {"status": "success"})])
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
+        assert events[0]["params"]["data"] == {"event": "running"}
+        assert events[0]["params"]["namespace"] == []
+
+    async def test_root_lifecycle_carries_graph_name_when_known(self, manager: BrokerManager) -> None:
+        await _seed(manager, "run-1", [("end", {"status": "success"})])
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",), graph="my_graph"))
+        assert events[0]["params"]["data"] == {"event": "running", "graph_name": "my_graph"}
+        assert events[-1]["params"]["data"] == {"event": "completed", "graph_name": "my_graph"}
+
     async def test_completed(self, manager: BrokerManager) -> None:
         await _seed(manager, "run-1", [("end", {"status": "success"})])
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
-        assert events[0]["params"]["data"] == {"event": "completed"}
+        assert events[-1]["params"]["data"] == {"event": "completed"}
 
     async def test_interrupted(self, manager: BrokerManager) -> None:
         await _seed(manager, "run-1", [("end", {"status": "interrupted"})])
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
-        assert events[0]["params"]["data"] == {"event": "interrupted"}
+        assert events[-1]["params"]["data"] == {"event": "interrupted"}
 
     async def test_failed_carries_error(self, manager: BrokerManager) -> None:
         # The real broker error event is {error, message} with NO status; the
         # failed status must come from the method, not a status key.
         await _seed(manager, "run-1", [("error", {"error": "RuntimeError", "message": "boom"})])
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
-        assert events[0]["params"]["data"] == {"event": "failed", "error": "boom"}
+        assert events[-1]["params"]["data"] == {"event": "failed", "error": "boom"}
 
 
 class TestMisc:
-    async def test_namespaced_custom_subscription_receives_custom(self, manager: BrokerManager) -> None:
+    async def test_custom_payload_wrapped_in_wire_shape(self, manager: BrokerManager) -> None:
         await _seed(
             manager,
             "run-1",
-            [("custom", _protocol_event("custom", {"payload": {"hello": "world"}})), ("end", {"status": "success"})],
+            [("custom", _protocol_event("custom", {"hello": "world"})), ("end", {"status": "success"})],
         )
-        events = await _collect(_make_session("t1", channels={"custom:my_event", "lifecycle"}, run_ids=("run-1",)))
-        assert any(e["method"] == "custom" for e in events)
+        events = await _collect(_make_session("t1", channels={"custom"}, run_ids=("run-1",)))
+        custom = [e for e in events if e["method"] == "custom"]
+        assert custom and custom[0]["params"]["data"] == {"payload": {"hello": "world"}}
+
+    async def test_named_custom_source_becomes_custom_with_name(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [("custom:my_event", _protocol_event("custom:my_event", {"x": 1})), ("end", {"status": "success"})],
+        )
+        events = await _collect(_make_session("t1", channels={"custom:my_event"}, run_ids=("run-1",)))
+        custom = [e for e in events if e["method"] == "custom"]
+        assert custom and custom[0]["params"]["data"] == {"name": "my_event", "payload": {"x": 1}}
+
+    async def test_named_subscription_filters_other_custom_events(self, manager: BrokerManager) -> None:
+        """custom:foo subscribers get only name==foo; unnamed events need a plain custom subscription."""
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("custom:other", _protocol_event("custom:other", {"x": 1})),
+                ("custom", _protocol_event("custom", {"y": 2})),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"custom:my_event"}, run_ids=("run-1",)))
+        assert not [e for e in events if e["method"] == "custom"]
+
+    async def test_plain_custom_subscription_receives_named_events(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [("custom:my_event", _protocol_event("custom:my_event", {"x": 1})), ("end", {"status": "success"})],
+        )
+        events = await _collect(_make_session("t1", channels={"custom"}, run_ids=("run-1",)))
+        assert [e for e in events if e["method"] == "custom"]
 
     async def test_empty_thread_closes_after_idle(self, manager: BrokerManager) -> None:
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=()))
@@ -296,12 +349,12 @@ class TestResumeAcrossRuns:
 
         revealed = False
 
-        async def lister() -> list[str]:
+        async def lister() -> list[tuple[str, str | None, str | None]]:
             nonlocal revealed
             if not revealed:
                 revealed = True
-                return ["run-a"]
-            return ["run-a", "run-b"]
+                return [("run-a", "interrupted", None)]
+            return [("run-a", "interrupted", None), ("run-b", "running", None)]
 
         async def reveal_run_b() -> None:
             # run-b appears a beat after run-a drains, as the resume round-trip lands.
@@ -333,7 +386,7 @@ class TestResumeAcrossRuns:
         await _seed(manager, "run-1", [("values", _protocol_event("values", {"a": 1})), ("end", {"status": "success"})])
         session = _make_session("t1", channels={"values", "lifecycle"}, run_ids=("run-1",))
         events = await _collect(session)
-        assert [e["method"] for e in events] == ["values", "lifecycle"]
+        assert [e["method"] for e in events] == ["lifecycle", "values", "lifecycle"]
 
 
 class TestNamespaceFilter:
@@ -369,7 +422,7 @@ class TestNamespaceFilter:
         """Lifecycle (empty namespace) is not subgraph-scoped; a namespace filter must not drop it."""
         await _seed(manager, "run-1", [("end", {"status": "success"})])
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",), namespaces=[["sub_a"]]))
-        assert events[0]["params"]["data"] == {"event": "completed"}
+        assert events[-1]["params"]["data"] == {"event": "completed"}
 
     async def test_namespace_filter_matches_dynamic_task_id_suffix(self, manager: BrokerManager) -> None:
         """Real subgraph namespaces are node:<task_id>; a clean-name prefix must match."""
@@ -397,7 +450,133 @@ class TestNamespaceFilter:
             ],
         )
         events = await _collect(_make_session("t1", channels={"values"}, run_ids=("run-1",), namespaces=[["sub_a"]]))
-        assert [(e["params"]["data"], e["seq"]) for e in events] == [({"b": 2}, 2)]
+        # seq 1 = running seed (lifecycle channel, unsubscribed), 2 = filtered sub_b.
+        assert [(e["params"]["data"], e["seq"]) for e in events] == [({"b": 2}, 3)]
+
+
+class TestUpdatesInterruptHandling:
+    async def test_sibling_node_update_survives_interrupt_in_same_chunk(self, manager: BrokerManager) -> None:
+        """A parallel branch's update arriving alongside __interrupt__ must not vanish."""
+        await _seed(
+            manager,
+            "run-1",
+            [
+                (
+                    "updates",
+                    _protocol_event(
+                        "updates",
+                        {"__interrupt__": [{"id": "int-1", "value": {"q": "ok?"}}], "worker": {"count": 2}},
+                    ),
+                ),
+                ("end", {"status": "interrupted"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"input", "updates"}, run_ids=("run-1",)))
+        assert [e for e in events if e["method"] == "input.requested"]
+        updates = [e for e in events if e["method"] == "updates"]
+        assert updates and updates[0]["params"]["data"] == {"node": "worker", "values": {"count": 2}}
+
+    async def test_interrupt_nested_in_node_values_surfaces_on_input(self, manager: BrokerManager) -> None:
+        """An interrupt riding inside a node's values must emit input.requested, not be silently stripped."""
+        await _seed(
+            manager,
+            "run-1",
+            [
+                (
+                    "updates",
+                    _protocol_event(
+                        "updates",
+                        {"gate": {"messages": [], "__interrupt__": [{"id": "int-2", "value": {"q": "sure?"}}]}},
+                    ),
+                ),
+                ("end", {"status": "interrupted"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"input", "updates"}, run_ids=("run-1",)))
+        input_events = [e for e in events if e["method"] == "input.requested"]
+        assert input_events and input_events[0]["params"]["data"]["interrupt_id"] == "int-2"
+        updates = [e for e in events if e["method"] == "updates"]
+        assert "__interrupt__" not in updates[0]["params"]["data"]["values"]
+
+    async def test_same_interrupt_via_updates_then_values_emits_once(self, manager: BrokerManager) -> None:
+        """The interrupt often rides an updates chunk AND the following values snapshot."""
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("updates", _protocol_event("updates", {"__interrupt__": [{"id": "int-3", "value": {"q": "go?"}}]})),
+                (
+                    "values",
+                    _protocol_event("values", {"messages": []}, interrupts=[{"id": "int-3", "value": {"q": "go?"}}]),
+                ),
+                ("end", {"status": "interrupted"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"input", "values"}, run_ids=("run-1",)))
+        input_events = [e for e in events if e["method"] == "input.requested"]
+        assert len(input_events) == 1
+        assert input_events[0]["params"]["data"]["interrupt_id"] == "int-3"
+
+
+class TestExpiredBrokerBackstop:
+    """A historical run whose broker events expired must not wedge the stream:
+    the persisted run status drains it instead of tailing an empty broker forever."""
+
+    async def test_terminal_run_with_empty_broker_drains_silently(self, manager: BrokerManager) -> None:
+        # run-old: success in DB, broker events long gone (empty recreated broker).
+        # run-new: live events. Without the status backstop, run-old wedges forever.
+        await _seed(
+            manager, "run-new", [("values", _protocol_event("values", {"a": 1})), ("end", {"status": "success"})]
+        )
+        events = await asyncio.wait_for(
+            _collect(
+                _make_session(
+                    "t1",
+                    channels={"values", "lifecycle"},
+                    run_ids=("run-old", "run-new"),
+                    statuses={"run-old": "success", "run-new": "success"},
+                )
+            ),
+            timeout=2.0,
+        )
+        assert [e["method"] for e in events] == ["lifecycle", "values", "lifecycle"]
+
+    async def test_terminal_run_with_lost_end_frame_gets_synthesized_terminal(self, manager: BrokerManager) -> None:
+        # Events survived but the end frame was lost — client still needs closure.
+        broker = manager.get_or_create_broker("run-old")
+        await broker.put("run-old_event_1", ("values", _protocol_event("values", {"a": 1})))
+        events = await asyncio.wait_for(
+            _collect(
+                _make_session(
+                    "t1",
+                    channels={"values", "lifecycle"},
+                    run_ids=("run-old",),
+                    statuses={"run-old": "success"},
+                )
+            ),
+            timeout=2.0,
+        )
+        assert [(e["method"], e["params"]["data"].get("event")) for e in events] == [
+            ("lifecycle", "running"),
+            ("values", None),
+            ("lifecycle", "completed"),
+        ]
+
+    async def test_error_status_synthesizes_failed_lifecycle(self, manager: BrokerManager) -> None:
+        broker = manager.get_or_create_broker("run-old")
+        await broker.put("run-old_event_1", ("values", _protocol_event("values", {"a": 1})))
+        events = await asyncio.wait_for(
+            _collect(
+                _make_session(
+                    "t1",
+                    channels={"lifecycle"},
+                    run_ids=("run-old",),
+                    statuses={"run-old": "error"},
+                )
+            ),
+            timeout=2.0,
+        )
+        assert events[-1]["params"]["data"]["event"] == "failed"
 
 
 class TestSubgraphLifecycle:
@@ -429,7 +608,7 @@ class TestSubgraphLifecycle:
         )
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
         lc = [(e["params"]["data"].get("event"), e["params"]["namespace"]) for e in events]
-        assert lc == [("started", ns), ("completed", ns), ("completed", [])]
+        assert lc == [("running", []), ("started", ns), ("completed", ns), ("completed", [])]
         started = next(e for e in events if e["params"]["data"].get("event") == "started")
         assert started["params"]["data"]["graph_name"] == "subgraph_agent"
 
@@ -467,7 +646,26 @@ class TestSubgraphLifecycle:
             ],
         )
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
-        assert [e["params"]["data"] for e in events] == [{"event": "completed"}]
+        assert [e["params"]["data"] for e in events] == [{"event": "running"}, {"event": "completed"}]
+
+    async def test_terminal_cascades_still_open_subgraph_namespaces(self, manager: BrokerManager) -> None:
+        """A cancel mid-subgraph never gets the producer's completed — the terminal
+        must close the open namespace so clients don't see it started forever."""
+        ns = ["worker:abc"]
+        await _seed(
+            manager,
+            "run-1",
+            [
+                (
+                    "lifecycle",
+                    _protocol_event("lifecycle", {"event": "started", "namespace": ns, "graph_name": "worker"}),
+                ),
+                ("end", {"status": "interrupted"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
+        lc = [(e["params"]["data"].get("event"), e["params"]["namespace"]) for e in events]
+        assert lc == [("running", []), ("started", ns), ("completed", ns), ("interrupted", [])]
 
     async def test_subgraph_lifecycle_respects_namespace_filter(self, manager: BrokerManager) -> None:
         await _seed(

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -247,7 +247,9 @@ class TestLifecycle:
         assert events[0]["params"]["data"] == {"event": "interrupted"}
 
     async def test_failed_carries_error(self, manager: BrokerManager) -> None:
-        await _seed(manager, "run-1", [("error", {"status": "error", "message": "boom"})])
+        # The real broker error event is {error, message} with NO status; the
+        # failed status must come from the method, not a status key.
+        await _seed(manager, "run-1", [("error", {"error": "RuntimeError", "message": "boom"})])
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
         assert events[0]["params"]["data"] == {"event": "failed", "error": "boom"}
 

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -371,6 +371,20 @@ class TestNamespaceFilter:
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",), namespaces=[["sub_a"]]))
         assert events[0]["params"]["data"] == {"event": "completed"}
 
+    async def test_namespace_filter_matches_dynamic_task_id_suffix(self, manager: BrokerManager) -> None:
+        """Real subgraph namespaces are node:<task_id>; a clean-name prefix must match."""
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("values", _protocol_event("values", {"a": 1}, namespace=["sub_a:9f3c-1"])),
+                ("values", _protocol_event("values", {"b": 2}, namespace=["sub_b:7e1a-2"])),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"values"}, run_ids=("run-1",), namespaces=[["sub_a"]]))
+        assert [e["params"]["data"] for e in events] == [{"a": 1}]
+
     async def test_seq_stays_absolute_under_namespace_filter(self, manager: BrokerManager) -> None:
         """Filtered-out events still advance seq, so reconnect cursors stay stable."""
         await _seed(
@@ -384,6 +398,96 @@ class TestNamespaceFilter:
         )
         events = await _collect(_make_session("t1", channels={"values"}, run_ids=("run-1",), namespaces=[["sub_a"]]))
         assert [(e["params"]["data"], e["seq"]) for e in events] == [({"b": 2}, 2)]
+
+
+class TestSubgraphLifecycle:
+    """Native producer emits per-subgraph lifecycle at root scope with the child
+    namespace in data.namespace; the session promotes it onto the wire so nested
+    agents get started/completed/failed frames on their own namespace."""
+
+    async def test_subgraph_started_completed_promoted_to_child_namespace(self, manager: BrokerManager) -> None:
+        ns = ["subgraph_agent:abc-123"]
+        await _seed(
+            manager,
+            "run-1",
+            [
+                (
+                    "lifecycle",
+                    _protocol_event(
+                        "lifecycle",
+                        {
+                            "event": "started",
+                            "namespace": ns,
+                            "graph_name": "subgraph_agent",
+                            "trigger_call_id": "abc-123",
+                        },
+                    ),
+                ),
+                ("lifecycle", _protocol_event("lifecycle", {"event": "completed", "namespace": ns})),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
+        lc = [(e["params"]["data"].get("event"), e["params"]["namespace"]) for e in events]
+        assert lc == [("started", ns), ("completed", ns), ("completed", [])]
+        started = next(e for e in events if e["params"]["data"].get("event") == "started")
+        assert started["params"]["data"]["graph_name"] == "subgraph_agent"
+
+    async def test_subgraph_failed_carries_error_on_child_namespace(self, manager: BrokerManager) -> None:
+        ns = ["child_node:xyz"]
+        await _seed(
+            manager,
+            "run-1",
+            [
+                (
+                    "lifecycle",
+                    _protocol_event(
+                        "lifecycle",
+                        {"event": "started", "namespace": ns, "graph_name": "child_graph", "trigger_call_id": "xyz"},
+                    ),
+                ),
+                ("lifecycle", _protocol_event("lifecycle", {"event": "failed", "namespace": ns, "error": "boom"})),
+                ("error", {"error": "RuntimeError", "message": "boom"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
+        failed = next(e for e in events if e["params"]["data"].get("event") == "failed")
+        assert failed["params"]["namespace"] == ns
+        assert failed["params"]["data"]["error"] == "boom"
+
+    async def test_root_scoped_native_lifecycle_dropped(self, manager: BrokerManager) -> None:
+        """A native lifecycle whose data.namespace is empty is root-scoped; the
+        terminal _lifecycle owns root, so the native one must not double-emit."""
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("lifecycle", _protocol_event("lifecycle", {"event": "running", "namespace": []})),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
+        assert [e["params"]["data"] for e in events] == [{"event": "completed"}]
+
+    async def test_subgraph_lifecycle_respects_namespace_filter(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [
+                (
+                    "lifecycle",
+                    _protocol_event("lifecycle", {"event": "started", "namespace": ["sub_a:1"], "graph_name": "a"}),
+                ),
+                (
+                    "lifecycle",
+                    _protocol_event("lifecycle", {"event": "started", "namespace": ["sub_b:1"], "graph_name": "b"}),
+                ),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",), namespaces=[["sub_a"]]))
+        started = [e["params"]["namespace"] for e in events if e["params"]["data"].get("event") == "started"]
+        assert started == [["sub_a:1"]]
 
 
 class TestValidateChannels:

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -1,5 +1,6 @@
 """Tests for ThreadEventSession: native-event forwarding, seq, filter, since, HITL, lifecycle."""
 
+import asyncio
 from collections.abc import Iterator
 from typing import Any
 
@@ -133,7 +134,7 @@ class TestForwarding:
         )
         events = await _collect(_make_session("t1", channels={"input", "updates"}, run_ids=("run-1",)))
         input_events = [e for e in events if e["method"] == "input.requested"]
-        assert input_events[0]["params"]["data"] == {"interrupt_id": "int-9", "payload": {"q": "ok?"}}
+        assert input_events[0]["params"]["data"] == {"interrupt_id": "int-9", "value": {"q": "ok?"}}
         assert not [e for e in events if e["method"] == "updates"]
 
 
@@ -217,7 +218,7 @@ class TestInterruptsToInputChannel:
         events = await _collect(_make_session("t1", channels={"input", "values"}, run_ids=("run-1",)))
         input_events = [e for e in events if e["method"] == "input.requested"]
         assert input_events
-        assert input_events[0]["params"]["data"] == {"interrupt_id": "int-1", "payload": interrupt_payload}
+        assert input_events[0]["params"]["data"] == {"interrupt_id": "int-1", "value": interrupt_payload}
 
     async def test_interrupt_stripped_from_values_payload(self, manager: BrokerManager) -> None:
         """__interrupt__ never leaks into the forwarded values data."""
@@ -264,6 +265,65 @@ class TestMisc:
     async def test_empty_thread_closes_after_idle(self, manager: BrokerManager) -> None:
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=()))
         assert events == []
+
+
+class TestResumeAcrossRuns:
+    """A HITL resume starts a fresh run on the thread; its events must reach the
+    same open stream, not be dropped when the interrupted run drains first."""
+
+    async def test_followup_run_after_interrupt_streams_on_same_session(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-a",
+            [
+                (
+                    "values",
+                    _protocol_event("values", {"messages": []}, interrupts=[{"id": "int-1", "value": {"q": "ok?"}}]),
+                ),
+                ("end", {"status": "interrupted"}),
+            ],
+        )
+
+        revealed = False
+
+        async def lister() -> list[str]:
+            nonlocal revealed
+            if not revealed:
+                revealed = True
+                return ["run-a"]
+            return ["run-a", "run-b"]
+
+        async def reveal_run_b() -> None:
+            # run-b appears a beat after run-a drains, as the resume round-trip lands.
+            await asyncio.sleep(0.05)
+            await _seed(
+                manager,
+                "run-b",
+                [("values", _protocol_event("values", {"messages": [{"type": "ai", "content": "done"}]}))],
+            )
+            await manager.get_or_create_broker("run-b").put("run-b_end", ("end", {"status": "success"}))
+
+        session = ThreadEventSession(
+            "t1",
+            channels={"input", "values", "lifecycle"},
+            list_run_ids=lister,
+            idle_grace_seconds=5.0,
+        )
+        seeder = asyncio.create_task(reveal_run_b())
+        events = [e async for e in session.stream()]
+        await seeder
+
+        methods = [(e["method"], e["params"]["data"]) for e in events]
+        assert ("input.requested", {"interrupt_id": "int-1", "value": {"q": "ok?"}}) in methods
+        # run-b's completion proves the stream stayed open across the run gap.
+        assert any(e["method"] == "lifecycle" and e["params"]["data"] == {"event": "completed"} for e in events)
+
+    async def test_terminal_run_still_closes_after_grace(self, manager: BrokerManager) -> None:
+        """A completed run with no follow-up closes after one grace window."""
+        await _seed(manager, "run-1", [("values", _protocol_event("values", {"a": 1})), ("end", {"status": "success"})])
+        session = _make_session("t1", channels={"values", "lifecycle"}, run_ids=("run-1",))
+        events = await _collect(session)
+        assert [e["method"] for e in events] == ["values", "lifecycle"]
 
 
 class TestValidateChannels:

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -49,13 +49,21 @@ def _msg_event(event_kind: str, **extra: Any) -> tuple[str, dict[str, Any]]:
 
 
 def _make_session(
-    thread_id: str, *, channels: set[str], run_ids: tuple[str, ...], since: int | None = None
+    thread_id: str,
+    *,
+    channels: set[str],
+    run_ids: tuple[str, ...],
+    since: int | None = None,
+    namespaces: list[list[str]] | None = None,
+    depth: int | None = None,
 ) -> ThreadEventSession:
     return ThreadEventSession(
         thread_id,
         channels=channels,
         list_run_ids=_lister(*run_ids),
         since=since,
+        namespaces=namespaces,
+        depth=depth,
         idle_grace_seconds=0.0,
     )
 
@@ -326,6 +334,56 @@ class TestResumeAcrossRuns:
         session = _make_session("t1", channels={"values", "lifecycle"}, run_ids=("run-1",))
         events = await _collect(session)
         assert [e["method"] for e in events] == ["values", "lifecycle"]
+
+
+class TestNamespaceFilter:
+    """namespaces (prefix include-list) and depth (nesting cap) filter subgraph events."""
+
+    async def test_namespaces_include_only_matching_prefix(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("values", _protocol_event("values", {"a": 1}, namespace=["sub_a"])),
+                ("values", _protocol_event("values", {"b": 2}, namespace=["sub_b"])),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"values"}, run_ids=("run-1",), namespaces=[["sub_a"]]))
+        assert [e["params"]["data"] for e in events] == [{"a": 1}]
+
+    async def test_depth_caps_nesting(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("values", _protocol_event("values", {"top": 1}, namespace=["sub_a"])),
+                ("values", _protocol_event("values", {"deep": 2}, namespace=["sub_a", "sub_b"])),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"values"}, run_ids=("run-1",), depth=1))
+        assert [e["params"]["data"] for e in events] == [{"top": 1}]
+
+    async def test_thread_level_events_always_pass_the_filter(self, manager: BrokerManager) -> None:
+        """Lifecycle (empty namespace) is not subgraph-scoped; a namespace filter must not drop it."""
+        await _seed(manager, "run-1", [("end", {"status": "success"})])
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",), namespaces=[["sub_a"]]))
+        assert events[0]["params"]["data"] == {"event": "completed"}
+
+    async def test_seq_stays_absolute_under_namespace_filter(self, manager: BrokerManager) -> None:
+        """Filtered-out events still advance seq, so reconnect cursors stay stable."""
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("values", _protocol_event("values", {"a": 1}, namespace=["sub_b"])),  # filtered
+                ("values", _protocol_event("values", {"b": 2}, namespace=["sub_a"])),  # kept, seq=2
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"values"}, run_ids=("run-1",), namespaces=[["sub_a"]]))
+        assert [(e["params"]["data"], e["seq"]) for e in events] == [({"b": 2}, 2)]
 
 
 class TestValidateChannels:

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -311,7 +311,7 @@ class TestResumeAcrossRuns:
         )
         seeder = asyncio.create_task(reveal_run_b())
         events = [e async for e in session.stream()]
-        await seeder
+        await asyncio.wait_for(seeder, timeout=1.0)
 
         methods = [(e["method"], e["params"]["data"]) for e in events]
         assert ("input.requested", {"interrupt_id": "int-1", "value": {"q": "ok?"}}) in methods

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -1,0 +1,262 @@
+"""Tests for ThreadEventSession: native-event forwarding, seq, filter, since, HITL, lifecycle."""
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from aegra_api.services.broker import BrokerManager
+from aegra_api.services.event_streaming import session as session_module
+from aegra_api.services.event_streaming.session import (
+    ThreadEventSession,
+    validate_channels,
+)
+
+
+@pytest.fixture
+def manager(monkeypatch: pytest.MonkeyPatch) -> Iterator[BrokerManager]:
+    """Swap in a fresh in-memory broker manager for the session under test."""
+    mgr = BrokerManager()
+    monkeypatch.setattr(session_module, "broker_manager", mgr)
+    yield mgr
+
+
+def _lister(*run_ids: str):
+    async def list_run_ids() -> list[str]:
+        return list(run_ids)
+
+    return list_run_ids
+
+
+def _protocol_event(method: str, data: Any, *, namespace: list[str] | None = None, **params: Any) -> dict[str, Any]:
+    """A native v3 ProtocolEvent as it sits in the broker for a v2 run."""
+    return {
+        "type": "event",
+        "method": method,
+        "params": {"namespace": namespace or [], "data": data, **params},
+    }
+
+
+async def _seed(manager: BrokerManager, run_id: str, events: list[tuple[str, Any]]) -> None:
+    broker = manager.get_or_create_broker(run_id)
+    for i, raw in enumerate(events, start=1):
+        await broker.put(f"{run_id}_event_{i}", raw)
+
+
+def _msg_event(event_kind: str, **extra: Any) -> tuple[str, dict[str, Any]]:
+    return ("messages", _protocol_event("messages", {"event": event_kind, **extra}))
+
+
+def _make_session(
+    thread_id: str, *, channels: set[str], run_ids: tuple[str, ...], since: int | None = None
+) -> ThreadEventSession:
+    return ThreadEventSession(
+        thread_id,
+        channels=channels,
+        list_run_ids=_lister(*run_ids),
+        since=since,
+        idle_grace_seconds=0.0,
+    )
+
+
+async def _collect(session: ThreadEventSession) -> list[dict[str, Any]]:
+    return [evt async for evt in session.stream()]
+
+
+class TestForwarding:
+    async def test_message_lifecycle_forwarded_verbatim(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [
+                _msg_event("message-start", role="ai", id="m1"),
+                _msg_event("content-block-delta", index=0, delta={"type": "text-delta", "text": "hi"}),
+                _msg_event("message-finish", usage={"total_tokens": 5}),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"messages", "lifecycle"}, run_ids=("run-1",)))
+        kinds = [(e["method"], e["params"]["data"].get("event")) for e in events]
+        assert kinds == [
+            ("messages", "message-start"),
+            ("messages", "content-block-delta"),
+            ("messages", "message-finish"),
+            ("lifecycle", "completed"),
+        ]
+
+    async def test_values_payload_in_params_data(self, manager: BrokerManager) -> None:
+        await _seed(manager, "run-1", [("values", _protocol_event("values", {"a": 1})), ("end", {"status": "success"})])
+        events = await _collect(_make_session("t1", channels={"values"}, run_ids=("run-1",)))
+        assert events[0]["params"]["data"] == {"a": 1}
+        assert events[0]["params"]["namespace"] == []
+
+    async def test_namespace_preserved(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [("values", _protocol_event("values", {"a": 1}, namespace=["sub:1"])), ("end", {"status": "success"})],
+        )
+        events = await _collect(_make_session("t1", channels={"values"}, run_ids=("run-1",)))
+        assert events[0]["params"]["namespace"] == ["sub:1"]
+
+    async def test_tools_channel_forwarded(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("tools", _protocol_event("tools", {"event": "tool-started", "tool_call_id": "c1"})),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"tools"}, run_ids=("run-1",)))
+        assert events[0]["params"]["data"] == {"event": "tool-started", "tool_call_id": "c1"}
+
+
+class TestSeqAndFilter:
+    async def test_seq_monotonic_from_one(self, manager: BrokerManager) -> None:
+        await _seed(manager, "run-1", [("values", _protocol_event("values", {"a": 1})), ("end", {"status": "success"})])
+        events = await _collect(_make_session("t1", channels={"values", "lifecycle"}, run_ids=("run-1",)))
+        assert [e["seq"] for e in events] == [1, 2]
+
+    async def test_seq_spans_multiple_runs(self, manager: BrokerManager) -> None:
+        await _seed(manager, "run-1", [("values", _protocol_event("values", {"a": 1})), ("end", {"status": "success"})])
+        await _seed(manager, "run-2", [("values", _protocol_event("values", {"a": 2})), ("end", {"status": "success"})])
+        events = await _collect(_make_session("t1", channels={"values", "lifecycle"}, run_ids=("run-1", "run-2")))
+        assert [e["seq"] for e in events] == [1, 2, 3, 4]
+
+    async def test_channel_filter_drops_unsubscribed(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("values", _protocol_event("values", {"a": 1})),
+                ("updates", _protocol_event("updates", {"node": "n", "values": {"b": 2}})),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"values"}, run_ids=("run-1",)))
+        assert {e["method"] for e in events} == {"values"}
+
+    async def test_seq_absolute_not_filter_relative(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("values", _protocol_event("values", {"a": 1})),
+                ("updates", _protocol_event("updates", {"node": "n", "values": {"b": 2}})),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
+        assert [(e["method"], e["seq"]) for e in events] == [("lifecycle", 3)]
+
+    async def test_since_skips_already_seen(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("values", _protocol_event("values", {"a": 1})),
+                ("values", _protocol_event("values", {"a": 2})),
+                ("end", {"status": "success"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"values", "lifecycle"}, run_ids=("run-1",), since=1))
+        assert [e["seq"] for e in events] == [2, 3]
+
+    async def test_applied_through_seq_tracks_max(self, manager: BrokerManager) -> None:
+        await _seed(manager, "run-1", [("values", _protocol_event("values", {"a": 1})), ("end", {"status": "success"})])
+        session = _make_session("t1", channels={"values", "lifecycle"}, run_ids=("run-1",))
+        await _collect(session)
+        assert session.applied_through_seq == 2
+
+
+class TestInterruptsToInputChannel:
+    async def test_interrupt_on_values_becomes_input_requested(self, manager: BrokerManager) -> None:
+        """An interrupt riding on a values event's params.interrupts surfaces on input."""
+        interrupt_payload = {"question": "Approve?"}
+        await _seed(
+            manager,
+            "run-1",
+            [
+                (
+                    "values",
+                    _protocol_event(
+                        "values",
+                        {"messages": []},
+                        interrupts=[{"id": "int-1", "value": interrupt_payload}],
+                    ),
+                ),
+                ("end", {"status": "interrupted"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"input", "values"}, run_ids=("run-1",)))
+        input_events = [e for e in events if e["method"] == "input.requested"]
+        assert input_events
+        assert input_events[0]["params"]["data"] == {"interrupt_id": "int-1", "payload": interrupt_payload}
+
+    async def test_interrupt_stripped_from_values_payload(self, manager: BrokerManager) -> None:
+        """__interrupt__ never leaks into the forwarded values data."""
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("values", _protocol_event("values", {"messages": [], "__interrupt__": [{"id": "int-1", "value": 1}]})),
+                ("end", {"status": "interrupted"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"values"}, run_ids=("run-1",)))
+        values_events = [e for e in events if e["method"] == "values"]
+        assert "__interrupt__" not in values_events[0]["params"]["data"]
+
+
+class TestLifecycle:
+    async def test_completed(self, manager: BrokerManager) -> None:
+        await _seed(manager, "run-1", [("end", {"status": "success"})])
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
+        assert events[0]["params"]["data"] == {"event": "completed"}
+
+    async def test_interrupted(self, manager: BrokerManager) -> None:
+        await _seed(manager, "run-1", [("end", {"status": "interrupted"})])
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
+        assert events[0]["params"]["data"] == {"event": "interrupted"}
+
+    async def test_failed_carries_error(self, manager: BrokerManager) -> None:
+        await _seed(manager, "run-1", [("error", {"status": "error", "message": "boom"})])
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=("run-1",)))
+        assert events[0]["params"]["data"] == {"event": "failed", "error": "boom"}
+
+
+class TestMisc:
+    async def test_namespaced_custom_subscription_receives_custom(self, manager: BrokerManager) -> None:
+        await _seed(
+            manager,
+            "run-1",
+            [("custom", _protocol_event("custom", {"payload": {"hello": "world"}})), ("end", {"status": "success"})],
+        )
+        events = await _collect(_make_session("t1", channels={"custom:my_event", "lifecycle"}, run_ids=("run-1",)))
+        assert any(e["method"] == "custom" for e in events)
+
+    async def test_empty_thread_closes_after_idle(self, manager: BrokerManager) -> None:
+        events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=()))
+        assert events == []
+
+
+class TestValidateChannels:
+    def test_valid_channels(self) -> None:
+        valid, invalid = validate_channels(["messages", "values", "custom:foo"])
+        assert valid == {"messages", "values", "custom:foo"}
+        assert invalid == []
+
+    def test_invalid_channels_collected(self) -> None:
+        valid, invalid = validate_channels(["messages", "bogus"])
+        assert valid == {"messages"}
+        assert invalid == ["bogus"]
+
+    def test_empty_list_is_error(self) -> None:
+        valid, invalid = validate_channels([])
+        assert valid == set()
+        assert invalid
+
+    def test_non_list_is_error(self) -> None:
+        valid, invalid = validate_channels("messages")
+        assert invalid

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -111,6 +111,31 @@ class TestForwarding:
         events = await _collect(_make_session("t1", channels={"tools"}, run_ids=("run-1",)))
         assert events[0]["params"]["data"] == {"event": "tool-started", "tool_call_id": "c1"}
 
+    async def test_raw_v3_updates_normalized_to_node_values(self, manager: BrokerManager) -> None:
+        """v3 emits updates as raw {node: values}; the wire form is {node, values}."""
+        await _seed(
+            manager,
+            "run-1",
+            [("updates", _protocol_event("updates", {"worker": {"count": 1}})), ("end", {"status": "success"})],
+        )
+        events = await _collect(_make_session("t1", channels={"updates"}, run_ids=("run-1",)))
+        assert events[0]["params"]["data"] == {"node": "worker", "values": {"count": 1}}
+
+    async def test_interrupt_node_in_updates_routes_to_input(self, manager: BrokerManager) -> None:
+        """An __interrupt__ update surfaces on the input channel, not as an updates event."""
+        await _seed(
+            manager,
+            "run-1",
+            [
+                ("updates", _protocol_event("updates", {"__interrupt__": [{"id": "int-9", "value": {"q": "ok?"}}]})),
+                ("end", {"status": "interrupted"}),
+            ],
+        )
+        events = await _collect(_make_session("t1", channels={"input", "updates"}, run_ids=("run-1",)))
+        input_events = [e for e in events if e["method"] == "input.requested"]
+        assert input_events[0]["params"]["data"] == {"interrupt_id": "int-9", "payload": {"q": "ok?"}}
+        assert not [e for e in events if e["method"] == "updates"]
+
 
 class TestSeqAndFilter:
     async def test_seq_monotonic_from_one(self, manager: BrokerManager) -> None:
@@ -130,7 +155,7 @@ class TestSeqAndFilter:
             "run-1",
             [
                 ("values", _protocol_event("values", {"a": 1})),
-                ("updates", _protocol_event("updates", {"node": "n", "values": {"b": 2}})),
+                ("updates", _protocol_event("updates", {"n": {"b": 2}})),
                 ("end", {"status": "success"}),
             ],
         )
@@ -143,7 +168,7 @@ class TestSeqAndFilter:
             "run-1",
             [
                 ("values", _protocol_event("values", {"a": 1})),
-                ("updates", _protocol_event("updates", {"node": "n", "values": {"b": 2}})),
+                ("updates", _protocol_event("updates", {"n": {"b": 2}})),
                 ("end", {"status": "success"}),
             ],
         )

--- a/libs/aegra-api/tests/unit/test_services/test_run_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_executor.py
@@ -144,6 +144,50 @@ class TestExecuteRunException:
         assert "execution failed" in error_args.args[1]
 
 
+def _v3_stream(*events: tuple[str, dict]):  # type: ignore[no-untyped-def]
+    async def gen(**_kwargs):  # type: ignore[no-untyped-def]
+        for method, event in events:
+            yield method, event
+
+    return gen
+
+
+class TestStreamNativeV2InterruptDetection:
+    """_stream_native_v2 must flag has_interrupt for every interrupt shape, else
+    the run finalizes 'success' and the client gets input.requested + completed."""
+
+    async def _run(self, *events: tuple[str, dict]) -> bool:
+        from aegra_api.services import run_executor as mod
+        from aegra_api.services.run_executor import _GraphResult, _stream_native_v2
+
+        result = _GraphResult()
+        with (
+            patch.object(mod, "stream_native_v3_events", _v3_stream(*events)),
+            patch.object(mod, "broker_manager") as bm,
+            patch.object(mod, "streaming_service") as ss,
+        ):
+            bm.allocate_event_id = AsyncMock(return_value="run-1_event_1")
+            ss.put_to_broker = AsyncMock()
+            await _stream_native_v2(_make_job(), MagicMock(), {"msg": "x"}, {}, result)
+        return result.has_interrupt
+
+    @pytest.mark.asyncio
+    async def test_interrupt_via_values_params_interrupts(self) -> None:
+        event = {"params": {"data": {"messages": []}, "interrupts": [{"id": "i1", "value": 1}]}}
+        assert await self._run(("values", event)) is True
+
+    @pytest.mark.asyncio
+    async def test_interrupt_via_updates_dunder_interrupt(self) -> None:
+        # The path session.py routes to input.requested but the executor missed.
+        event = {"params": {"data": {"__interrupt__": [{"id": "i1", "value": 1}]}}}
+        assert await self._run(("updates", event)) is True
+
+    @pytest.mark.asyncio
+    async def test_no_interrupt_when_absent(self) -> None:
+        event = {"params": {"data": {"messages": []}}}
+        assert await self._run(("values", event)) is False
+
+
 class TestSignalEndEvent:
     @pytest.mark.asyncio
     async def test_publishes_end_event(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
@@ -1,0 +1,51 @@
+"""Unit tests for run_preparation helpers."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from aegra_api.services.run_preparation import _validate_resume_command
+
+
+def _session_with_thread(status: str | None) -> AsyncMock:
+    """A session whose scalar() returns a thread of the given status, or None."""
+    session = AsyncMock()
+    session.scalar = AsyncMock(return_value=SimpleNamespace(status=status) if status else None)
+    return session
+
+
+class TestValidateResumeCommand:
+    async def test_resume_on_interrupted_thread_passes(self) -> None:
+        session = _session_with_thread("interrupted")
+        await _validate_resume_command(session, "t1", {"resume": "yes"})
+
+    async def test_resume_none_on_non_interrupted_thread_is_rejected(self) -> None:
+        """{"resume": None} must still be guarded — None is a valid resume payload."""
+        session = _session_with_thread("idle")
+        with pytest.raises(HTTPException) as exc:
+            await _validate_resume_command(session, "t1", {"resume": None})
+        assert exc.value.status_code == 400
+
+    async def test_resume_value_on_busy_thread_is_rejected(self) -> None:
+        session = _session_with_thread("busy")
+        with pytest.raises(HTTPException) as exc:
+            await _validate_resume_command(session, "t1", {"resume": "yes"})
+        assert exc.value.status_code == 400
+
+    async def test_resume_on_missing_thread_is_404(self) -> None:
+        session = _session_with_thread(None)
+        with pytest.raises(HTTPException) as exc:
+            await _validate_resume_command(session, "t1", {"resume": None})
+        assert exc.value.status_code == 404
+
+    async def test_non_resume_command_skips_check(self) -> None:
+        session = _session_with_thread("idle")
+        await _validate_resume_command(session, "t1", {"goto": "node"})
+        session.scalar.assert_not_awaited()
+
+    async def test_none_command_skips_check(self) -> None:
+        session = _session_with_thread("idle")
+        await _validate_resume_command(session, "t1", None)
+        session.scalar.assert_not_awaited()

--- a/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
@@ -1,51 +1,78 @@
 """Unit tests for run_preparation helpers."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
 
+from aegra_api.services import run_preparation as mod
 from aegra_api.services.run_preparation import _validate_resume_command
 
 
-def _session_with_thread(status: str | None) -> AsyncMock:
-    """A session whose scalar() returns a thread of the given status, or None."""
+@pytest.fixture(autouse=True)
+def _fast_settle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Collapse the resume-settle backoff so reject paths don't wait."""
+    monkeypatch.setattr(mod, "_RESUME_SETTLE_INTERVAL_SECONDS", 0)
+
+
+def _thread(status: str) -> SimpleNamespace:
+    return SimpleNamespace(status=status)
+
+
+def _session_returning(thread: object) -> AsyncMock:
     session = AsyncMock()
-    session.scalar = AsyncMock(return_value=SimpleNamespace(status=status) if status else None)
+    session.scalar = AsyncMock(return_value=thread)
     return session
+
+
+def _patch_fresh_sessions(monkeypatch: pytest.MonkeyPatch, *threads: object) -> None:
+    """Make run_preparation's fresh-session poll yield the given threads in order."""
+    seq = list(threads)
+
+    async def scalar(_stmt: object) -> object:
+        return seq.pop(0) if len(seq) > 1 else (seq[0] if seq else None)
+
+    fresh = AsyncMock()
+    fresh.scalar = AsyncMock(side_effect=scalar)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=fresh)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(mod, "_get_session_maker", lambda: MagicMock(return_value=ctx))
 
 
 class TestValidateResumeCommand:
     async def test_resume_on_interrupted_thread_passes(self) -> None:
-        session = _session_with_thread("interrupted")
+        session = _session_returning(_thread("interrupted"))
         await _validate_resume_command(session, "t1", {"resume": "yes"})
 
-    async def test_resume_none_on_non_interrupted_thread_is_rejected(self) -> None:
+    async def test_resume_none_on_non_interrupted_thread_is_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """{"resume": None} must still be guarded — None is a valid resume payload."""
-        session = _session_with_thread("idle")
+        _patch_fresh_sessions(monkeypatch, _thread("idle"))
+        session = _session_returning(_thread("idle"))
         with pytest.raises(HTTPException) as exc:
             await _validate_resume_command(session, "t1", {"resume": None})
         assert exc.value.status_code == 400
 
-    async def test_resume_value_on_busy_thread_is_rejected(self) -> None:
-        session = _session_with_thread("busy")
-        with pytest.raises(HTTPException) as exc:
-            await _validate_resume_command(session, "t1", {"resume": "yes"})
-        assert exc.value.status_code == 400
+    async def test_resume_settles_when_status_flips_to_interrupted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The interrupt reaches the client before finalize commits 'interrupted';
+        the guard polls a fresh session and accepts once the status settles."""
+        _patch_fresh_sessions(monkeypatch, _thread("busy"), _thread("interrupted"))
+        session = _session_returning(_thread("busy"))  # first (request-session) read is stale
+        await _validate_resume_command(session, "t1", {"resume": "yes"})
 
     async def test_resume_on_missing_thread_is_404(self) -> None:
-        session = _session_with_thread(None)
+        session = _session_returning(None)
         with pytest.raises(HTTPException) as exc:
             await _validate_resume_command(session, "t1", {"resume": None})
         assert exc.value.status_code == 404
 
     async def test_non_resume_command_skips_check(self) -> None:
-        session = _session_with_thread("idle")
+        session = _session_returning(_thread("idle"))
         await _validate_resume_command(session, "t1", {"goto": "node"})
         session.scalar.assert_not_awaited()
 
     async def test_none_command_skips_check(self) -> None:
-        session = _session_with_thread("idle")
+        session = _session_returning(_thread("idle"))
         await _validate_resume_command(session, "t1", None)
         session.scalar.assert_not_awaited()

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -97,8 +97,8 @@ CRON_ENABLED=true
 # --- Event Streaming (Agent Protocol v2) ---
 # The v2 thread streaming endpoints (/threads/{id}/stream/events and
 # /threads/{id}/commands) used by the latest LangGraph JS/Python SDKs.
-# On by default. This flag is a kill switch: set false to unregister the
-# routes (clients get 404) and roll back without a redeploy.
+# On by default. This flag is a kill switch: set false to disable v2 serving
+# (requests return 503 with an enable hint) and roll back without a redeploy.
 # FF_V2_EVENT_STREAMING=true
 
 # --- LLM Providers ---

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -94,6 +94,13 @@ CRON_ENABLED=true
 # Soft cap on the JSONB payload size (bytes) accepted on create/update.
 # CRON_MAX_PAYLOAD_BYTES=65536
 
+# --- Event Streaming (Agent Protocol v2) ---
+# The v2 thread streaming endpoints (/threads/{id}/stream/events and
+# /threads/{id}/commands) used by the latest LangGraph JS/Python SDKs.
+# On by default. This flag is a kill switch: set false to unregister the
+# routes (clients get 404) and roll back without a redeploy.
+# FF_V2_EVENT_STREAMING=true
+
 # --- LLM Providers ---
 OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=...


### PR DESCRIPTION
## What

Adds the Agent Protocol v2 thread-scoped streaming transport that the latest LangGraph JS/Python SDKs (and the Vue/React `useStream()` composables) target:

- `POST /threads/{thread_id}/stream/events` — channel-filtered SSE stream
- `POST /threads/{thread_id}/commands` — `run.start` / `input.respond`

Closes #413.

## How

v2 runs stream through langgraph's `astream_events(version="v3")`, which emits protocol events already in wire shape — the content-block message lifecycle, tool-call blocks, token usage, and interrupts. `ThreadEventSession` **forwards** them (restamps `seq`/`event_id`, channel/namespace/depth-filters, splits interrupts onto the `input` channel, derives lifecycle) rather than reconstructing them by hand.

The v3-vs-legacy choice is a per-run flag (`event_streaming_v2`) branched at the stream-consume layer in the executor. Runs still execute once through the shared lease / broker / crash-recovery path. **v1 is byte-for-byte unaffected.**

Two paths a hand-rolled projection would drop come through natively:

- **Tool calls** arrive as `content-block-*` events on the `messages` channel; tool results as tool-role messages on `values`/`updates` (matched by `tool_call_id`).
- **HITL interrupts** surface as `input.requested` (with the interrupt id) so the SDK can resume on the same open stream.

## Channel + protocol coverage

All nine channels (`values`, `updates`, `messages`, `tools`, `custom`, `lifecycle`, `input`, `checkpoints`, `tasks`) and the command surface are covered, including:

- **Per-subgraph lifecycle** — nested runs emit `started` / `completed` / `failed` on the child namespace with `graph_name`, not just one root event. Terminal cascades any still-open subgraph namespace (deepest first) so a cancel mid-subgraph never leaves it `started`.
- **Root lifecycle** — every run opens with `lifecycle: running` and closes with a terminal carrying `graph_name`.
- **HITL resume** — `input.respond` resumes via an id-keyed resume map (the only form that works with multiple pending interrupts), supports the batch `responses` array, and returns `no_such_interrupt` for ids that can never match. Recovers the assistant from the thread's last run (the SDK sends only `interrupt_id`/`response`).
- **State normalization** — content blocks (`server_tool_call*`, `image_url`→`image`, `input_audio`→`audio`, `non_standard` wrap), OpenAI-nested `function` tool calls, `additional_kwargs` audio/tool_calls, `artifact`/`example`/`invalid_tool_calls` preservation.
- **Custom events** — wire shape `{name?, payload}` with per-name (`custom:<name>`) filtering.
- **Reconnect** — `since=<seq>` resumes past seen events; `seq` is absolute so a reconnect with a different channel set still resumes correctly. Historical runs whose broker events expired drain from the persisted run status instead of hanging the stream.
- **Streaming filters** — `namespaces` (prefix include-list, dynamic `:task_id` suffix aware) and `depth` (nesting cap).
- `params.timestamp` (ms epoch) and `meta.applied_through_seq` on the relevant envelopes.

## Wire-behavior notes for reviewers

Three client-observable behaviors worth knowing before merge (all intentional, all tested):

- Command **error envelopes ride HTTP 200** (not 4xx) so an envelope-parsing client sees the protocol error code instead of throwing on a non-2xx status.
- Every run emits a leading `lifecycle: running` frame and a `params.timestamp` on every event.
- HITL resume sends `Command(resume={interrupt_id: value})` (id-keyed map), verified against the stock SDK end to end.

## Security

The thread a run attaches to is authorized at three layers: the route ownership check (`_verify_thread_owned_or_new`, 404 cross-tenant, at entry on both endpoints), server-forced `configurable.thread_id`/`run_id` in `create_run_config` (a body- or checkpoint-supplied thread_id is discarded — the checkpointer keys on thread_id alone), and a `user_id == user.identity` filter on every tenant-scoped query. Cross-tenant 404 is tested on both routes.

## Default-on / kill switch

`FF_V2_EVENT_STREAMING` defaults **on** — it's a new endpoint set with no v1 to break. Setting it `false` makes both routes return `503` (they stay mounted, capability-gated) and rolls v2 back without a redeploy; v1 is unaffected. `503` also fires when the runtime is too old to emit native v3 events (capability probe with an upgrade hint).

## Verification

- 1700 unit + integration tests
- E2E through the **stock SDK** against a live server in **both dev (in-memory broker) and prod (Redis broker) modes** (`make e2e-both`): thread-stream + `run.start`, values, raw wire contract, tool-calling agent content-blocks, full HITL interrupt → respond → resume → complete on one stream, subgraph lifecycle, graph-error → `failed`, reconnect-with-`since`, cancel-mid-stream, ignore-resume.

## Not in scope

- **`tools`-channel execution lifecycle** (`tool-started`/`tool-finished`). The v3 transformer path we use has no tools projection; the tool-call handler that emits those events rides the legacy `stream_mode` path, which v3 does not accept. Tool *calls* and *results* are already visible via the `messages` and `values`/`updates` channels (verified live). Revisit if/when a tools transformer ships for the v3 path.
- WebSocket transport and WS-only commands (`subscription.*`, `agent.getTree`) — this transport is SSE.
- Multi-run live interleaving — runs drain oldest-first; concurrent runs on one thread are not interleaved.

## Maintainer notes

Internal architecture + debug guide (pipeline map, broker fan-out gotcha, HITL flow, the security layering, symptom→file cheat-sheet) is in `dev-docs/v2-streaming-architecture.md` — not published.

## Note

Supersedes #435 — that PR's review threads were against the earlier hand-projection design which this replaces. Opening fresh for clean review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

