### PR TITLE
fix(observability): bind structlog contextvars in LocalExecutor run path

### DIFF
--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -203,11 +203,18 @@ def make_run_trace_context(
         trace_name=graph_id,
         metadata=metadata,
     )
-    ctx.run(
-        structlog.contextvars.bind_contextvars,
-        run_id=run_id,
-        thread_id=thread_id,
-        graph_id=graph_id,
-        user_id=user_identity,
-    )
+    # Bind structlog context vars inside the same isolated context so
+    # background-task logs include the run identifiers. Run via ``ctx.run``
+    # so the binding lands in the returned context, not the caller's.
+    # ``user_id`` is only bound when present, matching the OTEL path above
+    # (``set_trace_context`` guards on truthy ``user_id``) — anonymous runs
+    # omit the key rather than logging ``user_id=None``.
+    structlog_bindings: dict[str, str] = {
+        "run_id": run_id,
+        "thread_id": thread_id,
+        "graph_id": graph_id,
+    }
+    if user_identity is not None:
+        structlog_bindings["user_id"] = user_identity
+    ctx.run(structlog.contextvars.bind_contextvars, **structlog_bindings)
     return ctx

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -25,6 +25,7 @@ import contextvars
 import logging
 from typing import Any
 
+import structlog
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 
@@ -174,15 +175,19 @@ def make_run_trace_context(
     *,
     extra_metadata: dict[str, Any] | None = None,
 ) -> contextvars.Context:
-    """Return an isolated context copy with OTEL trace attributes pre-set for a run.
+    """Return an isolated context copy with trace context pre-set for a run.
 
-    Creates a copy of the current context and populates it with per-request
-    span attributes.  Pass the returned context to ``asyncio.create_task(...,
-    context=ctx)`` so the background task starts with the correct trace data.
+    Creates a copy of the current context and populates it with both the
+    per-request OTEL span attributes and the structlog context vars
+    (``run_id``, ``thread_id``, ``graph_id``, ``user_id``).  Pass the
+    returned context to ``asyncio.create_task(..., context=ctx)`` so the
+    background task starts with the correct trace data and every log line
+    it emits carries the run identifiers automatically — mirroring the
+    worker path's ``_restore_trace_context``.
 
     User-supplied ``extra_metadata`` is merged with the system runtime keys
-    (``run_id``, ``thread_id``, ``graph_id``).  System keys win on collision —
-    see :func:`merge_run_metadata`.
+    (``run_id``, ``thread_id``, ``graph_id``) for the OTEL attributes.
+    System keys win on collision — see :func:`merge_run_metadata`.
     """
     system_metadata: dict[str, str | int | float | bool] = {
         "run_id": run_id,
@@ -197,5 +202,12 @@ def make_run_trace_context(
         session_id=thread_id,
         trace_name=graph_id,
         metadata=metadata,
+    )
+    ctx.run(
+        structlog.contextvars.bind_contextvars,
+        run_id=run_id,
+        thread_id=thread_id,
+        graph_id=graph_id,
+        user_id=user_identity,
     )
     return ctx

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -291,6 +291,20 @@ class TestMakeRunTraceContext:
 
         assert structlog.contextvars.get_contextvars() == {}
 
+    def test_anonymous_user_omits_structlog_user_id(self) -> None:
+        """user_identity=None omits user_id instead of binding it as None.
+
+        Mirrors the OTEL path, which skips user.id for anonymous runs, so
+        logs never carry a noisy ``user_id=None``.
+        """
+        ctx = make_run_trace_context("run-1", "thread-1", "my_graph", None)
+
+        bound = ctx.run(structlog.contextvars.get_contextvars)
+        assert "user_id" not in bound
+        assert bound["run_id"] == "run-1"
+        assert bound["thread_id"] == "thread-1"
+        assert bound["graph_id"] == "my_graph"
+
 
 class TestMergeRunMetadata:
     """Tests for merge_run_metadata()."""

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -5,6 +5,7 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
+import structlog
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
@@ -211,8 +212,9 @@ class TestMakeRunTraceContext:
     """Tests for make_run_trace_context()."""
 
     def setup_method(self) -> None:
-        """Reset context var before each test."""
+        """Reset context vars before each test."""
         _trace_attrs.set(None)
+        structlog.contextvars.clear_contextvars()
 
     def test_returned_context_contains_expected_attributes(self) -> None:
         """Returned context has all trace attributes pre-set."""
@@ -272,6 +274,22 @@ class TestMakeRunTraceContext:
         attrs = ctx.run(_trace_attrs.get)
         assert attrs["langfuse.trace.metadata.run_id"] == "run-actual"
         assert attrs["langfuse.trace.metadata.tenant"] == "acme"
+
+    def test_returned_context_binds_structlog_vars(self) -> None:
+        """Returned context has structlog context vars bound for run logs."""
+        ctx = make_run_trace_context("run-1", "thread-1", "my_graph", "user-1")
+
+        bound = ctx.run(structlog.contextvars.get_contextvars)
+        assert bound["run_id"] == "run-1"
+        assert bound["thread_id"] == "thread-1"
+        assert bound["graph_id"] == "my_graph"
+        assert bound["user_id"] == "user-1"
+
+    def test_structlog_binding_does_not_pollute_caller_context(self) -> None:
+        """Binding happens inside the returned context, not the caller's."""
+        make_run_trace_context("run-1", "thread-1", "my_graph", "user-1")
+
+        assert structlog.contextvars.get_contextvars() == {}
 
 
 class TestMergeRunMetadata:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background run logs now automatically include run-specific identifiers for easier tracing across async tasks.
  * Run context setup now unifies tracing details and logging context so related logs share the same identifiers.

* **Tests**
  * Expanded coverage to verify that log context is bound correctly during run-context creation (including conditional user identifier handling).
  * Added checks to ensure log context does not leak into the caller’s context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a missing structlog context binding in the `LocalExecutor` run path by calling `structlog.contextvars.bind_contextvars` inside the already-isolated `ctx.run()` in `make_run_trace_context`, so background-task logs automatically carry `run_id`, `thread_id`, `graph_id`, and (when present) `user_id`. It also addresses a prior review finding by guarding `user_id` on `is not None` rather than binding `None` unconditionally.

- **`span_enrichment.py`**: Adds a `ctx.run(structlog.contextvars.bind_contextvars, ...)` call after the existing OTEL `set_trace_context` binding, keeping both in the isolated context copy and leaving the caller's context untouched.
- **`test_span_enrichment.py`**: Adds three targeted test cases verifying structlog bindings are present in the returned context, do not leak into the caller, and omit `user_id` for anonymous runs; `setup_method` is extended to clear structlog contextvars before each test.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to adding structlog bindings inside an already-isolated context copy, with no mutation of the caller's context and no changes to the OTEL path.

The implementation follows the same ctx.run() pattern already used for set_trace_context, the three new tests directly verify isolation and correctness, and the prior review concern about user_id=None is correctly resolved. The only minor point is a predicate inconsistency (is not None vs truthy) between the structlog and OTEL paths, which is unlikely to matter in practice but is worth aligning.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/observability/span_enrichment.py | Adds structlog.contextvars.bind_contextvars call inside ctx.run() so background-task logs carry run identifiers; correctly guards user_id on not-None; minor inconsistency with the OTEL path's truthy guard. |
| libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py | Adds three new test cases covering structlog bindings in the returned context, non-pollution of caller context, and anonymous-user omission; setup_method extended to clear structlog contextvars. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant make_run_trace_context
    participant ctx as isolated ctx (copy_context)
    participant set_trace_context
    participant structlog.bind_contextvars
    participant asyncio.create_task

    Caller->>make_run_trace_context: run_id, thread_id, graph_id, user_identity
    make_run_trace_context->>ctx: copy_context()
    make_run_trace_context->>ctx: ctx.run(set_trace_context, ...)
    ctx->>set_trace_context: sets OTEL _trace_attrs ContextVar in ctx
    make_run_trace_context->>ctx: ctx.run(bind_contextvars, run_id, thread_id, graph_id[, user_id])
    ctx->>structlog.bind_contextvars: sets structlog ContextVar in ctx
    make_run_trace_context-->>Caller: returns ctx (Caller context unchanged)
    Caller->>asyncio.create_task: "create_task(..., context=ctx)"
    Note over asyncio.create_task: Background task runs with both OTEL trace attrs and structlog vars pre-bound to run identifiers
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant make_run_trace_context
    participant ctx as isolated ctx (copy_context)
    participant set_trace_context
    participant structlog.bind_contextvars
    participant asyncio.create_task

    Caller->>make_run_trace_context: run_id, thread_id, graph_id, user_identity
    make_run_trace_context->>ctx: copy_context()
    make_run_trace_context->>ctx: ctx.run(set_trace_context, ...)
    ctx->>set_trace_context: sets OTEL _trace_attrs ContextVar in ctx
    make_run_trace_context->>ctx: ctx.run(bind_contextvars, run_id, thread_id, graph_id[, user_id])
    ctx->>structlog.bind_contextvars: sets structlog ContextVar in ctx
    make_run_trace_context-->>Caller: returns ctx (Caller context unchanged)
    Caller->>asyncio.create_task: "create_task(..., context=ctx)"
    Note over asyncio.create_task: Background task runs with both OTEL trace attrs and structlog vars pre-bound to run identifiers
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(observability): only bind structlog ..."](https://github.com/aegra/aegra/commit/56283cbcde7c4b8d210cbc331d9aef110b17262f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42064552)</sub>

<!-- /greptile_comment -->