### PR TITLE
fix(docs): add root ASSISTANT.md for Mintlify skill discovery

### DIFF
--- a/ASSISTANT.md
+++ b/ASSISTANT.md
@@ -1,0 +1,9 @@
+# Aegra
+
+Aegra is an open-source, self-hosted alternative to LangSmith Deployments: a
+production-ready Agent Protocol server for running LangGraph agents on your own
+infrastructure (Python 3.12+, FastAPI, PostgreSQL).
+
+Published documentation lives in [`docs/`](docs/) and is served at
+https://docs.aegra.dev. Contributor and agent guidance is in
+[`CLAUDE.md`](CLAUDE.md) and [`AGENTS.md`](AGENTS.md).


### PR DESCRIPTION
## Problem

The **Mintlify Deployment** check goes red on every commit to `main`:

```
Fetching ASSISTANT.md file...
Discovering assistant skills...
Unable to find docs.json or mint.json
No Assistant.md file found
```

Mintlify's deploy runs an assistant-skill discovery step that probes the **repo root** for `ASSISTANT.md` and a config file. Aegra keeps `docs.json` under `docs/`, so this step fails and marks the whole check `failure` — even though the docs site itself deploys fine (the main build finds `docs/docs.json`; only the root-probing skill-discovery sub-step fails). This is pre-existing and independent of code changes.

## Fix

Add a minimal root `ASSISTANT.md` (the file the error names as missing) that points at the existing `docs/`, `CLAUDE.md`, and `AGENTS.md` — single source of truth, no duplicated content.

## Notes

- Not a blocking check (no branch protection), but it shows a red cross on every commit.
- If the check still fails after this (i.e. Mintlify also insists on a root-level `docs.json`), the alternative is a dashboard content-directory setting — flagged for follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new assistant overview with product positioning and deployment context.
  * Included guidance links for setup, documentation, and contributor/agent workflows.
  * Clarified that the project supports self-hosted, production-ready deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a minimal root-level `ASSISTANT.md` to satisfy Mintlify's assistant-skill discovery CI step, which was probing the repo root for both this file and a config file (`docs.json`/`mint.json`) and marking the check red when neither was found.

- Adds `ASSISTANT.md` at the repo root with a brief project description and relative links to `docs/`, `CLAUDE.md`, and `AGENTS.md` — no content is duplicated, just pointers to the existing single sources of truth.
- The missing `docs.json` at the root (kept under `docs/`) is not addressed by this PR; as the author notes, the skill-discovery step may still fail on that missing piece, requiring a Mintlify dashboard `content-directory` setting as follow-up.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only change is adding a small markdown pointer file at the repo root with no impact on application code or the docs build.

The addition is limited to a nine-line markdown file that carries no build-time logic. The linked files (docs/, CLAUDE.md, AGENTS.md) all exist in the repo, so none of the references are broken. The PR author already calls out the remaining risk — Mintlify may still probe for a root-level docs.json — so there are no hidden surprises here.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| ASSISTANT.md | New root-level ASSISTANT.md added to satisfy Mintlify's assistant-skill discovery probe; content is accurate and links to existing docs/, CLAUDE.md, and AGENTS.md |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to main] --> B[Mintlify Deploy CI]
    B --> C[Main build\ndocs/ → docs.aegra.dev]
    B --> D[Assistant skill discovery step\nprobes repo root]
    D --> E{ASSISTANT.md\nat root?}
    E -- Before PR: No --> F[❌ Skill discovery fails\nwhole check goes red]
    E -- After PR: Yes --> G{docs.json or mint.json\nat root?}
    G -- No\nstill in docs/ --> H[⚠️ May still fail\nif Mintlify requires root docs.json]
    G -- Yes --> I[✅ Both checks pass]
    C --> J[✅ Docs site deploys fine\nfinds docs/docs.json]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Push to main] --> B[Mintlify Deploy CI]
    B --> C[Main build\ndocs/ → docs.aegra.dev]
    B --> D[Assistant skill discovery step\nprobes repo root]
    D --> E{ASSISTANT.md\nat root?}
    E -- Before PR: No --> F[❌ Skill discovery fails\nwhole check goes red]
    E -- After PR: Yes --> G{docs.json or mint.json\nat root?}
    G -- No\nstill in docs/ --> H[⚠️ May still fail\nif Mintlify requires root docs.json]
    G -- Yes --> I[✅ Both checks pass]
    C --> J[✅ Docs site deploys fine\nfinds docs/docs.json]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(docs): add root ASSISTANT.md for Min..."](https://github.com/aegra/aegra/commit/75cb42411f5ff65d36ab6a13fbade2647e20150c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41904306)</sub>

<!-- /greptile_comment -->