### PR TITLE
fix(metrics): support FastAPI >=0.137 (bump prometheus instrumentator to >=8.0.2)

### DIFF
--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -43,7 +43,9 @@ dependencies = [
     "openinference-instrumentation-langchain>=0.1.58",
 
     # Metrics
-    "prometheus-fastapi-instrumentator>=7.1.0",
+    # >=8.0.2: 7.x reads route.path on FastAPI >=0.137's _IncludedRouter (which has
+    # no .path), 500ing every request when metrics are on. 8.0.2 handles the new tree.
+    "prometheus-fastapi-instrumentator>=8.0.2",
 
     # Utils
     "structlog>=25.4.0",

--- a/libs/aegra-api/tests/integration/test_prometheus_metrics.py
+++ b/libs/aegra-api/tests/integration/test_prometheus_metrics.py
@@ -2,7 +2,7 @@
 
 import prometheus_client
 import pytest
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 
 from aegra_api.observability import metrics as metrics_module
@@ -51,6 +51,34 @@ def test_metrics_endpoint_returns_prometheus_format(
     body = metrics_response.text
     # Should contain standard HTTP metrics from the instrumentator
     assert "http_request_duration" in body or "http_requests" in body
+
+
+def test_instrumented_request_on_included_router_route_does_not_500(
+    monkeypatch: pytest.MonkeyPatch,
+    fresh_registry: prometheus_client.CollectorRegistry,
+) -> None:
+    """A templated route added via include_router must not 500 with metrics on.
+
+    Regression for FastAPI >=0.137: include_router puts an _IncludedRouter (no
+    .path) in app.routes. The instrumentator walks app.routes and reads .path on
+    a match, which raised AttributeError on every request with the old pin. Aegra
+    mounts all its real routers via include_router, so this is the production path.
+    """
+    app = FastAPI()
+    router = APIRouter()
+
+    @router.get("/items/{item_id}")
+    def get_item(item_id: str) -> dict[str, str]:
+        return {"item_id": item_id}
+
+    app.include_router(router)
+    monkeypatch.setattr(metrics_module.settings.observability, "ENABLE_PROMETHEUS_METRICS", True)
+    setup_prometheus_metrics(app, registry=fresh_registry)
+
+    client = TestClient(app)
+    response = client.get("/items/42")
+    assert response.status_code == 200, f"instrumented include_router route 500'd: {response.text}"
+    assert response.json() == {"item_id": "42"}
 
 
 def test_metrics_endpoint_not_exposed_when_disabled(

--- a/uv.lock
+++ b/uv.lock
@@ -72,7 +72,7 @@ requires-dist = [
     { name = "opentelemetry-api", specifier = ">=1.39.1" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.39.1" },
     { name = "opentelemetry-sdk", specifier = ">=1.39.1" },
-    { name = "prometheus-fastapi-instrumentator", specifier = ">=7.1.0" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=8.0.2" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.6"
+version = "0.138.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -628,9 +628,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/d1/195005b5e45b443e305136df47ee7df4493d782e0c039dd0d97065580324/fastapi-0.128.6.tar.gz", hash = "sha256:0cb3946557e792d731b26a42b04912f16367e3c3135ea8290f620e234f2b604f", size = 374757, upload-time = "2026-02-09T17:27:03.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c9/5e8defe249899c0dc900643695fc07829a67fc88b4ff2cdb03fcbdbf5a4b/fastapi-0.138.1.tar.gz", hash = "sha256:96e3702dce09ee0dce48856135620d3d865ca684a79fe7513fd7b13a12f82862", size = 419646, upload-time = "2026-06-25T15:40:42.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/58/a2c4f6b240eeb148fb88cdac48f50a194aba760c1ca4988c6031c66a20ee/fastapi-0.128.6-py3-none-any.whl", hash = "sha256:bb1c1ef87d6086a7132d0ab60869d6f1ee67283b20fbf84ec0003bd335099509", size = 103674, upload-time = "2026-02-09T17:27:02.355Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl", hash = "sha256:b994cae7ba8b82c976a728b544244de31333fa5f7d261f9a1dffe526444cae23", size = 129182, upload-time = "2026-06-25T15:40:40.771Z" },
 ]
 
 [[package]]
@@ -1644,15 +1644,15 @@ wheels = [
 
 [[package]]
 name = "prometheus-fastapi-instrumentator"
-version = "7.1.0"
+version = "8.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "prometheus-client" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/e9/2065686d1dfa62296fdc158b6e8fd25b0cb3dca09b0632cabeb5ae81fe4d/prometheus_fastapi_instrumentator-8.0.2.tar.gz", hash = "sha256:3c252e748151768a7aefd66824a04a870144f71de48a67aed211749a9ca2a548", size = 21342, upload-time = "2026-06-23T09:39:31.611Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/72/0824c18f3bc75810f55dacc2dd933f6ec829771180245ae3cc976195dec0/prometheus_fastapi_instrumentator-7.1.0-py3-none-any.whl", hash = "sha256:978130f3c0bb7b8ebcc90d35516a6fe13e02d2eb358c8f83887cdef7020c31e9", size = 19296, upload-time = "2025-03-19T19:35:04.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c7/fa2b3f469a2e6001b829e0d6bc8680755349aa1329a87bf48731e9d5d30a/prometheus_fastapi_instrumentator-8.0.2-py3-none-any.whl", hash = "sha256:746002ec1e2c58b93f61444e1d104de959a9463a6a3f1c8909ac3757e16c3866", size = 20549, upload-time = "2026-06-23T09:39:32.616Z" },
 ]
 
 [[package]]
@@ -2356,15 +2356,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

With `ENABLE_PROMETHEUS_METRICS=true` and FastAPI `>=0.137`, **every request returns HTTP 500**.

FastAPI 0.137 ([fastapi/fastapi#15745](https://github.com/fastapi/fastapi/pull/15745)) changed `app.routes` to hold `_IncludedRouter` tree nodes that have no `.path`. `prometheus-fastapi-instrumentator` 7.x walks `app.routes` and reads `route.path` on a match:

```
File ".../prometheus_fastapi_instrumentator/routing.py", line 55, in _get_route_name
    route_name = route.path
AttributeError: '_IncludedRouter' object has no attribute 'path'
```

Aegra mounts all its routers via `include_router`, so an `_IncludedRouter` is always present, and the instrumentator middleware raises on every request. The same FastAPI change broke `opentelemetry-instrumentation-fastapi` ([open-telemetry/opentelemetry-python-contrib#4699](https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4699)).

Reported against `aegra-api==0.9.21` + FastAPI 0.137.0.

## Fix

Bump the floor: `prometheus-fastapi-instrumentator>=7.1.0` → `>=8.0.2`. 8.0.2 handles the new route tree.

## Verification

Reproduced the exact `AttributeError` 500 with 7.1.0 + FastAPI 0.137 on an `include_router` app, confirmed 8.0.2 returns 200 on both FastAPI 0.138.1 (the broken range) and the older FastAPI we previously resolved. Added an integration regression that drives a templated `include_router` route under metrics (the prior test used a direct `@app.get`, which never produces an `_IncludedRouter` and so could not catch this). Full unit + integration suite green on the bumped resolve (FastAPI 0.138.1 / starlette 1.3.1).

## Scope

Confirmed metrics is the only thing affected. The other two places Aegra touches `app.routes` are safe on 0.137: the custom-route auth walker type-checks (`isinstance APIRoute` / recurses on `.routes`) and the root-route check already guards with `hasattr(route, "path")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus metrics compatibility with newer FastAPI routing behavior, preventing 500 errors when metrics are enabled on routed endpoints.
  * Updated the metrics dependency to a newer version that handles the current router structure more reliably.

* **Tests**
  * Added an integration test covering a routed endpoint with metrics enabled to verify successful responses and guard against regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Prometheus metrics dependency for newer FastAPI route trees. The main changes are:

- Raises `prometheus-fastapi-instrumentator` to `>=8.0.2`.
- Refreshes the lockfile to FastAPI 0.138.1 and Starlette 1.3.1.
- Adds an integration test for metrics on an `include_router` route.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/pyproject.toml | Updates the Prometheus instrumentator lower bound and documents the FastAPI route-tree compatibility reason. |
| libs/aegra-api/tests/integration/test_prometheus_metrics.py | Adds an isolated regression test for an instrumented route mounted through `include_router`. |
| uv.lock | Refreshes locked versions for the metrics and FastAPI/Starlette stack. |

<sub>Reviews (1): Last reviewed commit: ["fix(metrics): bump prometheus-fastapi-in..."](https://github.com/aegra/aegra/commit/9c48e2601e00f826623a78029bef28f575005f41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40375888)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=1640ab19-5310-4fc5-aaf6-3760087c66e8))
- Context used - AGENTS.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=15e5c4fa-b823-4fae-b564-d5a58cb22ed4))

<!-- /greptile_comment -->