### PR TITLE
docs(readme): downloads badge + surface v2 streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <p align="center">
   <a href="https://pypi.org/project/aegra-api/"><img src="https://img.shields.io/pypi/v/aegra-api?label=aegra-api&color=blue" alt="PyPI API"></a>
   <a href="https://pypi.org/project/aegra-cli/"><img src="https://img.shields.io/pypi/v/aegra-cli?label=aegra-cli&color=blue" alt="PyPI CLI"></a>
+  <a href="https://pepy.tech/project/aegra-api"><img src="https://img.shields.io/pepy/dt/aegra-api?label=downloads&color=blue" alt="Downloads"></a>
   <a href="https://github.com/aegra/aegra/actions/workflows/ci.yml"><img src="https://github.com/aegra/aegra/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://app.codecov.io/gh/aegra/aegra"><img src="https://codecov.io/gh/aegra/aegra/graph/badge.svg" alt="Codecov"></a>
 </p>
@@ -27,6 +28,8 @@
 Aegra is a drop-in replacement for LangSmith Deployments. Use the same LangGraph SDK, same APIs, but run it on your own infrastructure with PostgreSQL persistence.
 
 **Works with:** [Agent Chat UI](https://github.com/langchain-ai/agent-chat-ui) | [LangGraph Studio](https://github.com/langchain-ai/langgraph-studio) | [AG-UI / CopilotKit](https://github.com/CopilotKit/CopilotKit)
+
+> **🆕 New: Agent Protocol v2 streaming.** Thread-scoped SSE with content-block events, per-subgraph lifecycle, and native human-in-the-loop resume — the wire the latest LangGraph SDKs and `useStream()` target. Enabled by default. See the [streaming guide](https://docs.aegra.dev/guides/streaming).
 
 ## 🚀 Quick Start
 
@@ -101,7 +104,7 @@ async for chunk in client.runs.stream(
 - **[Worker architecture](https://docs.aegra.dev/guides/worker-architecture)** - Redis job queue with 30 concurrent runs per instance, lease-based crash recovery, and horizontal scaling across multiple instances
 - **[Scheduled cron jobs](https://docs.aegra.dev/guides/cron)** - Trigger runs on a schedule with standard 5-field or seconds-level 6-field expressions, IANA timezone support, and multi-instance safe `SKIP LOCKED` claim
 - **[Human-in-the-loop](https://docs.aegra.dev/guides/human-in-the-loop)** - Approval gates and user intervention points
-- **[Streaming](https://docs.aegra.dev/guides/streaming)** - Real-time SSE streaming with cross-instance pub/sub and automatic reconnection with event replay
+- **[Streaming](https://docs.aegra.dev/guides/streaming)** - Real-time SSE streaming with cross-instance pub/sub and automatic reconnection with event replay. Supports both the legacy run-scoped stream and **Agent Protocol v2** thread-scoped streaming (content-block events, per-subgraph lifecycle, HITL resume) for the latest LangGraph SDKs and `useStream()`
 - **[Persistent state](https://docs.aegra.dev/guides/threads-and-state)** - PostgreSQL checkpoints via LangGraph
 - **[Configurable auth](https://docs.aegra.dev/guides/authentication)** - JWT, OAuth, Firebase, or none
 - **[Unified Observability](https://docs.aegra.dev/guides/observability)** - Fan-out tracing support via OpenTelemetry


### PR DESCRIPTION
## What

Two README additions:

**Downloads badge** — total downloads (pepy, `aegra-api`, ~174k) placed right after the version badges. Matches the convention of the closest peer projects (LangGraph, LangChain, reflex all use a pepy total-downloads badge after version). One badge, single registry — no monthly/weekly clutter.

**Agent Protocol v2 streaming visibility** — the feature just shipped (#436) but wasn't surfaced in the README. Added:
- a "🆕 New" callout above the fold (after the "Works with" line)
- expanded the existing Streaming feature bullet to name v2 explicitly (thread-scoped, content-block events, per-subgraph lifecycle, HITL resume, `useStream()`)

Both link to the existing [streaming guide](https://docs.aegra.dev/guides/streaming).

## Why

v2 streaming is a headline feature with no README presence — new visitors couldn't tell it exists. The callout makes it clear as day now; the feature bullet keeps it documented after the "new" callout is eventually removed.

Docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a PyPI downloads badge for the project.
  * Highlighted “Agent Protocol v2 streaming” with a link to the streaming guide.
  * Expanded the Streaming feature description to include automatic reconnection, event replay, thread-scoped streaming, per-subgraph lifecycle events, and HITL resume support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a docs-only change to `README.md` that adds two things: a pepy.tech total-downloads badge for `aegra-api` placed between the version badges and the CI badge, and visibility for the Agent Protocol v2 streaming feature that shipped in #436 but had no README presence.

- **Downloads badge** — uses the standard `img.shields.io/pepy/dt/aegra-api` shield linked to `pepy.tech/project/aegra-api`, consistent with how peer projects (LangGraph, LangChain) surface download counts.
- **v2 streaming callout** — a blockquote above the Quick Start section describes the thread-scoped SSE, content-block events, per-subgraph lifecycle, and HITL resume capabilities; the existing Streaming feature bullet is also expanded to name v2 explicitly with the same details.

<h3>Confidence Score: 4/5</h3>

Safe to merge — purely additive documentation change with no code impact.

The only change is to README.md: a pepy badge and a new blockquote callout for v2 streaming. There is one minor grammatical fragment in the callout ("the wire the latest LangGraph SDKs") that leaves a sentence technically incomplete for first-time readers, but nothing that affects runtime behavior.

No files require special attention beyond the one-word fix in the v2 streaming callout.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds a pepy.tech total-downloads badge for aegra-api and surfaces the Agent Protocol v2 streaming feature via a new blockquote callout and an expanded streaming bullet; one minor grammatical fragment in the callout text. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as Client (useStream())
    participant Aegra as Aegra Server
    participant LG as LangGraph

    Client->>Aegra: "GET /threads/{id}/runs/stream (v2 SSE)"
    Aegra->>LG: Execute graph
    LG-->>Aegra: content-block events (per-subgraph)
    Aegra-->>Client: SSE: thread-scoped events
    Note over Aegra,Client: Human-in-the-loop interrupt
    Aegra-->>Client: SSE: interrupt event
    Client->>Aegra: "POST /threads/{id}/runs (HITL resume)"
    LG-->>Aegra: resume execution
    Aegra-->>Client: SSE: remaining events
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as Client (useStream())
    participant Aegra as Aegra Server
    participant LG as LangGraph

    Client->>Aegra: "GET /threads/{id}/runs/stream (v2 SSE)"
    Aegra->>LG: Execute graph
    LG-->>Aegra: content-block events (per-subgraph)
    Aegra-->>Client: SSE: thread-scoped events
    Note over Aegra,Client: Human-in-the-loop interrupt
    Aegra-->>Client: SSE: interrupt event
    Client->>Aegra: "POST /threads/{id}/runs (HITL resume)"
    LG-->>Aegra: resume execution
    Aegra-->>Client: SSE: remaining events
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A32%0AThe%20phrase%20%22the%20wire%22%20is%20a%20fragment%20%E2%80%94%20a%20noun%20like%20%22format%22%20or%20%22protocol%22%20is%20missing%2C%20making%20the%20sentence%20awkward%20to%20parse.%0A%0A%60%60%60suggestion%0A%3E%20**%F0%9F%86%95%20New%3A%20Agent%20Protocol%20v2%20streaming.**%20Thread-scoped%20SSE%20with%20content-block%20events%2C%20per-subgraph%20lifecycle%2C%20and%20native%20human-in-the-loop%20resume%20%E2%80%94%20the%20wire%20format%20the%20latest%20LangGraph%20SDKs%20and%20%60useStream%28%29%60%20target.%20Enabled%20by%20default.%20See%20the%20%5Bstreaming%20guide%5D%28https%3A%2F%2Fdocs.aegra.dev%2Fguides%2Fstreaming%29.%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A32%0AThe%20phrase%20%22the%20wire%22%20is%20a%20fragment%20%E2%80%94%20a%20noun%20like%20%22format%22%20or%20%22protocol%22%20is%20missing%2C%20making%20the%20sentence%20awkward%20to%20parse.%0A%0A%60%60%60suggestion%0A%3E%20**%F0%9F%86%95%20New%3A%20Agent%20Protocol%20v2%20streaming.**%20Thread-scoped%20SSE%20with%20content-block%20events%2C%20per-subgraph%20lifecycle%2C%20and%20native%20human-in-the-loop%20resume%20%E2%80%94%20the%20wire%20format%20the%20latest%20LangGraph%20SDKs%20and%20%60useStream%28%29%60%20target.%20Enabled%20by%20default.%20See%20the%20%5Bstreaming%20guide%5D%28https%3A%2F%2Fdocs.aegra.dev%2Fguides%2Fstreaming%29.%0A%60%60%60%0A%0A&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22docs%2Freadme-v2-streaming-downloads-badge%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2Freadme-v2-streaming-downloads-badge%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A32%0AThe%20phrase%20%22the%20wire%22%20is%20a%20fragment%20%E2%80%94%20a%20noun%20like%20%22format%22%20or%20%22protocol%22%20is%20missing%2C%20making%20the%20sentence%20awkward%20to%20parse.%0A%0A%60%60%60suggestion%0A%3E%20**%F0%9F%86%95%20New%3A%20Agent%20Protocol%20v2%20streaming.**%20Thread-scoped%20SSE%20with%20content-block%20events%2C%20per-subgraph%20lifecycle%2C%20and%20native%20human-in-the-loop%20resume%20%E2%80%94%20the%20wire%20format%20the%20latest%20LangGraph%20SDKs%20and%20%60useStream%28%29%60%20target.%20Enabled%20by%20default.%20See%20the%20%5Bstreaming%20guide%5D%28https%3A%2F%2Fdocs.aegra.dev%2Fguides%2Fstreaming%29.%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): add downloads badge and su..."](https://github.com/aegra/aegra/commit/342f26076c1d8fcb557151ea1c07495d1ed35fc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41908598)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->