### PR TITLE
feat: automate auth E2E tests in GitHub Actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -300,7 +300,7 @@ jobs:
         env:
           SERVER_URL: http://localhost:2026
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: uv run pytest tests/e2e/manual_auth_tests -v --tb=short -m auth_only
+        run: uv run pytest tests/e2e/manual_auth_tests -v --tb=short -m auth_only -o addopts="--strict-markers -ra --color=yes"
 
       - name: Show server logs on failure
         if: failure()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -217,3 +217,102 @@ jobs:
           if [ -f server.pid ]; then
             kill $(cat server.pid) || true
           fi
+
+  e2e-auth:
+    name: E2E (Auth Enabled)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: aegra
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install aegra-api dependencies
+        working-directory: libs/aegra-api
+        run: uv sync
+
+      - name: Run database migrations
+        working-directory: libs/aegra-api
+        env:
+          POSTGRES_USER: "user"
+          POSTGRES_PASSWORD: "password"
+          POSTGRES_HOST: "localhost"
+          POSTGRES_PORT: "5432"
+          POSTGRES_DB: "aegra"
+        run: uv run alembic upgrade head
+
+      - name: Start Aegra server (auth enabled)
+        env:
+          AEGRA_CONFIG: ${{ github.workspace }}/aegra.auth.json
+          POSTGRES_USER: "user"
+          POSTGRES_PASSWORD: "password"
+          POSTGRES_HOST: "localhost"
+          POSTGRES_PORT: "5432"
+          POSTGRES_DB: "aegra"
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          AUTH_TYPE: custom
+          HOST: "0.0.0.0"
+          PORT: "2026"
+          REDIS_BROKER_ENABLED: "false"
+          PYTHONPATH: ${{ github.workspace }}/examples
+        working-directory: libs/aegra-api
+        run: |
+          uv run uvicorn aegra_api.main:app --host 0.0.0.0 --port 2026 > server.log 2>&1 &
+          echo $! > server.pid
+          echo "Waiting for server to be ready..."
+          for i in {1..30}; do
+            if curl -s http://localhost:2026/health > /dev/null 2>&1; then
+              echo "Server is ready!"
+              exit 0
+            fi
+            echo "Attempt $i/30: Server not ready yet..."
+            sleep 2
+          done
+          echo "Server failed to start. Logs:"
+          cat server.log
+          exit 1
+
+      - name: Run auth E2E tests
+        working-directory: libs/aegra-api
+        env:
+          SERVER_URL: http://localhost:2026
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: uv run pytest tests/e2e/manual_auth_tests -v --tb=short -m auth_only
+
+      - name: Show server logs on failure
+        if: failure()
+        working-directory: libs/aegra-api
+        run: |
+          echo "=== Server Logs ==="
+          cat server.log || echo "No server logs found"
+
+      - name: Stop server
+        if: always()
+        working-directory: libs/aegra-api
+        run: |
+          if [ -f server.pid ]; then
+            kill $(cat server.pid) || true
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,9 +206,10 @@ Aegra has two execution modes (dev = LocalExecutor, prod = WorkerExecutor). E2E 
 make e2e-dev     # Dev mode (no Redis, in-process tasks)
 make e2e-prod    # Prod mode (Redis workers, lease recovery)
 make e2e-both    # Run both sequentially
+make e2e-auth    # Auth-enabled server (JWT mock); runs auth_only tests
 ```
 
-Tests marked `@pytest.mark.prod_only` are skipped in dev mode (they require Redis workers). Multi-instance and stress tests in `tests/e2e/multi_instance/` are manual-only — run them explicitly when testing worker architecture or scaling changes.
+Tests marked `@pytest.mark.prod_only` are skipped in dev mode (they require Redis workers). Tests marked `@pytest.mark.auth_only` live under `tests/e2e/manual_auth_tests/` and run only in the auth job / `make e2e-auth`. Multi-instance and stress tests in `tests/e2e/multi_instance/` are manual-only — run them explicitly when testing worker architecture or scaling changes.
 
 ### LLM Agent Anti-Patterns (IMPORTANT)
 These rules exist because AI agents repeatedly make these mistakes. Follow them carefully:

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ e2e-auth:
 		exit 1; \
 	fi
 	@rc=0; \
-	uv run --package aegra-api pytest libs/aegra-api/tests/e2e/manual_auth_tests/ -v --tb=short -m auth_only || rc=$$?; \
+	uv run --package aegra-api pytest libs/aegra-api/tests/e2e/manual_auth_tests/ -v --tb=short -m auth_only -o addopts="--strict-markers -ra --color=yes" || rc=$$?; \
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.auth.yml down; \
 	exit $$rc
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev-install setup-hooks format lint type-check security test test-api test-cli test-cov clean run ci-check openapi e2e-dev e2e-prod e2e-both
+.PHONY: help install dev-install setup-hooks format lint type-check security test test-api test-cli test-cov clean run ci-check openapi e2e-dev e2e-prod e2e-auth e2e-both
 
 help:
 	@echo "Available commands:"
@@ -17,6 +17,7 @@ help:
 	@echo "  make ci-check      - Run all CI checks locally"
 	@echo "  make e2e-dev       - Run E2E tests in dev mode (no Redis)"
 	@echo "  make e2e-prod      - Run E2E tests in prod mode (Redis workers)"
+	@echo "  make e2e-auth      - Run auth E2E tests (JWT mock auth enabled)"
 	@echo "  make e2e-both      - Run E2E tests in both modes"
 	@echo "  make clean         - Clean cache files"
 	@echo "  make run           - Run the server"
@@ -102,6 +103,26 @@ e2e-prod:
 	@rc=0; \
 	uv run --package aegra-api pytest libs/aegra-api/tests/e2e/ $(E2E_IGNORE) -v --tb=short || rc=$$?; \
 	docker compose down; \
+	exit $$rc
+
+e2e-auth:
+	@echo "Starting auth mode (JWT mock auth, LocalExecutor)..."
+	@docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.auth.yml up -d postgres aegra
+	@echo "Waiting for server..."; \
+	ready=0; \
+	for i in $$(seq 1 45); do \
+		if curl -s http://localhost:2026/health > /dev/null 2>&1; then ready=1; break; fi; \
+		sleep 2; \
+	done; \
+	if [ "$$ready" = "0" ]; then \
+		echo "Server failed to start within 90s"; \
+		docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.auth.yml logs --tail=80; \
+		docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.auth.yml down; \
+		exit 1; \
+	fi
+	@rc=0; \
+	uv run --package aegra-api pytest libs/aegra-api/tests/e2e/manual_auth_tests/ -v --tb=short -m auth_only || rc=$$?; \
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.auth.yml down; \
 	exit $$rc
 
 e2e-both: e2e-dev e2e-prod

--- a/aegra.auth.json
+++ b/aegra.auth.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": ["./examples"],
+  "graphs": {
+    "agent": "./examples/react_agent/graph.py:graph"
+  },
+  "auth": {
+    "path": "./examples/jwt_mock_auth_example.py:auth"
+  },
+  "http": {
+    "app": "./examples/custom_routes_example.py:app",
+    "enable_custom_route_auth": false
+  }
+}

--- a/docker-compose.auth.yml
+++ b/docker-compose.auth.yml
@@ -1,0 +1,28 @@
+# Auth E2E override — JWT mock auth + custom routes, no Redis host ports.
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.auth.yml up -d postgres aegra
+#
+# Postgres is published on 5433 to avoid clashing with a local Postgres on 5432.
+# Redis is profile-gated so it is not started for auth E2E.
+
+services:
+  postgres:
+    ports: !override
+      - "5433:5432"
+
+  redis:
+    profiles:
+      - redis
+
+  aegra:
+    environment:
+      - AUTH_TYPE=custom
+      - AEGRA_CONFIG=/app/aegra.auth.json
+      - REDIS_BROKER_ENABLED=false
+      - POSTGRES_HOST=postgres
+      - PYTHONPATH=/app/src:/app/examples
+    volumes:
+      - ./aegra.auth.json:/app/aegra.auth.json:ro
+    depends_on: !override
+      postgres:
+        condition: service_healthy

--- a/docs/guides/contributing.mdx
+++ b/docs/guides/contributing.mdx
@@ -50,6 +50,9 @@ make type-check    # Run type checking
 make test          # Run tests
 make test-cov      # Tests with coverage
 make ci-check      # Run all CI checks locally
+make e2e-dev       # E2E in LocalExecutor mode
+make e2e-prod      # E2E with Redis workers
+make e2e-auth      # Auth E2E (JWT mock auth)
 make clean         # Clean cache files
 ```
 
@@ -196,6 +199,7 @@ Every feature needs tests at all applicable levels:
 | Unit | `tests/unit/` | Isolated functions with mocked dependencies |
 | Integration | `tests/integration/` | HTTP requests via FastAPI TestClient with mocked DB |
 | E2E | `tests/e2e/` | Real server + real database via LangGraph SDK |
+| Auth E2E | `tests/e2e/manual_auth_tests/` | Auth-enabled server (`make e2e-auth`, marker `auth_only`) |
 
 ## LangGraph service architecture
 

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.24"
+version = "0.9.25"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -111,6 +111,7 @@ markers = [
     "unit: unit tests",
     "e2e: end-to-end tests requiring a running server",
     "prod_only: tests that require Redis workers (skipped in dev mode)",
+    "auth_only: tests that require an auth-enabled server (run with -m auth_only)",
 ]
 
 [dependency-groups]

--- a/libs/aegra-api/tests/e2e/conftest.py
+++ b/libs/aegra-api/tests/e2e/conftest.py
@@ -2,6 +2,6 @@
 
 E2E tests use the full system with real database and services.
 
-Note: Auth tests have been moved to tests/e2e/manual_auth_tests/ and are
-skipped by default via pytest.ini. They can be run explicitly with: pytest -m manual_auth
+Note: Auth tests live in tests/e2e/manual_auth_tests/ and are skipped by default
+via pytest.ini (-m "not auth_only"). Run with: make e2e-auth  or  pytest -m auth_only
 """

--- a/libs/aegra-api/tests/e2e/manual_auth_tests/README.md
+++ b/libs/aegra-api/tests/e2e/manual_auth_tests/README.md
@@ -1,64 +1,69 @@
-# Manual Auth Tests
+# Auth E2E Tests
 
-**⚠️ These tests are skipped by default and should only be run when making changes to authentication/authorization code.**
+These tests verify authentication and authorization against a real server with JWT mock auth enabled. They are skipped by default (`-m "not auth_only"`) and run automatically in CI via the **E2E (Auth Enabled)** job.
 
 ## Purpose
 
-These tests verify the authentication and authorization functionality of Aegra. Since Aegra is designed to be a package where users implement their own auth, these tests are not part of the regular test suite.
+Aegra is designed so users bring their own auth. These tests exercise the auth middleware, `@auth.authenticate` / `@auth.on.*` handlers, custom routes, and per-user thread isolation using [`examples/jwt_mock_auth_example.py`](../../../../../examples/jwt_mock_auth_example.py).
 
-## When to Run These Tests
+## When to run locally
 
-Run these tests when:
-- Making changes to `src/agent_server/core/auth_middleware.py`
-- Making changes to `src/agent_server/core/auth_handlers.py`
-- Making changes to `src/agent_server/core/auth_deps.py`
-- Making changes to authorization handler resolution logic
-- Adding new authentication features
-- Fixing authentication-related bugs
+Run these when changing:
 
-## How to Run
+- `libs/aegra-api/src/aegra_api/core/auth_middleware.py`
+- `libs/aegra-api/src/aegra_api/core/auth_handlers.py`
+- `libs/aegra-api/src/aegra_api/core/auth_deps.py`
+- Authorization handler resolution
+- Auth-related features or bug fixes
 
-1. **Create an auth config file** (e.g., `my_auth_config.json`):
-   ```json
-   {
-     "graphs": {
-       "agent": "./graphs/react_agent/graph.py:graph"
-     },
-     "auth": {
-       "path": "./jwt_mock_auth_example.py:auth"
-     },
-     "http": {
-       "app": "./custom_routes_example.py:app",
-       "enable_custom_route_auth": false
-     }
-   }
-   ```
+## How to run
 
-2. **Start the server with auth enabled:**
+### Recommended: Makefile
+
+```bash
+make e2e-auth
+```
+
+This starts Docker (dev executor + [`aegra.auth.json`](../../../../../aegra.auth.json)), waits for health, runs the auth suite, then tears down.
+
+### Manual
+
+1. Start the server with auth config (from repo root):
+
    ```bash
-   AEGRA_CONFIG=my_auth_config.json python run_server.py
-   # OR for Docker:
-   AEGRA_CONFIG=my_auth_config.json docker compose up
+   # Full Docker (dev executor + auth config):
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.auth.yml up -d
+
+   # Or API process only (Postgres already running):
+   AEGRA_CONFIG=aegra.auth.json AUTH_TYPE=custom REDIS_BROKER_ENABLED=false \
+     uv run --package aegra-api uvicorn aegra_api.main:app --host 127.0.0.1 --port 2026
    ```
 
-3. **Run the manual auth tests:**
+2. Run the tests:
+
    ```bash
-   # Run all manual auth tests
-   pytest tests/e2e/manual_auth_tests/ -v -m manual_auth
+   uv run --package aegra-api pytest libs/aegra-api/tests/e2e/manual_auth_tests/ -v -m auth_only
 
-   # Run specific test file
-   pytest tests/e2e/manual_auth_tests/test_auth_e2e.py -v -m manual_auth
-   pytest tests/e2e/manual_auth_tests/test_authorization_handlers_e2e.py -v -m manual_auth
+   # Specific file
+   uv run --package aegra-api pytest libs/aegra-api/tests/e2e/manual_auth_tests/test_auth_e2e.py -v -m auth_only
    ```
 
-## Test Files
+## Config
 
-- `test_auth_e2e.py` - Core authentication flow tests (JWT, custom routes, error handling)
-- `test_authorization_handlers_e2e.py` - Authorization handler tests (@auth.on.* decorators)
+Root [`aegra.auth.json`](../../../../../aegra.auth.json) registers:
+
+- Graph: `examples/react_agent`
+- Auth: `examples/jwt_mock_auth_example.py:auth`
+- Custom HTTP app: `examples/custom_routes_example.py:app`
+
+## Test files
+
+- `test_auth_e2e.py` — Core auth flow (JWT, custom routes, error handling)
+- `test_authorization_handlers_e2e.py` — `@auth.on.*` authorization handlers
+- `test_thread_user_isolation_e2e.py` — Per-user thread isolation
 
 ## Notes
 
-- These tests require a server running with auth enabled (create your own config file)
-- Tests will automatically skip if the server doesn't have auth enabled
-- These tests use the mock JWT auth from `jwt_mock_auth_example.py`
-- Since auth is user-specific, these tests are manual and not part of CI
+- Tests skip automatically if the server is up but auth is not enabled (`check_server_has_auth`)
+- Token format for the mock handler: `mock-jwt-<user_id>-<role>-<team_id>`
+- Marker: `@pytest.mark.auth_only` (same pattern as `prod_only`)

--- a/libs/aegra-api/tests/e2e/manual_auth_tests/conftest.py
+++ b/libs/aegra-api/tests/e2e/manual_auth_tests/conftest.py
@@ -1,19 +1,10 @@
-"""Pytest configuration for manual auth E2E tests.
+"""Pytest configuration for auth E2E tests.
 
-⚠️ These tests are skipped by default (via pytest.ini -m "not manual_auth").
-Run them explicitly when making auth changes: pytest -m manual_auth
+Skipped by default (pytest.ini -m "not auth_only").
+Run with: make e2e-auth  or  pytest -m auth_only
 
-This conftest.py skips auth flow tests if the server doesn't have auth enabled.
-
-The server loads config at startup, so it must be started with a config file
-that includes auth configuration:
-    AEGRA_CONFIG=my_auth_config.json python run_server.py
-    OR: AEGRA_CONFIG=my_auth_config.json docker compose up
-
-Create your own config file with auth.path pointing to your auth implementation.
-See tests/e2e/manual_auth_tests/README.md for details.
-
-If auth is not enabled, tests are skipped with a helpful message.
+This conftest skips the suite if the server does not have auth enabled.
+Start the server with aegra.auth.json (see README.md) or docker-compose.auth.yml.
 """
 
 import pytest
@@ -23,30 +14,20 @@ from tests.e2e._utils import check_server_has_auth
 
 
 @pytest.fixture(scope="session", autouse=True)
-def skip_if_no_auth():
-    """Skip auth flow tests if server doesn't have auth enabled.
-
-    This fixture automatically skips all tests in test_auth_flow if:
-    - Server is not running
-    - Server doesn't have auth enabled
-
-    This allows regular E2E tests to run without auth, while auth tests
-    are skipped unless the server is configured with auth.
-    """
+def skip_if_no_auth() -> None:
+    """Skip auth E2E tests if the server is missing or auth is disabled."""
     server_url = settings.app.SERVER_URL
 
-    # Check if server has auth enabled
     has_auth = check_server_has_auth(server_url)
 
     if has_auth is False:
         pytest.skip(
             "Server is running but does not have auth enabled. "
-            "Create a config file with auth.path and start server with: "
-            "AEGRA_CONFIG=my_auth_config.json python run_server.py"
+            "Start with: make e2e-auth  or  "
+            "AEGRA_CONFIG=aegra.auth.json AUTH_TYPE=custom (see README.md)"
         )
     elif has_auth is None:
         pytest.skip(
             f"Could not connect to server at {server_url} or determine auth status. "
-            "Make sure server is running and started with a config file that includes auth."
+            "Start an auth-enabled server with make e2e-auth or docker-compose.auth.yml."
         )
-    # If has_auth is True, continue with tests

--- a/libs/aegra-api/tests/e2e/manual_auth_tests/test_auth_e2e.py
+++ b/libs/aegra-api/tests/e2e/manual_auth_tests/test_auth_e2e.py
@@ -1,20 +1,9 @@
 """E2E tests for authentication flow with running server.
 
-⚠️ MANUAL TESTS - These are skipped by default. Run with: pytest -m manual_auth
+These tests require a server started with auth enabled (see aegra.auth.json).
+Skipped by default; run with: make e2e-auth  or  pytest -m auth_only
 
-These tests require a server started with auth enabled (create your own config file).
-
-See tests/e2e/manual_auth_tests/README.md for details on when and how to run these tests.
-
-To run these tests:
-1. Create a config file with auth.path pointing to jwt_mock_auth_example.py:auth
-2. Start the server with your auth config:
-   AEGRA_CONFIG=my_auth_config.json python run_server.py
-   # OR for Docker:
-   AEGRA_CONFIG=my_auth_config.json docker compose up
-
-3. Run tests explicitly:
-   pytest tests/e2e/manual_auth_tests/test_auth_e2e.py -v -m manual_auth
+See tests/e2e/manual_auth_tests/README.md for details.
 """
 
 import httpx
@@ -42,7 +31,7 @@ def get_auth_headers(token: str | None = None) -> dict[str, str]:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestCoreRoutesAuth:
     """Test that core routes require authentication"""
 
@@ -99,7 +88,7 @@ class TestCoreRoutesAuth:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestCustomRoutesAuth:
     """Test authentication with custom routes"""
 
@@ -176,7 +165,7 @@ class TestCustomRoutesAuth:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestCustomRouteAuthConfig:
     """Test enable_custom_route_auth configuration"""
 
@@ -208,7 +197,7 @@ class TestCustomRouteAuthConfig:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestUserCustomFields:
     """Test that custom fields from auth flow through to routes"""
 
@@ -263,7 +252,7 @@ class TestUserCustomFields:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestNoopAuth:
     """Test noop authentication behavior"""
 
@@ -284,7 +273,7 @@ class TestNoopAuth:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestAuthErrorHandling:
     """Test authentication error handling"""
 

--- a/libs/aegra-api/tests/e2e/manual_auth_tests/test_authorization_handlers_e2e.py
+++ b/libs/aegra-api/tests/e2e/manual_auth_tests/test_authorization_handlers_e2e.py
@@ -1,11 +1,9 @@
 """E2E tests for authorization handlers (@auth.on.*)
 
-⚠️ MANUAL TESTS - These are skipped by default. Run with: pytest -m manual_auth
+Require an auth-enabled server (aegra.auth.json). Skipped by default.
+Run with: make e2e-auth  or  pytest -m auth_only
 
-These tests require a running Aegra server started with auth enabled (create your own
-config file) which includes authorization handlers.
-
-See tests/e2e/manual_auth_tests/README.md for details on when and how to run these tests.
+See tests/e2e/manual_auth_tests/README.md for details.
 
 **Hybrid Testing Approach:**
 - **SDK Client**: Used for standard API endpoints (threads, assistants)
@@ -15,15 +13,6 @@ See tests/e2e/manual_auth_tests/README.md for details on when and how to run the
 - **httpx**: Used for custom routes (/custom/*) and GET /threads (list endpoint)
   - SDK doesn't support custom routes
   - GET /threads uses different endpoint than SDK's search()
-
-To run these tests:
-1. Create a config file with auth.path pointing to jwt_mock_auth_example.py:auth
-2. Start the server with your auth config:
-   AEGRA_CONFIG=my_auth_config.json python run_server.py
-   # OR: AEGRA_CONFIG=my_auth_config.json docker compose up
-
-3. Run tests explicitly:
-   pytest tests/e2e/manual_auth_tests/test_authorization_handlers_e2e.py -v -m manual_auth
 """
 
 import httpx
@@ -66,7 +55,7 @@ def get_client_with_auth(user_id: str = "alice", role: str = "user", team_id: st
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestThreadAuthorization:
     """Test authorization handlers for thread operations"""
 
@@ -103,7 +92,7 @@ class TestThreadAuthorization:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestAssistantAuthorization:
     """Test authorization handlers for assistant operations"""
 
@@ -185,7 +174,7 @@ class TestAssistantAuthorization:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestAuthorizationHandlerPrecedence:
     """Test that handler precedence works correctly"""
 
@@ -198,7 +187,7 @@ class TestAuthorizationHandlerPrecedence:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestAuthorizationMetadataInjection:
     """Test that authorization handlers can inject metadata"""
 

--- a/libs/aegra-api/tests/e2e/manual_auth_tests/test_thread_user_isolation_e2e.py
+++ b/libs/aegra-api/tests/e2e/manual_auth_tests/test_thread_user_isolation_e2e.py
@@ -4,12 +4,8 @@ Claim under test:
   When authentication is enabled, threads are automatically scoped to the
   authenticated user. Users can only see and interact with their own threads.
 
-⚠️ MANUAL TESTS - These are skipped by default. Run with: pytest -m manual_auth
-
-Requires a running Aegra server with auth enabled. See README.md for setup.
-
-Run:
-    pytest tests/e2e/manual_auth_tests/test_thread_user_isolation_e2e.py -v -m manual_auth
+Require an auth-enabled server. See README.md for setup.
+Run with: make e2e-auth  or  pytest -m auth_only
 """
 
 import uuid
@@ -38,7 +34,7 @@ def get_client_with_auth(user_id: str, role: str = "user", team_id: str = "team1
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestThreadOwnership:
     """Threads are created and stored under the authenticated user's identity."""
 
@@ -72,7 +68,7 @@ class TestThreadOwnership:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestThreadSearch:
     """Thread search/list only returns threads belonging to the requesting user."""
 
@@ -126,7 +122,7 @@ class TestThreadSearch:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestThreadMutationIsolation:
     """Users cannot mutate threads that belong to another user."""
 
@@ -223,7 +219,7 @@ class TestThreadMutationIsolation:
 
 
 @pytest.mark.e2e
-@pytest.mark.manual_auth
+@pytest.mark.auth_only
 class TestUnauthenticatedAccess:
     """Requests without a valid token are rejected entirely."""
 

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.24"
+version = "0.9.25"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,7 +11,7 @@ markers =
     integration: Integration tests (require database or multiple components)
     e2e: End-to-end tests (full system with real database)
     slow: Tests that take more than 1 second
-    manual_auth: Manual auth tests (skipped by default, run when auth code changes)
+    auth_only: Auth-enabled E2E tests (skipped by default; run with -m auth_only or make e2e-auth)
 
 # Output options
 console_output_style = progress
@@ -20,7 +20,7 @@ addopts =
     --tb=short
     -ra
     --color=yes
-    -m "not manual_auth"
+    -m "not auth_only"
 
 # Asyncio configuration
 asyncio_mode = auto


### PR DESCRIPTION
## Summary

- Add a third E2E CI job (`e2e-auth`) that boots Aegra with JWT mock auth via `aegra.auth.json` and runs the auth suite
- Rename `@pytest.mark.manual_auth` → `@pytest.mark.auth_only` (aligned with `prod_only`)
- Add `make e2e-auth` + `docker-compose.auth.yml` for local runs
- Document the auth E2E mode in CLAUDE.md and contributing docs

Closes #242

## Test plan

- [x] `make e2e-auth` — 32 passed locally
- [ ] Confirm new **E2E (Auth Enabled)** job runs on this PR / `workflow_dispatch`
- [ ] Confirm existing `e2e-dev-mode` / `e2e-prod-mode` still ignore `manual_auth_tests`
- [ ] Spot-check marker: `pytest --markers | grep auth_only`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authentication-enabled E2E mode running auth-only tests via a new `make e2e-auth` command, with dedicated server configuration and a docker-compose auth override.
  * Added an `e2e-auth` CI job that provisions services, waits for server readiness, and executes the auth-focused suite.
* **Tests**
  * Introduced the `auth_only` pytest marker and retagged auth E2E tests to run under it (skipped by default).
* **Documentation**
  * Updated contributing/testing docs and the auth E2E test README with new run commands and configuration details.
* **Chores**
  * Bumped API and CLI versions to 0.9.25.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automated auth end-to-end coverage for the API. The main changes are:

- A new GitHub Actions auth E2E job.
- A local `make e2e-auth` target with Docker Compose auth overrides.
- A shared `aegra.auth.json` config for JWT mock auth.
- The auth test marker renamed to `auth_only`.
- Docs updated for running the auth suite.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.
- No blocking issues found in the changed code.
- The auth-only pytest commands now override the default marker exclusion.
- The local and CI auth targets both select the intended auth test marker.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/e2e.yml | Adds the auth-enabled E2E job and selects `auth_only` tests with the default exclusion removed. |
| Makefile | Adds `make e2e-auth` with the same auth-only pytest selection used in CI. |
| pytest.ini | Renames the skipped-by-default auth marker from `manual_auth` to `auth_only`. |
| aegra.auth.json | Adds the auth-enabled test config for the mock JWT auth example. |
| docker-compose.auth.yml | Adds Docker Compose overrides for running the auth E2E server locally. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into 242"](https://github.com/aegra/aegra/commit/fdfca2176177b5c55ebe293d2f112b3dd6b2e8ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45572373)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=1640ab19-5310-4fc5-aaf6-3760087c66e8))
- Context used - AGENTS.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=15e5c4fa-b823-4fae-b564-d5a58cb22ed4))

<!-- /greptile_comment -->