### PR TITLE
chore(release): bump version to 0.9.24

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.23"
+    "version": "0.9.24"
   },
   "paths": {
     "/info": {
@@ -3125,7 +3125,7 @@
           "Event Streaming"
         ],
         "summary": "Stream Thread Events",
-        "description": "Open a channel-filtered SSE stream of the thread's run events.\n\nThread-scoped: events for any run on the thread flow through, so a\nclient can open the stream then issue ``run.start``. Each SSE frame's\n``data:`` is a protocol event envelope; ``id:`` is the ``seq`` a client\nechoes back as ``since`` on resume.",
+        "description": "Open a channel-filtered SSE stream of the thread's run events.\n\nThread-scoped: events for any run on the thread flow through, so a\nclient can open the stream then issue ``run.start``. Each SSE frame's\n``data:`` is a protocol event envelope; ``id:`` is the ``seq`` a client\nechoes back as ``since`` on resume.\n\nDB work runs in short-lived sessions (the upfront ownership check here, and\neach run-lister poll) so no connection is held for the SSE lifetime (#423).",
         "operationId": "stream_thread_events_threads__thread_id__stream_events_post",
         "parameters": [
           {
@@ -3183,7 +3183,7 @@
           "Event Streaming"
         ],
         "summary": "Post Thread Command",
-        "description": "Run a single v2 command on the thread and return its response envelope.",
+        "description": "Run a single v2 command on the thread and return its response envelope.\n\nUses a short-lived session (the run created by ``run.start`` executes on\nthe worker; the response returns before streaming begins).",
         "operationId": "post_thread_command_threads__thread_id__commands_post",
         "parameters": [
           {
@@ -3208,15 +3208,12 @@
         },
         "responses": {
           "200": {
-            "description": "Successful Response",
+            "description": "Protocol response envelope (success or error)",
             "content": {
               "application/json": {
                 "schema": {}
               }
             }
-          },
-          "400": {
-            "description": "Invalid request (unsupported channels, malformed command)"
           },
           "404": {
             "description": "Thread owned by another user"

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.23"
+version = "0.9.24"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.23"
+version = "0.9.24"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.23"
+version = "0.9.24"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.23"
+version = "0.9.24"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
Patch release bump `0.9.23` → `0.9.24` (both `aegra-api` and `aegra-cli`, kept in lockstep).

## Unreleased commits since 0.9.23 (all non-breaking)

- #440 fix: `prometheus-fastapi-instrumentator >=8.0.2` (FastAPI ≥0.137 `_IncludedRouter` crash)
- #436 feat: Agent Protocol v2 event streaming via native v3 (new endpoints, flag default-on, v1 unaffected)
- #401 feat: auth dispatch hoist into the service layer (base + assistants, explicitly non-breaking)

Per the pre-1.0 scheme (`0.MAJOR.PATCH`), a new non-breaking feature is a **patch** bump. The auth workstream's breaking renames (`runs.*`→`threads.*`, `store.search`→`store.list_namespaces`) remain earmarked for `0.10.0`.

## Changes

- `libs/aegra-api/pyproject.toml`: `0.9.23` → `0.9.24`
- `libs/aegra-cli/pyproject.toml`: `0.9.23` → `0.9.24`
- `uv.lock`: synced
- `aegra-api~=0.9.0` constraint unchanged (patch-compatible)

Tag + publish handled separately by the maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the release version for the API package to **0.9.24**.
  * Bumped the release version for the CLI package to **0.9.24**.
* **Documentation**
  * Updated the public API documentation (OpenAPI) to reflect version **0.9.24**, including clearer operation descriptions for streaming sessions and command execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a patch version bump from `0.9.23` → `0.9.24` for both `aegra-api` and `aegra-cli`, with `uv.lock` synced accordingly. The `docs/openapi.json` is also updated to reflect the new version and to document the Agent Protocol v2 event streaming endpoints introduced in #436.

- **Version files**: `pyproject.toml` for both packages and `uv.lock` updated with the new version; no dependency changes.
- **OpenAPI docs**: Endpoint descriptions for `/threads/{id}/stream_events` and `/threads/{id}/commands` enriched with session-lifetime and connection-management notes; the `400` response is removed from `post_thread_command` and the `200` response is re-described as a \"Protocol response envelope (success or error)\", reflecting the v2 protocol design where errors are carried in-band.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a version bump with documentation updates; no logic changes in this PR.

All four changed files are version strings, the generated lock file, and generated OpenAPI documentation. There is no application logic or migration in the diff. The one documentation question (whether the `post_thread_command` endpoint can still return HTTP 400 after #436) is low-risk and does not block the release.

No files require special attention; the OpenAPI 400-removal is worth a quick sanity-check against the implementation but is not blocking.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/openapi.json | Version string updated to 0.9.24; stream events and post_thread_command endpoint descriptions enriched; 400 response removed from post_thread_command in favour of a 200 'Protocol response envelope (success or error)' — should be verified that the implementation always returns 200 and never HTTP 400. |
| libs/aegra-api/pyproject.toml | Version bumped from 0.9.23 to 0.9.24; no other changes. |
| libs/aegra-cli/pyproject.toml | Version bumped from 0.9.23 to 0.9.24 in lockstep with aegra-api; no other changes. |
| uv.lock | Lock file updated to reflect both aegra-api and aegra-cli at 0.9.24; no dependency changes. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant API as aegra-api 0.9.24
    participant Worker
    participant DB

    Client->>API: "POST /threads/{id}/commands (v2 command)"
    API->>DB: Short-lived session: ownership check
    DB-->>API: OK
    API->>Worker: Dispatch run.start
    Worker-->>API: Response envelope (success or error)
    API-->>Client: 200 Protocol response envelope

    Client->>API: "POST /threads/{id}/stream_events (SSE)"
    API->>DB: Short-lived session: ownership check
    DB-->>API: OK
    loop SSE lifetime
        Worker->>API: run events
        API-->>Client: SSE frame (data: event envelope, id: seq)
    end
    Client->>API: "Resume with ?since={seq}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant API as aegra-api 0.9.24
    participant Worker
    participant DB

    Client->>API: "POST /threads/{id}/commands (v2 command)"
    API->>DB: Short-lived session: ownership check
    DB-->>API: OK
    API->>Worker: Dispatch run.start
    Worker-->>API: Response envelope (success or error)
    API-->>Client: 200 Protocol response envelope

    Client->>API: "POST /threads/{id}/stream_events (SSE)"
    API->>DB: Short-lived session: ownership check
    DB-->>API: OK
    loop SSE lifetime
        Worker->>API: run events
        API-->>Client: SSE frame (data: event envelope, id: seq)
    end
    Client->>API: "Resume with ?since={seq}"
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore(release): regenerate openapi.json ..."](https://github.com/aegra/aegra/commit/97ecc8bc1a6ffef643c8156e4daa4c0177c3f8ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41901456)</sub>

<!-- /greptile_comment -->