### PR TITLE
fix(serializer): serialize tool-returned Command structurally on the stream

### DIFF
--- a/libs/aegra-api/src/aegra_api/core/serializers/general.py
+++ b/libs/aegra-api/src/aegra_api/core/serializers/general.py
@@ -1,5 +1,6 @@
 """General-purpose object serialization for complex objects"""
 
+import dataclasses
 import inspect
 from typing import Any
 
@@ -36,6 +37,12 @@ class GeneralSerializer(Serializer):
         # Handle LangGraph Interrupt objects (they don't have .dict() method)
         elif obj.__class__.__name__ == "Interrupt" and hasattr(obj, "value") and hasattr(obj, "id"):
             return {"value": self._serialize_object(obj.value), "id": obj.id}
+
+        # Command (from tools like write_todos) is a dataclass with no model_dump/
+        # .dict()/_asdict; it would otherwise hit str() and reach consumers as an
+        # unparseable repr. Emit all fields to match orjson's native output on Platform.
+        elif obj.__class__.__name__ == "Command" and dataclasses.is_dataclass(obj):
+            return {field.name: self._serialize_object(getattr(obj, field.name)) for field in dataclasses.fields(obj)}
 
         # Handle NamedTuples (like PregelTask) - they have _asdict() method
         elif hasattr(obj, "_asdict") and callable(obj._asdict):

--- a/libs/aegra-api/tests/unit/test_core/test_serializers/test_general.py
+++ b/libs/aegra-api/tests/unit/test_core/test_serializers/test_general.py
@@ -3,6 +3,8 @@
 from collections import namedtuple
 
 import pytest
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
 from pydantic import BaseModel
 
 from aegra_api.core.serializers.base import SerializationError
@@ -193,6 +195,52 @@ class TestGeneralSerializer:
 
         assert isinstance(result, str)
         assert "CustomObject" in result
+
+    def test_serialize_command_structurally(self):
+        """A LangGraph Command (returned by state-updating tools like
+        write_todos) must serialize to its structural dict, NOT the str()
+        fallback. Command is a dataclass with no model_dump/.dict()/_asdict, so
+        without a dedicated branch it collapses to a repr string on the wire,
+        and stream consumers (e.g. @ag-ui/langgraph's on_tool_end handler, which
+        reads output.update.messages) can't recover the tool result — they read
+        an undefined tool_call_id off a string and emit an invalid event.
+
+        All four dataclass fields are emitted (graph/update/resume/goto), matching
+        orjson's native dataclass output on LangGraph Platform so consumers read
+        the Command byte-for-byte as they do there."""
+        command = Command(
+            update={
+                "todos": [{"content": "Look up customer", "status": "in_progress"}],
+                "messages": [
+                    ToolMessage(
+                        "Updated todo list",
+                        tool_call_id="call_abc",
+                        name="write_todos",
+                        id="msg_1",
+                    )
+                ],
+            }
+        )
+        result = self.serializer.serialize(command)
+
+        assert isinstance(result, dict), "Command must not fall back to str()"
+        assert set(result) == {"graph", "update", "resume", "goto"}, "all fields emitted (Platform parity)"
+        assert result["graph"] is None
+        assert result["resume"] is None
+        assert result["goto"] == []  # unset goto defaults to () → []
+        message = result["update"]["messages"][0]
+        assert message["type"] == "tool"
+        assert message["tool_call_id"] == "call_abc"
+        assert message["name"] == "write_todos"
+        assert result["update"]["todos"][0]["status"] == "in_progress"
+
+    def test_serialize_command_preserves_falsy_resume(self):
+        """A falsy resume value (False/0/"") is a legitimate resume payload and
+        must survive serialization. Emitting all fields preserves it; a truthy
+        filter (``if getattr(obj, name)``) would silently drop it."""
+        assert self.serializer.serialize(Command(resume=False))["resume"] is False
+        assert self.serializer.serialize(Command(resume=0))["resume"] == 0
+        assert self.serializer.serialize(Command(resume=""))["resume"] == ""
 
     def test_serialize_pydantic_model_with_nested_data(self):
         """Test serialization of Pydantic model with nested structures"""

--- a/libs/aegra-api/tests/unit/test_core/test_sse.py
+++ b/libs/aegra-api/tests/unit/test_core/test_sse.py
@@ -3,6 +3,9 @@
 import json
 from datetime import datetime
 
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
 from aegra_api.core.sse import (
     SSEEvent,
     create_debug_event,
@@ -123,6 +126,29 @@ class TestFormatSSEMessage:
         result = format_sse_message("test_event", data, serializer=custom_serializer)
 
         assert "custom_date" in result
+
+    def test_format_message_serializes_langgraph_command_structurally(self):
+        """A Command embedded in an events payload (astream_events surfaces a
+        tool-returned Command as on_tool_end.data.output) must reach the wire as a
+        structural dict, not a repr string, so consumers can read
+        output.update.messages instead of an undefined tool_call_id off a string."""
+        event = {
+            "event": "on_tool_end",
+            "data": {
+                "output": Command(
+                    update={"messages": [ToolMessage("done", tool_call_id="call_abc", name="write_todos")]}
+                )
+            },
+        }
+
+        result = format_sse_message("events", event)
+
+        data_line = next(line[len("data: ") :] for line in result.splitlines() if line.startswith("data: "))
+        output = json.loads(data_line)["data"]["output"]
+        assert isinstance(output, dict), "Command must not reach the wire as a repr string"
+        message = output["update"]["messages"][0]
+        assert message["type"] == "tool"
+        assert message["tool_call_id"] == "call_abc"
 
 
 class TestCreateMetadataEvent:


### PR DESCRIPTION
## Description

`GeneralSerializer` has no case for `langgraph.types.Command` — a dataclass with no `model_dump`/`.dict()`/`_asdict`. A `Command` returned by a **state-updating tool** (e.g. LangChain's `write_todos` / `TodoListMiddleware`) therefore hits the `str()` fallback and goes onto the wire as its Python repr:

```
"Command(update={'todos': [...], 'messages': [ToolMessage(...)]})"
```

Stream consumers can't recover structured data from that string. It surfaces **only in `events` mode**: a tool-returned `Command` is applied internally in `updates`/`values`/`messages` modes, but appears raw as `astream_events`' `on_tool_end.data.output`. `@ag-ui/langgraph`'s `on_tool_end` handler reads `output.update.messages` to emit tool-call events; against a string it reads an undefined `tool_call_id` and emits an invalid `TOOL_CALL_START`, which `@ag-ui/core` rejects and `@ag-ui/client` maps to `EMPTY` — silently aborting the run (the chat "freezes" on every `Command`-returning tool).

## Fix

Add a `Command` branch that serializes **all** of its dataclass fields; values recurse through the serializer, so a `ToolMessage` inside `update` becomes its `model_dump` (`type="tool"`, `tool_call_id`, `name`, `content`).

Emitting every field (rather than filtering `None`) is deliberate. LangGraph Platform (`langgraph-api`'s `serde.py`) serializes the stream with `orjson`, whose native dataclass support emits all fields. Verified against a real `langgraph-api` install, this serializer is now byte-identical to Platform for the `update`-bearing `Command` this fixes:

| `Command` | This PR **and** LangGraph Platform |
|---|---|
| `Command(update={…})` | `{"graph":null,"update":{…},"resume":null,"goto":[]}` |
| `Command(resume=False)` | `{"graph":null,"update":null,"resume":false,"goto":[]}` |

The one divergence is `Command(goto=[Send(...)])`, where Platform emits `[null]` and this serializer emits the `Send` repr — i.e. it loses less; structural `Send` serialization is out of scope here. (LangChain has no canonical form for `Command` either — `langchain_core.load.dumpd(Command(...))` returns `{"type":"not_implemented","repr":…}` — so orjson-native is the right parity target.)

The fix sits at the serialization chokepoint, so it covers every path a `Command` can surface on: the SSE wire (dev) and the Redis broker (prod) both route through `GeneralSerializer`.

## Type of Change
- [x] `fix`: Bug fix

## Related Issues
_None — opening directly. Happy to file a tracking issue if you'd prefer one._

## Changes Made
- `core/serializers/general.py` — add a `Command` branch that serializes all dataclass fields structurally.
- `tests/unit/test_core/test_serializers/test_general.py` — assert the full structural dict (Platform parity) and that falsy `resume` values (`False`/`0`/`""`) survive.
- `tests/unit/test_core/test_sse.py` — a `Command` inside an `events` payload must reach the wire structurally through `format_sse_message`, not as a repr string.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated — the SSE wire path is covered by a unit-level test in `test_core/test_sse.py`
- [ ] E2E tests added/updated — would require adding a new example graph; the wire path is covered above
- [x] Manual testing performed — reproduced the `on_tool_end` `Command` against real LangGraph and confirmed structural output through both the SSE and Redis-broker serialization paths

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking — change introduces no new `ty` diagnostics
- [x] All tests pass (unit + integration — the suite CI runs)
- [ ] Documentation updated — n/a (internal serialization behavior; no user-facing docs describe it)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes serialization of LangGraph `Command` objects in streamed payloads.
- Adds recursive structural serialization of all `Command` dataclass fields.
- Adds serializer coverage for nested tool messages and falsy resume values.
- Adds SSE regression coverage confirming structured command output reaches clients.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/serializers/general.py | Adds a dedicated recursive serialization branch for LangGraph `Command` dataclasses. |
| libs/aegra-api/tests/unit/test_core/test_serializers/test_general.py | Verifies complete structural output, nested `ToolMessage` serialization, and preservation of falsy resume payloads. |
| libs/aegra-api/tests/unit/test_core/test_sse.py | Verifies that an event containing a `Command` reaches the SSE wire as structured JSON. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/serialize-c..."](https://github.com/aegra/aegra/commit/1fb02d42297bc64105c0572333f549638f5fbf3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46630357)</sub>

**Context used:**

- Knowledge Base — [Authenticated Services and Serializers](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/authenticated-services-and-serializers.md)
- Knowledge Base — [Streaming: from LangGraph execution to SSE wire events](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/streaming.md)

<!-- /greptile_comment -->