### PR TITLE
test(api): align streaming endpoint tests with session-maker refactor

### DIFF
--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -453,10 +453,12 @@ class TestStreamRun:
             async def scalar(self, _stmt):
                 return None
 
-        override_session_dependency(app, BasicSession)
         client = make_client(app)
 
-        resp = client.get("/threads/test-thread-123/runs/nonexistent/stream")
+        # stream_run manages its session via _get_session_maker (not Depends),
+        # so the DI override doesn't apply — patch the maker instead.
+        with patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(Session())):
+            resp = client.get("/threads/test-thread-123/runs/nonexistent/stream")
 
         assert resp.status_code == 404
 

--- a/libs/aegra-api/tests/integration/test_api/test_stateless_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_stateless_runs_crud.py
@@ -67,6 +67,18 @@ def _run_row(
     return run
 
 
+def _make_session_maker(session_instance: DummySessionBase) -> MagicMock:
+    """Return a callable mimicking ``async_sessionmaker``.
+
+    Calling the returned object produces an async context manager that yields
+    *session_instance*, matching the ``async with maker() as session:`` pattern.
+    """
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session_instance)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=ctx)
+
+
 # ---------------------------------------------------------------------------
 # POST /runs/wait
 # ---------------------------------------------------------------------------
@@ -109,11 +121,7 @@ class TestStatelessWaitForRun:
             async def scalar(self, _stmt: object) -> None:
                 return None
 
-        session_instance = Session()
-        ctx = MagicMock()
-        ctx.__aenter__ = AsyncMock(return_value=session_instance)
-        ctx.__aexit__ = AsyncMock(return_value=False)
-        mock_maker = MagicMock(return_value=ctx)
+        mock_maker = _make_session_maker(Session())
 
         override_session_dependency(app, Session)
         client = make_client(app)
@@ -136,11 +144,7 @@ class TestStatelessWaitForRun:
 
         app = create_test_app(include_runs=True, include_threads=False)
 
-        session_instance = BasicSession()
-        ctx = MagicMock()
-        ctx.__aenter__ = AsyncMock(return_value=session_instance)
-        ctx.__aexit__ = AsyncMock(return_value=False)
-        mock_maker = MagicMock(return_value=ctx)
+        mock_maker = _make_session_maker(BasicSession())
 
         override_session_dependency(app, BasicSession)
         client = make_client(app)
@@ -205,11 +209,7 @@ class TestStatelessWaitForRun:
 
                 return Result()
 
-        session_instance = Session()
-        ctx = MagicMock()
-        ctx.__aenter__ = AsyncMock(return_value=session_instance)
-        ctx.__aexit__ = AsyncMock(return_value=False)
-        mock_maker = MagicMock(return_value=ctx)
+        mock_maker = _make_session_maker(Session())
 
         override_session_dependency(app, Session)
         client = make_client(app)
@@ -265,10 +265,13 @@ class TestStatelessStreamRun:
             async def scalar(self, _stmt: object) -> None:
                 return None
 
+        mock_maker = _make_session_maker(Session())
+
         override_session_dependency(app, Session)
         client = make_client(app)
 
         with (
+            patch("aegra_api.api.runs._get_session_maker", return_value=mock_maker),
             patch("aegra_api.services.run_preparation.get_langgraph_service") as mock_service,
             patch("aegra_api.api.stateless_runs.delete_thread_by_id", new_callable=AsyncMock),
         ):
@@ -283,17 +286,21 @@ class TestStatelessStreamRun:
     def test_on_completion_keep_accepted(self) -> None:
         """on_completion='keep' passes validation."""
         app = create_test_app(include_runs=True, include_threads=False)
+
+        mock_maker = _make_session_maker(BasicSession())
+
         override_session_dependency(app, BasicSession)
         client = make_client(app)
 
-        resp = client.post(
-            "/runs/stream",
-            json={
-                "assistant_id": "asst-123",
-                "input": {"msg": "hi"},
-                "on_completion": "keep",
-            },
-        )
+        with patch("aegra_api.api.runs._get_session_maker", return_value=mock_maker):
+            resp = client.post(
+                "/runs/stream",
+                json={
+                    "assistant_id": "asst-123",
+                    "input": {"msg": "hi"},
+                    "on_completion": "keep",
+                },
+            )
         assert resp.status_code != 422
 
 

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -15,6 +15,14 @@ from aegra_api.core.orm import Run as RunORM
 from aegra_api.models import RunCreate, User
 
 
+def _make_session_maker(session: AsyncMock) -> MagicMock:
+    """Build a mock async_sessionmaker that always yields the given session."""
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=ctx)
+
+
 class TestRunsStreamingEndpoints:
     """Test streaming run endpoints."""
 
@@ -69,6 +77,7 @@ class TestRunsStreamingEndpoints:
             patch("aegra_api.api.runs.asyncio.create_task") as mock_create_task,
             patch("aegra_api.api.runs.active_runs", {}),
             patch("aegra_api.api.runs.streaming_service.stream_run_execution") as mock_stream_exec,
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
         ):
             mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
 
@@ -81,7 +90,7 @@ class TestRunsStreamingEndpoints:
 
             mock_stream_exec.return_value = mock_generator()
 
-            response = await create_and_stream_run(thread_id, request, mock_user, mock_session)
+            response = await create_and_stream_run(thread_id, request, mock_user)
 
             # Verify Response
             assert response.status_code == 200
@@ -148,12 +157,13 @@ class TestRunsStreamingEndpoints:
             patch("aegra_api.api.runs.active_runs", {}),
             patch("aegra_api.api.runs.streaming_service.stream_run_execution", return_value=_fake_stream()),
             patch("aegra_api.api.runs.broker_manager.request_cancel", new_callable=AsyncMock) as mock_cancel,
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
         ):
             mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
             # First scalar = thread ownership check (None = new thread); second = assistant
             mock_session.scalar.side_effect = [None, sample_assistant]
 
-            response = await create_and_stream_run(thread_id, request, mock_user, mock_session)
+            response = await create_and_stream_run(thread_id, request, mock_user)
 
             handler = response.client_close_handler_callable
             if not expect_handler:
@@ -202,12 +212,13 @@ class TestRunsStreamingEndpoints:
                 new_callable=AsyncMock,
                 side_effect=RedisError("broker down"),
             ),
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
         ):
             mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
             # First scalar = thread ownership check (None = new thread); second = assistant
             mock_session.scalar.side_effect = [None, sample_assistant]
 
-            response = await create_and_stream_run(thread_id, request, mock_user, mock_session)
+            response = await create_and_stream_run(thread_id, request, mock_user)
             handler = response.client_close_handler_callable
             assert handler is not None
             # Must not raise even though the broker side-effect blows up
@@ -232,7 +243,10 @@ class TestRunsStreamingEndpoints:
 
         mock_session.scalar.return_value = run_orm
 
-        with patch("aegra_api.api.runs.streaming_service.stream_run_execution") as mock_stream_exec:
+        with (
+            patch("aegra_api.api.runs.streaming_service.stream_run_execution") as mock_stream_exec,
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
+        ):
             # Mock generator
             async def mock_generator() -> AsyncGenerator:
                 yield "data"
@@ -244,7 +258,6 @@ class TestRunsStreamingEndpoints:
                 run_id,
                 last_event_id="evt-1",
                 user=mock_user,
-                session=mock_session,
             )
 
             assert response.status_code == 200
@@ -296,16 +309,18 @@ class TestRunsStreamingEndpoints:
         async def _fake_stream() -> AsyncGenerator:
             yield "data"
 
-        with patch(
-            "aegra_api.api.runs.streaming_service.stream_run_execution",
-            return_value=_fake_stream(),
+        with (
+            patch(
+                "aegra_api.api.runs.streaming_service.stream_run_execution",
+                return_value=_fake_stream(),
+            ),
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
         ):
             response = await stream_run(
                 thread_id,
                 run_id,
                 last_event_id=last_event_id,
                 user=mock_user,
-                session=mock_session,
             )
 
         assert response.client_close_handler_callable is None
@@ -315,8 +330,11 @@ class TestRunsStreamingEndpoints:
         """Test streaming non-existent run."""
         mock_session.scalar.return_value = None
 
-        with pytest.raises(HTTPException) as exc:
-            await stream_run("t", "r", user=mock_user, session=mock_session)
+        with (
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await stream_run("t", "r", user=mock_user)
 
         assert exc.value.status_code == 404
 

--- a/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
@@ -480,15 +480,8 @@ class TestStatelessStreamRun:
     def mock_user(self) -> User:
         return User(identity="test-user", scopes=[])
 
-    @pytest.fixture
-    def mock_session(self) -> AsyncMock:
-        session = AsyncMock()
-        session.refresh = AsyncMock()
-        session.add = MagicMock()
-        return session
-
     @pytest.mark.asyncio
-    async def test_delegates_and_wraps_body_for_cleanup(self, mock_user: User, mock_session: AsyncMock) -> None:
+    async def test_delegates_and_wraps_body_for_cleanup(self, mock_user: User) -> None:
         """Delegates to create_and_stream_run and wraps iterator for cleanup."""
         request = RunCreate(assistant_id="agent", input={"msg": "hi"})
 
@@ -514,10 +507,10 @@ class TestStatelessStreamRun:
                 new_callable=AsyncMock,
             ) as mock_delete,
         ):
-            result = await stateless_stream_run(request, mock_user, mock_session)
+            result = await stateless_stream_run(request, mock_user)
 
             assert isinstance(result, EventSourceResponse)
-            mock_stream.assert_called_once_with("eph-thread-4", request, mock_user, mock_session)
+            mock_stream.assert_called_once_with("eph-thread-4", request, mock_user)
             # Outer response must re-expose the inner close handler so real
             # http.disconnect still cancels the run.
             assert result.client_close_handler_callable is inner_close_handler
@@ -531,7 +524,7 @@ class TestStatelessStreamRun:
             mock_delete.assert_called_once_with("eph-thread-4", mock_user.identity)
 
     @pytest.mark.asyncio
-    async def test_passes_through_when_keep(self, mock_user: User, mock_session: AsyncMock) -> None:
+    async def test_passes_through_when_keep(self, mock_user: User) -> None:
         """Returns original response unchanged when on_completion='keep'."""
         request = RunCreate(assistant_id="agent", input={"msg": "hi"}, on_completion="keep")
 
@@ -552,14 +545,14 @@ class TestStatelessStreamRun:
                 new_callable=AsyncMock,
             ) as mock_delete,
         ):
-            result = await stateless_stream_run(request, mock_user, mock_session)
+            result = await stateless_stream_run(request, mock_user)
 
         # Should return original response, not wrapped
         assert result is mock_response
         mock_delete.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_cleans_up_thread_when_delegation_raises(self, mock_user: User, mock_session: AsyncMock) -> None:
+    async def test_cleans_up_thread_when_delegation_raises(self, mock_user: User) -> None:
         """Thread is deleted if create_and_stream_run raises (e.g. assistant not found)."""
         request = RunCreate(assistant_id="agent", input={"msg": "hi"})
 
@@ -576,12 +569,12 @@ class TestStatelessStreamRun:
             ) as mock_delete,
             pytest.raises(RuntimeError, match="setup failed"),
         ):
-            await stateless_stream_run(request, mock_user, mock_session)
+            await stateless_stream_run(request, mock_user)
 
         mock_delete.assert_called_once_with("eph-thread-err", mock_user.identity)
 
     @pytest.mark.asyncio
-    async def test_early_disconnect_keeps_thread(self, mock_user: User, mock_session: AsyncMock) -> None:
+    async def test_early_disconnect_keeps_thread(self, mock_user: User) -> None:
         """Client disconnect before stream completion must NOT delete the thread.
 
         Regression: deleting the thread here would cancel active runs via
@@ -613,7 +606,7 @@ class TestStatelessStreamRun:
                 new_callable=AsyncMock,
             ) as mock_delete,
         ):
-            result = await stateless_stream_run(request, mock_user, mock_session)
+            result = await stateless_stream_run(request, mock_user)
 
             # Drain until CancelledError bubbles up from the iterator
             with contextlib.suppress(asyncio.CancelledError):
@@ -626,7 +619,6 @@ class TestStatelessStreamRun:
     async def test_slow_client_disconnect_with_finished_run_schedules_cleanup(
         self,
         mock_user: User,
-        mock_session: AsyncMock,
     ) -> None:
         """Slow-client / dead-proxy abort after the run finished must clean up.
 
@@ -673,7 +665,7 @@ class TestStatelessStreamRun:
             # defunct event loop).
             tasks_before = set(_background_cleanup_tasks)
 
-            result = await stateless_stream_run(request, mock_user, mock_session)
+            result = await stateless_stream_run(request, mock_user)
 
             with contextlib.suppress(asyncio.CancelledError):
                 async for _chunk in result.body_iterator:
@@ -689,7 +681,6 @@ class TestStatelessStreamRun:
     async def test_slow_client_disconnect_with_active_run_keeps_thread(
         self,
         mock_user: User,
-        mock_session: AsyncMock,
     ) -> None:
         """Slow-client abort while the run is still active must NOT clean up.
 
@@ -731,7 +722,7 @@ class TestStatelessStreamRun:
         ):
             tasks_before = set(_background_cleanup_tasks)
 
-            result = await stateless_stream_run(request, mock_user, mock_session)
+            result = await stateless_stream_run(request, mock_user)
 
             with contextlib.suppress(asyncio.CancelledError):
                 async for _chunk in result.body_iterator:
@@ -748,7 +739,6 @@ class TestStatelessStreamRun:
     async def test_slow_client_disconnect_without_run_id_keeps_thread(
         self,
         mock_user: User,
-        mock_session: AsyncMock,
     ) -> None:
         """Missing Content-Location header → slow-client cleanup branch is skipped.
 
@@ -783,7 +773,7 @@ class TestStatelessStreamRun:
         ):
             tasks_before = set(_background_cleanup_tasks)
 
-            result = await stateless_stream_run(request, mock_user, mock_session)
+            result = await stateless_stream_run(request, mock_user)
 
             with contextlib.suppress(asyncio.CancelledError):
                 async for _chunk in result.body_iterator:
@@ -800,7 +790,7 @@ class TestStatelessStreamRun:
         assert not new_tasks, "Should not schedule cleanup when run_id unavailable"
 
     @pytest.mark.asyncio
-    async def test_stream_cleanup_failure_is_logged_not_raised(self, mock_user: User, mock_session: AsyncMock) -> None:
+    async def test_stream_cleanup_failure_is_logged_not_raised(self, mock_user: User) -> None:
         """If _delete_thread_by_id raises during stream cleanup, it is logged but not propagated."""
         request = RunCreate(assistant_id="agent", input={"msg": "hi"})
 
@@ -822,7 +812,7 @@ class TestStatelessStreamRun:
                 side_effect=OSError("cleanup failed"),
             ),
         ):
-            result = await stateless_stream_run(request, mock_user, mock_session)
+            result = await stateless_stream_run(request, mock_user)
 
             # Consuming the iterator should not raise despite cleanup failure
             chunks: list[bytes] = []


### PR DESCRIPTION
## Description
  The #428 refactor ("release db sessions before SSE streaming") changed the streaming endpoints `create_and_stream_run`, `stream_run`, and `stateless_stream_run` to acquire their own short-lived session via `_get_session_maker()` and dropped the injected `session` parameter. The unit tests were never updated to match, so they still passed `session`/`mock_session` and failed at collection/run time with `TypeError` (e.g. `create_and_stream_run() takes from 2 to 3 positional arguments but 4 were given`, `stream_run() got an unexpected keyword argument 'session'`). This PR updates the affected unit tests to the new signatures. No production code changes.

  ## Type of Change
  - [ ] `feat`: New feature
  - [ ] `fix`: Bug fix
  - [ ] `docs`: Documentation changes
  - [ ] `style`: Code style/formatting
  - [ ] `refactor`: Code refactoring
  - [ ] `perf`: Performance improvement
  - [x] `test`: Tests added/updated
  - [ ] `chore`: Maintenance (dependencies, build, etc.)
  - [ ] `ci`: CI/CD changes

  ## Related Issues
  Follow-up to #428.

  ## Changes Made
  - `test_runs_streaming.py`: drop the `session` argument from the 6 `create_and_stream_run` / `stream_run` calls and patch `aegra_api.api.runs._get_session_maker` to yield the mock session, mirroring how production acquires its short-lived session. Reuse the canonical `_make_session_maker` helper shape (matching `test_runs_wait` / `test_heartbeat_keepalive`) instead of coining a new name.
  - `test_stateless_runs.py`: drop the now-unused `mock_session` argument from the 8 `stateless_stream_run` calls (the endpoint takes no session and delegates to the mocked `create_and_stream_run`), fix the delegation assertion, and remove the orphaned `mock_session` fixture + parameters.
  - `TestStatelessCreateRun` is intentionally left untouched — that endpoint still receives a `session` via dependency injection.

  ## Testing
  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] E2E tests added/updated
  - [ ] Manual testing performed

  Full unit suite green: `1223 passed`. The updated tests still fail for the right reasons — removing the `_get_session_maker` patch makes them hit the real DB and fail, and removing `session.add` in production fails `test_create_and_stream_run_success` — so coverage is preserved, not weakened.

  ## Checklist
  - [x] Code follows project style (Ruff formatting)
  - [x] All linting checks pass (`make lint`)
  - [x] Type checking passes (`make type-check`)
  - [x] All tests pass (`make test`)
  - [ ] Documentation updated (if needed) — N/A, test-only change
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] PR title follows Conventional Commits format

  ## Screenshots (if applicable)
  N/A

  ## Additional Notes
  Test-only change; no version bump (no behavior change). The new tests adopt the existing `_make_session_maker` helper convention rather than introducing a new variant; consolidating the several near-duplicate session-maker helpers into a shared fixtures module is left as a separate cleanup to keep this PR focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined unit and integration test setup for run streaming and stateless run streaming by standardizing how mocked async sessions are created and injected.
  * Updated endpoint tests to match the revised call patterns (no longer passing an explicit mock session argument).
  * Consolidated duplicated session-maker mocking into shared helpers, and adjusted assertions for disconnect/reconnect, “not found” (404), and cleanup scheduling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns unit and integration tests for the streaming endpoints (`create_and_stream_run`, `stream_run`, `stateless_stream_run`) with the session-maker refactor from #428, which dropped injected `session` parameters in favour of `_get_session_maker()`. No production code is changed.

- **`test_runs_streaming.py`**: Adds `_make_session_maker` helper and patches `_get_session_maker` in all six affected tests; drops the `session` positional argument from every `create_and_stream_run` / `stream_run` call.
- **`test_stateless_runs.py`**: Removes the now-unused `mock_session` fixture from `TestStatelessStreamRun` and drops it from all eight call sites, fixing the delegation assertion to match the new three-argument signature.
- **`test_stateless_runs_crud.py` / `test_runs_crud.py`**: Extracts the repeated inline async-context-manager mock into the shared `_make_session_maker` helper and patches `_get_session_maker` where the DI override no longer reaches the endpoint.

<h3>Confidence Score: 5/5</h3>

Test-only change that correctly aligns test call sites and mock infrastructure with the session-maker refactor; no production code is touched and the suite passes green.

All four changed files are test files. The edits mechanically remove a session parameter that the production endpoints no longer accept and add the appropriate _get_session_maker patch, matching the existing pattern used by wait/heartbeat tests. The delegation assertion in test_stateless_runs.py is updated to the correct three-argument form. No logic, migration, or API contract is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/tests/unit/test_api/test_runs_streaming.py | Adds _make_session_maker helper and patches _get_session_maker in all streaming tests; drops the session positional argument from create_and_stream_run and stream_run calls — correctly mirrors the new production signatures. |
| libs/aegra-api/tests/unit/test_api/test_stateless_runs.py | Removes orphaned mock_session fixture and all eight call-site parameters from TestStatelessStreamRun; fixes delegation assertion to match the new three-argument create_and_stream_run signature. |
| libs/aegra-api/tests/integration/test_api/test_stateless_runs_crud.py | Introduces _make_session_maker helper (DummySessionBase variant) to de-duplicate three inline mock-maker constructions; adds _get_session_maker patch to TestStatelessStreamRun tests. No coverage regressions. |
| libs/aegra-api/tests/integration/test_api/test_runs_crud.py | Replaces ineffective override_session_dependency with _get_session_maker patch in TestStreamRun.test_stream_run_not_found; uses locally defined Session (scalar→None) to trigger the 404 path correctly. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test
    participant patch as patch(_get_session_maker)
    participant Endpoint as streaming endpoint
    participant SM as _get_session_maker()
    participant DB as async session

    Note over Test,DB: New test pattern (post-refactor)
    Test->>patch: install mock returning _make_session_maker(mock_session)
    Test->>Endpoint: call without session arg
    Endpoint->>SM: _get_session_maker()
    SM-->>Endpoint: async_sessionmaker mock
    Endpoint->>DB: async with maker() as session
    DB-->>Endpoint: mock_session
    Endpoint->>DB: session.scalar() / session.add() / session.commit()
    Endpoint-->>Test: EventSourceResponse
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test
    participant patch as patch(_get_session_maker)
    participant Endpoint as streaming endpoint
    participant SM as _get_session_maker()
    participant DB as async session

    Note over Test,DB: New test pattern (post-refactor)
    Test->>patch: install mock returning _make_session_maker(mock_session)
    Test->>Endpoint: call without session arg
    Endpoint->>SM: _get_session_maker()
    SM-->>Endpoint: async_sessionmaker mock
    Endpoint->>DB: async with maker() as session
    DB-->>Endpoint: mock_session
    Endpoint->>DB: session.scalar() / session.add() / session.commit()
    Endpoint-->>Test: EventSourceResponse
```

</a>

<sub>Reviews (2): Last reviewed commit: ["test(api): fix streaming integration tes..."](https://github.com/aegra/aegra/commit/3fd2345d6b7ca005d03dacd9012fae2e1453b5fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39465877)</sub>

<!-- /greptile_comment -->