### PR TITLE
fix(redis-broker): retry transient RedisError on the write path (put)

### DIFF
--- a/libs/aegra-api/src/aegra_api/services/redis_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/redis_broker.py
@@ -205,6 +205,7 @@ class RedisRunBroker(BaseRunBroker):
         # the end event was published before we subscribed on this instance).
         end_already_in_buffer = await self._check_end_in_buffer()
 
+        last_yielded_event_id: str | None = None
         try:
             while True:
                 message = await pubsub.get_message(
@@ -221,6 +222,15 @@ class RedisRunBroker(BaseRunBroker):
 
                 data = json.loads(message["data"])
                 event_id: str = data["event_id"]
+
+                # Drop an at-least-once republish (put() retries a transient
+                # publish failure). event_ids are unique per event and the write
+                # lock keeps a retry adjacent, so skipping a repeat of the last
+                # id de-duplicates without dropping a distinct event.
+                if event_id == last_yielded_event_id:
+                    continue
+                last_yielded_event_id = event_id
+
                 payload = _deserialize_payload(data["payload"])
 
                 yield event_id, payload
@@ -265,9 +275,20 @@ class RedisRunBroker(BaseRunBroker):
         all_events: list[tuple[str, Any]] = []
         events_after: list[tuple[str, Any]] = []
         found_last = last_event_id is None
+        prev_event_id: str | None = None
         for raw in raw_messages:
             data = json.loads(raw)
             event_id: str = data["event_id"]
+
+            # Skip an adjacent duplicate: put() retries are at-least-once, so a
+            # write that timed out *after* Redis applied it can RPUSH the same
+            # event twice. The per-run write lock keeps the copies adjacent, and
+            # event_ids are unique per event, so dropping a run of equal ids is
+            # safe and removes the duplicate from replay.
+            if event_id == prev_event_id:
+                continue
+            prev_event_id = event_id
+
             payload = _deserialize_payload(data["payload"])
             all_events.append((event_id, payload))
 

--- a/libs/aegra-api/src/aegra_api/services/redis_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/redis_broker.py
@@ -86,8 +86,21 @@ class RedisRunBroker(BaseRunBroker):
         self._cache_key = cache_key
         self._counter_key = counter_key
         self._finished = False
+        # Serializes writes for this run so concurrent put() calls (e.g. a
+        # cancel/error signal racing a stream write) keep cache-then-publish
+        # ordering — without it, a backoff sleep on one put could let a later
+        # event's publish overtake an earlier one.
+        self._write_lock = asyncio.Lock()
 
     async def put(self, event_id: str, payload: Any, *, resumable: bool = True) -> None:
+        """Append an event to the replay buffer and publish it to live subscribers.
+
+        Writes are retried with bounded backoff (see ``_write_with_retry``), so
+        delivery is **at-least-once**: in the rare case a write times out *after*
+        Redis already applied it, a retry may re-deliver the event. ``event_id``
+        is stable (allocated once upstream), so consumers de-duplicate on
+        ``Last-Event-ID`` during replay.
+        """
         if self._finished:
             logger.warning(f"Attempted to put event {event_id} into finished broker for run {self.run_id}")
             return
@@ -101,23 +114,28 @@ class RedisRunBroker(BaseRunBroker):
 
         is_end = isinstance(payload, tuple) and len(payload) >= 1 and payload[0] == "end"
 
-        try:
+        async with self._write_lock:
             # Cache and publish are retried independently so a publish failure
             # never re-runs the cache pipeline (which would double-write the
             # replay buffer and double-increment the sequence counter).
-            if resumable:
-                await self._write_with_retry(self._cache_event, message)
+            operation = "cache"
+            try:
+                if resumable:
+                    await self._write_with_retry(self._cache_event, message)
 
-            await self._write_with_retry(self._publish_event, message)
+                operation = "publish"
+                await self._write_with_retry(self._publish_event, message)
 
-            if is_end:
-                self._finished = True
-        except RedisError as e:
-            logger.error(f"Redis publish failed for run {self.run_id} after {_PUT_MAX_ATTEMPTS} attempts: {e}")
-            # Even if Redis fails, mark finished for end events so aiter() can exit
-            # rather than looping forever waiting for an end event that won't arrive.
-            if is_end:
-                self._finished = True
+                if is_end:
+                    self._finished = True
+            except RedisError as e:
+                logger.error(
+                    f"Redis {operation} write failed for run {self.run_id} after {_PUT_MAX_ATTEMPTS} attempts: {e}"
+                )
+                # Even if Redis fails, mark finished for end events so aiter() can exit
+                # rather than looping forever waiting for an end event that won't arrive.
+                if is_end:
+                    self._finished = True
 
     async def _cache_event(self, message: str) -> None:
         """Append the event to the replay buffer and bump the sequence counter."""

--- a/libs/aegra-api/src/aegra_api/services/redis_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/redis_broker.py
@@ -13,7 +13,7 @@ import contextlib
 import json
 import random
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
 import structlog
@@ -41,6 +41,12 @@ _REPLAY_MAX_EVENTS = 10_000
 _BACKOFF_BASE = 0.5
 _BACKOFF_MAX = 30.0
 _BACKOFF_FACTOR = 2.0
+
+# Bounded retry for the write path (put). The read path (aiter) retries
+# RedisError indefinitely; the write path must be bounded so a producer can't
+# block forever, but it should still retry a transient blip rather than drop the
+# event — a dropped event is a permanently lost SSE token.
+_PUT_MAX_ATTEMPTS = 3
 
 
 def _serialize_payload(payload: Any) -> str:
@@ -96,27 +102,62 @@ class RedisRunBroker(BaseRunBroker):
         is_end = isinstance(payload, tuple) and len(payload) >= 1 and payload[0] == "end"
 
         try:
-            client = redis_manager.get_client()
-
+            # Cache and publish are retried independently so a publish failure
+            # never re-runs the cache pipeline (which would double-write the
+            # replay buffer and double-increment the sequence counter).
             if resumable:
-                pipe = client.pipeline()
-                pipe.rpush(self._cache_key, message)
-                pipe.ltrim(self._cache_key, -_REPLAY_MAX_EVENTS, -1)
-                pipe.expire(self._cache_key, _REPLAY_TTL_SECONDS)
-                pipe.incr(self._counter_key)
-                pipe.expire(self._counter_key, _REPLAY_TTL_SECONDS)
-                await pipe.execute()  # type: ignore[invalid-await]
+                await self._write_with_retry(self._cache_event, message)
 
-            await client.publish(self._channel, message)
+            await self._write_with_retry(self._publish_event, message)
 
             if is_end:
                 self._finished = True
         except RedisError as e:
-            logger.error(f"Redis publish failed for run {self.run_id}: {e}")
+            logger.error(f"Redis publish failed for run {self.run_id} after {_PUT_MAX_ATTEMPTS} attempts: {e}")
             # Even if Redis fails, mark finished for end events so aiter() can exit
             # rather than looping forever waiting for an end event that won't arrive.
             if is_end:
                 self._finished = True
+
+    async def _cache_event(self, message: str) -> None:
+        """Append the event to the replay buffer and bump the sequence counter."""
+        client = redis_manager.get_client()
+        pipe = client.pipeline()
+        pipe.rpush(self._cache_key, message)
+        pipe.ltrim(self._cache_key, -_REPLAY_MAX_EVENTS, -1)
+        pipe.expire(self._cache_key, _REPLAY_TTL_SECONDS)
+        pipe.incr(self._counter_key)
+        pipe.expire(self._counter_key, _REPLAY_TTL_SECONDS)
+        await pipe.execute()  # type: ignore[invalid-await]
+
+    async def _publish_event(self, message: str) -> None:
+        """Broadcast the event to live subscribers."""
+        client = redis_manager.get_client()
+        await client.publish(self._channel, message)
+
+    async def _write_with_retry(self, op: Callable[[str], Awaitable[None]], message: str) -> None:
+        """Run a Redis write with bounded exponential backoff.
+
+        Mirrors the retry/backoff the read path (aiter) already applies, so a
+        transient client-side blip (e.g. socket timeout) is retried instead of
+        dropping the event. Bounded by ``_PUT_MAX_ATTEMPTS`` so a producer never
+        blocks indefinitely; the final ``RedisError`` propagates to ``put()``.
+        """
+        attempt = 0
+        while True:
+            try:
+                await op(message)
+                return
+            except RedisError as e:
+                attempt += 1
+                if attempt >= _PUT_MAX_ATTEMPTS:
+                    raise
+                delay = _backoff_delay(attempt)
+                logger.warning(
+                    f"Redis write failed for run {self.run_id}, retrying in {delay:.1f}s: {e}",
+                    attempt=attempt,
+                )
+                await asyncio.sleep(delay)
 
     async def aiter(self) -> AsyncIterator[tuple[str, Any]]:
         attempt = 0

--- a/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
@@ -279,6 +279,65 @@ class TestRedisRunBroker:
         assert order == ["A-cache-start", "A-cache-end", "publish", "B-cache", "publish"]
 
     @pytest.mark.asyncio
+    async def test_replay_dedups_adjacent_duplicate_event(self) -> None:
+        """An at-least-once retry can RPUSH the same event twice; replay() drops
+        the adjacent duplicate so a resuming client doesn't receive it twice."""
+        broker = self._make_broker()
+        mock_client = AsyncMock()
+        mock_client.lrange.return_value = [
+            json.dumps({"event_id": "evt-1", "payload": ["values", {"a": 1}]}),
+            json.dumps({"event_id": "evt-2", "payload": ["values", {"a": 2}]}),
+            json.dumps({"event_id": "evt-2", "payload": ["values", {"a": 2}]}),  # duplicate
+            json.dumps({"event_id": "evt-3", "payload": ["end", {}]}),
+        ]
+
+        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+            mock_rm.get_client.return_value = mock_client
+
+            events = await broker.replay(None)
+
+        assert [event_id for event_id, _ in events] == ["evt-1", "evt-2", "evt-3"]
+
+    @pytest.mark.asyncio
+    async def test_aiter_dedups_adjacent_duplicate_live_event(self) -> None:
+        """A republished (retried) live event with the same event_id is yielded once."""
+        broker = self._make_broker()
+
+        messages = [
+            {"type": "message", "data": json.dumps({"event_id": "evt-1", "payload": ["values", {"msg": "hi"}]})},
+            {"type": "message", "data": json.dumps({"event_id": "evt-1", "payload": ["values", {"msg": "hi"}]})},  # dup
+            {"type": "message", "data": json.dumps({"event_id": "evt-2", "payload": ["end", {"status": "success"}]})},
+        ]
+        call_count = 0
+
+        async def mock_get_message(ignore_subscribe_messages: bool = True, timeout: float = 0.5) -> dict | None:
+            nonlocal call_count
+            if call_count < len(messages):
+                msg = messages[call_count]
+                call_count += 1
+                return msg
+            return None
+
+        mock_pubsub = AsyncMock()
+        mock_pubsub.get_message = mock_get_message
+        mock_pubsub.subscribe = AsyncMock()
+        mock_pubsub.unsubscribe = AsyncMock()
+        mock_pubsub.aclose = AsyncMock()
+
+        mock_client = MagicMock()
+        mock_client.pubsub.return_value = mock_pubsub
+        mock_client.lrange = AsyncMock(return_value=[])
+
+        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+            mock_rm.get_client.return_value = mock_client
+
+            events: list[tuple[str, object]] = []
+            async for event_id, payload in broker.aiter():
+                events.append((event_id, payload))
+
+        assert [event_id for event_id, _ in events] == ["evt-1", "evt-2"]
+
+    @pytest.mark.asyncio
     async def test_aiter_yields_events(self) -> None:
         broker = self._make_broker()
 

--- a/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
@@ -1,5 +1,6 @@
 """Unit tests for RedisRunBroker and RedisBrokerManager"""
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -238,6 +239,44 @@ class TestRedisRunBroker:
             await broker.put("evt-end", ("end", {"status": "success"}))
 
         assert broker.is_finished()
+
+    @pytest.mark.asyncio
+    async def test_put_serializes_concurrent_calls(self) -> None:
+        """The per-broker write lock keeps concurrent put() calls from
+        interleaving: a second put cannot start writing while the first is
+        mid-flight, preserving cache-then-publish event ordering."""
+        broker = self._make_broker()
+        order: list[str] = []
+        gate = asyncio.Event()
+
+        async def slow_first_cache(message: str) -> None:
+            order.append("A-cache-start")
+            await gate.wait()  # hold the write lock until released
+            order.append("A-cache-end")
+
+        async def publish_noop(message: str) -> None:
+            order.append("publish")
+
+        async def second_cache(message: str) -> None:
+            order.append("B-cache")
+
+        broker._cache_event = slow_first_cache  # type: ignore[method-assign]
+        broker._publish_event = publish_noop  # type: ignore[method-assign]
+        task_a = asyncio.create_task(broker.put("evt-A", ("values", {})))
+        await asyncio.sleep(0)  # let A acquire the lock and enter its cache write
+        assert order == ["A-cache-start"]
+
+        # B is queued while A holds the lock — it must not write yet.
+        broker._cache_event = second_cache  # type: ignore[method-assign]
+        task_b = asyncio.create_task(broker.put("evt-B", ("values", {})))
+        await asyncio.sleep(0)
+        assert "B-cache" not in order
+
+        gate.set()  # release A
+        await asyncio.gather(task_a, task_b)
+
+        # A fully completes (cache then publish) before B begins.
+        assert order == ["A-cache-start", "A-cache-end", "publish", "B-cache", "publish"]
 
     @pytest.mark.asyncio
     async def test_aiter_yields_events(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
@@ -7,6 +7,7 @@ import pytest
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from aegra_api.services.redis_broker import (
+    _PUT_MAX_ATTEMPTS,
     RedisBrokerManager,
     RedisRunBroker,
     _deserialize_payload,
@@ -158,11 +159,85 @@ class TestRedisRunBroker:
         mock_client.publish = AsyncMock()
         mock_client.pipeline.return_value = mock_pipe
 
-        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+        with (
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+            patch("aegra_api.services.redis_broker.asyncio.sleep", new_callable=AsyncMock),
+        ):
             mock_rm.get_client.return_value = mock_client
 
-            # Should not raise
+            # Should not raise even after retries are exhausted
             await broker.put("evt-1", ("values", {"data": "test"}))
+
+        # Retried up to the bounded limit before giving up
+        assert mock_pipe.execute.await_count == _PUT_MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_put_retries_cache_write_then_succeeds(self) -> None:
+        """A transient RedisError on the cache pipeline is retried, not dropped.
+
+        Mirrors the read path (aiter), which already retries on RedisError.
+        """
+        broker = self._make_broker()
+        mock_pipe = MagicMock()
+        mock_pipe.execute = AsyncMock(side_effect=[RedisConnectionError("blip"), None])
+        mock_client = MagicMock()
+        mock_client.publish = AsyncMock()
+        mock_client.pipeline.return_value = mock_pipe
+
+        with (
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+            patch("aegra_api.services.redis_broker.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
+            mock_rm.get_client.return_value = mock_client
+
+            await broker.put("evt-1", ("values", {"msg": "hi"}))
+
+        assert mock_pipe.execute.await_count == 2  # one retry
+        mock_client.publish.assert_awaited_once()  # publish runs after cache succeeds
+        mock_sleep.assert_awaited()  # backed off between attempts
+
+    @pytest.mark.asyncio
+    async def test_put_retries_publish_without_rerunning_cache(self) -> None:
+        """A publish failure retries publish only — the cache pipeline is not
+        re-run, so the replay buffer is never double-written (no duplicate RPUSH)."""
+        broker = self._make_broker()
+        mock_pipe = MagicMock()
+        mock_pipe.execute = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.publish = AsyncMock(side_effect=[RedisConnectionError("blip"), None])
+        mock_client.pipeline.return_value = mock_pipe
+
+        with (
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+            patch("aegra_api.services.redis_broker.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_rm.get_client.return_value = mock_client
+
+            await broker.put("evt-1", ("values", {"msg": "hi"}))
+
+        assert mock_client.publish.await_count == 2  # publish retried
+        mock_pipe.execute.assert_awaited_once()  # cache written exactly once
+
+    @pytest.mark.asyncio
+    async def test_put_end_event_marks_finished_even_when_dropped(self) -> None:
+        """If an 'end' event can't be delivered after retries, the broker is still
+        marked finished so aiter() can exit instead of looping forever."""
+        broker = self._make_broker()
+        mock_pipe = MagicMock()
+        mock_pipe.execute = AsyncMock(side_effect=RedisConnectionError("down"))
+        mock_client = MagicMock()
+        mock_client.publish = AsyncMock(side_effect=RedisConnectionError("down"))
+        mock_client.pipeline.return_value = mock_pipe
+
+        with (
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+            patch("aegra_api.services.redis_broker.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_rm.get_client.return_value = mock_client
+
+            await broker.put("evt-end", ("end", {"status": "success"}))
+
+        assert broker.is_finished()
 
     @pytest.mark.asyncio
     async def test_aiter_yields_events(self) -> None:


### PR DESCRIPTION
## Problem (closes the gap reported in #439)

`RedisRunBroker.put()` catches `RedisError`, logs, and **drops the event with no
retry**, while the read path (`aiter`) already retries with exponential backoff.
So a *transient* client-side blip (e.g. a `socket_timeout` / `TimeoutError`
reading from the primary under load) permanently loses an SSE token — the
streamed run shows gaps / stalls even though Redis itself is healthy.

This was observed in a stage load test: the ElastiCache primary was idle
(EngineCPU ~8%, replication lag 0), yet `put()` logged
`Redis publish failed ... Timeout reading from master` and the dropped events
surfaced downstream as stalled/failed streaming.

## Fix

Give the write path the same retry/backoff the read path has:

- **Split** `put()` into `_cache_event` (the replay-buffer pipeline) and
  `_publish_event`, each retried independently. A `publish` failure therefore
  does **not** re-run the cache pipeline — avoiding a duplicate `RPUSH` / a
  double `INCR` of the sequence counter.
- **`_write_with_retry`** applies bounded exponential backoff via the existing
  `_backoff_delay` (shared with `aiter`). It is bounded by `_PUT_MAX_ATTEMPTS`
  (3) so a producer can never block indefinitely — unlike the consumer loop,
  which can retry forever.
- On exhausting retries the final `RedisError` is handled as before (logged),
  and `end` events still mark the broker finished so `aiter()` can exit.

At-least-once semantics: in the rare case a command times out *after* the
server applied it, a retry may re-deliver — strictly better than the current
guaranteed loss of the token.

## Tests

`tests/unit/test_services/test_redis_broker.py`:
- cache-write retried then succeeds (event not dropped);
- publish retried **without** re-running the cache pipeline (no duplicate RPUSH);
- retries exhausted → no raise, attempts == `_PUT_MAX_ATTEMPTS`;
- `end` event still marks the broker finished when delivery fails.

Backoff `asyncio.sleep` is patched in tests so they stay fast.

Full `aegra-api` unit suite: **1013 passed**; `ruff` clean on changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added bounded, retryable Redis write handling to prevent indefinite waits on transient Redis failures.
  * Improved “end” event behavior so iteration completes even if Redis cache and/or live publishing ultimately fails.
  * Separated retry behavior for caching versus live publishing to avoid duplicate replay writes and improve delivery reliability.
* **Tests**
  * Expanded unit tests to verify bounded retry counts and correct behavior across transient cache, transient publish, and end-event failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds bounded retry handling for Redis broker writes. The main changes are:

- Splits replay-buffer caching from live publish.
- Adds bounded backoff retries on the write path.
- Serializes same-instance writes with an async lock.
- Adds adjacent duplicate filtering for live and replay delivery.
- Adds unit tests for retry, ordering, and duplicate handling.

<h3>Confidence Score: 4/5</h3>

This should be fixed before merging.

- The retry path still allows duplicate replay events when two processes interleave writes for the same run.
- The new lock only protects one process, so live subscribers can still receive events out of order in Redis deployments.
- The new tests cover the single-process cases but not the cross-process Redis behavior.

libs/aegra-api/src/aegra_api/services/redis_broker.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/redis_broker.py | Adds retry, locking, and duplicate filtering for Redis broker writes, but cross-process runs can still produce duplicate replay events and live ordering inversions. |
| libs/aegra-api/tests/unit/test_services/test_redis_broker.py | Adds focused unit tests for single-process retry behavior, publish isolation, write serialization, and adjacent duplicate filtering. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fredis_broker.py%3A288-290%0A**Replay%20Dedupe%20Misses%20Interleaving**%0A%0AThis%20only%20removes%20duplicates%20when%20the%20repeated%20event%20is%20adjacent%20to%20its%20first%20copy.%20In%20Redis%20mode%2C%20two%20processes%20can%20have%20separate%20broker%20objects%20for%20the%20same%20run.%20If%20process%20A's%20cache%20write%20times%20out%20after%20Redis%20applied%20it%2C%20process%20B%20can%20append%20its%20event%20before%20A%20retries%20the%20same%20cache%20write.%20The%20replay%20buffer%20can%20become%20A%2C%20B%2C%20A%2C%20so%20this%20%60prev_event_id%60%20check%20yields%20the%20second%20A%20and%20a%20reconnecting%20SSE%20client%20receives%20the%20duplicated%20event.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fredis_broker.py%3A93%0A**Lock%20Is%20Process%20Local**%0A%0AThis%20lock%20preserves%20cache-then-publish%20order%20only%20inside%20one%20broker%20object.%20In%20the%20Redis%20production%20path%2C%20separate%20processes%20can%20still%20write%20the%20same%20run%20through%20separate%20%60RedisRunBroker%60%20instances.%20If%20process%20A%20caches%20event%20A%20and%20backs%20off%20before%20publish%20while%20process%20B%20caches%20and%20publishes%20event%20B%2C%20live%20subscribers%20can%20receive%20B%20before%20A%20even%20though%20replay%20order%20is%20A%2C%20B.%0A%0A&repo=aegra%2Faegra&pr=441&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fredis_broker.py%3A288-290%0A**Replay%20Dedupe%20Misses%20Interleaving**%0A%0AThis%20only%20removes%20duplicates%20when%20the%20repeated%20event%20is%20adjacent%20to%20its%20first%20copy.%20In%20Redis%20mode%2C%20two%20processes%20can%20have%20separate%20broker%20objects%20for%20the%20same%20run.%20If%20process%20A's%20cache%20write%20times%20out%20after%20Redis%20applied%20it%2C%20process%20B%20can%20append%20its%20event%20before%20A%20retries%20the%20same%20cache%20write.%20The%20replay%20buffer%20can%20become%20A%2C%20B%2C%20A%2C%20so%20this%20%60prev_event_id%60%20check%20yields%20the%20second%20A%20and%20a%20reconnecting%20SSE%20client%20receives%20the%20duplicated%20event.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fredis_broker.py%3A93%0A**Lock%20Is%20Process%20Local**%0A%0AThis%20lock%20preserves%20cache-then-publish%20order%20only%20inside%20one%20broker%20object.%20In%20the%20Redis%20production%20path%2C%20separate%20processes%20can%20still%20write%20the%20same%20run%20through%20separate%20%60RedisRunBroker%60%20instances.%20If%20process%20A%20caches%20event%20A%20and%20backs%20off%20before%20publish%20while%20process%20B%20caches%20and%20publishes%20event%20B%2C%20live%20subscribers%20can%20receive%20B%20before%20A%20even%20though%20replay%20order%20is%20A%2C%20B.%0A%0A&pr=441&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fredis-broker-put-retry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fredis-broker-put-retry%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fredis_broker.py%3A288-290%0A**Replay%20Dedupe%20Misses%20Interleaving**%0A%0AThis%20only%20removes%20duplicates%20when%20the%20repeated%20event%20is%20adjacent%20to%20its%20first%20copy.%20In%20Redis%20mode%2C%20two%20processes%20can%20have%20separate%20broker%20objects%20for%20the%20same%20run.%20If%20process%20A's%20cache%20write%20times%20out%20after%20Redis%20applied%20it%2C%20process%20B%20can%20append%20its%20event%20before%20A%20retries%20the%20same%20cache%20write.%20The%20replay%20buffer%20can%20become%20A%2C%20B%2C%20A%2C%20so%20this%20%60prev_event_id%60%20check%20yields%20the%20second%20A%20and%20a%20reconnecting%20SSE%20client%20receives%20the%20duplicated%20event.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fredis_broker.py%3A93%0A**Lock%20Is%20Process%20Local**%0A%0AThis%20lock%20preserves%20cache-then-publish%20order%20only%20inside%20one%20broker%20object.%20In%20the%20Redis%20production%20path%2C%20separate%20processes%20can%20still%20write%20the%20same%20run%20through%20separate%20%60RedisRunBroker%60%20instances.%20If%20process%20A%20caches%20event%20A%20and%20backs%20off%20before%20publish%20while%20process%20B%20caches%20and%20publishes%20event%20B%2C%20live%20subscribers%20can%20receive%20B%20before%20A%20even%20though%20replay%20order%20is%20A%2C%20B.%0A%0A&repo=aegra%2Faegra&pr=441&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(redis-broker): de-duplicate at-least..."](https://github.com/aegra/aegra/commit/d6b1317878139c0d38cb747084870277a4eb8532) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40482781)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=1640ab19-5310-4fc5-aaf6-3760087c66e8))
- Context used - AGENTS.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=15e5c4fa-b823-4fae-b564-d5a58cb22ed4))

<!-- /greptile_comment -->