### PR TITLE
fix(ci): pin ruff and exclude markdown from the formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, develop]
 
+env:
+  # Keep in sync with the ruff floor in libs/*/pyproject.toml dev dependencies.
+  RUFF_VERSION: "0.16.0"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -20,11 +24,13 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      # Pinned: an unpinned uvx pulls the newest ruff, so a release can turn
+      # every open PR red without a single line of repo code changing.
       - name: Check formatting with ruff
-        run: uvx ruff format --check .
+        run: uvx ruff@${{ env.RUFF_VERSION }} format --check .
 
       - name: Lint with ruff
-        run: uvx ruff check .
+        run: uvx ruff@${{ env.RUFF_VERSION }} check .
 
   test-api:
     runs-on: ubuntu-latest

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -79,6 +79,11 @@ packages = ["src/aegra_api"]
 line-length = 120
 target-version = "py312"
 
+[tool.ruff.format]
+# This package's [tool.ruff] overrides the root config for files beneath it, so
+# the markdown exclusion has to be repeated here. See the root pyproject.toml.
+exclude = ["**/*.md"]
+
 [tool.ruff.lint]
 select = [
     "E",     # pycodestyle errors
@@ -119,7 +124,7 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-mock>=3.15.1",
     "pytest-cov>=6.0.0",
-    "ruff>=0.13.0",
+    "ruff>=0.16.0",
     "ty>=0.0.17,<0.1.0",
     "bandit>=1.8.0",
     "pre-commit>=4.0.1",

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -47,6 +47,11 @@ packages = ["src/aegra_cli"]
 line-length = 100
 target-version = "py312"
 
+[tool.ruff.format]
+# This package's [tool.ruff] overrides the root config for files beneath it, so
+# the markdown exclusion has to be repeated here. See the root pyproject.toml.
+exclude = ["**/*.md"]
+
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
 ignore = ["F841"]  # Unused variables (common in tests where we invoke but check side effects)
@@ -59,5 +64,5 @@ dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=6.0.0",
-    "ruff>=0.13.0",
+    "ruff>=0.16.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,12 @@ dev = [
 line-length = 120
 target-version = "py312"
 
+[tool.ruff.format]
+# Docs contain deliberately-wrong examples (see the "# WRONG" blocks in
+# CLAUDE.md). Formatting markdown rewrites them into correct style and destroys
+# the point. Ruff only began picking up .md in 0.15; this keeps prior behavior.
+exclude = ["**/*.md"]
+
 [tool.ruff.lint]
 select = [
     "E",     # pycodestyle errors


### PR DESCRIPTION
## Problem

The lint job is failing on `main` and on every open PR, and no contributor caused it.

CI runs `uvx ruff format --check .` with no version pin, so each job pulls whatever ruff is newest. A recent ruff release started formatting fenced code blocks inside markdown files. That flipped the lint job red without a single line of repo code changing.

Evidence it is a tooling regression, not a code problem:

- last green CI run on `main` was 2026-07-10 (`d142457`), and nothing in the tree has changed since
- `ruff 0.14.0` on current `main`: `344 files already formatted`, passes
- `ruff 0.16.0` on the same tree: 3 markdown files fail
- ruff 0.14 scanned 344 files, 0.16 scans 366, it started picking up `.md`

Affected files were `CLAUDE.md`, `libs/aegra-api/README.md`, and `libs/aegra-api/tests/README.md`. All seven open fork PRs inherited the red check, and at least one contributor was told to "run ruff format" for a failure that was never theirs.

## Fix

**Pin the version.** `RUFF_VERSION` env var in `ci.yml`, with the dev dependency floor raised to match so local and CI agree. An upstream release can no longer redden every open PR overnight.

**Exclude markdown from the formatter.** Auto-formatting docs is actively wrong here. `CLAUDE.md` contains deliberately-bad examples under `# WRONG` headings, and the formatter rewrites them into correct style, destroying the thing they exist to demonstrate. For instance it collapses the mutable-default example into a single tidy line.

The exclusion is repeated in both package `pyproject.toml` files because each declares its own `[tool.ruff]`, which overrides the root config for files beneath it. Root-only did not cover the two nested READMEs.

## Verification

```
uvx ruff@0.16.0 format --check .   ->  344 files already formatted
uvx ruff@0.16.0 check .            ->  All checks passed!
```

344 matches the pre-regression 0.14 count exactly.

Python formatting is still enforced. Confirmed by dropping a deliberately misformatted file under the nested `aegra-api` config, which correctly reported `1 file would be reformatted`, then passing again once removed.

## Follow-up

Unblocks the lint check on #385, #457, #466, #453, #455, #432, #448, #349, #465, #462, #467, #443, #458.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized code-quality checks on a consistent Ruff version.
  * Improved formatting rules to preserve Markdown examples and documentation formatting.
  * Updated development tooling requirements across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes Ruff behavior across CI and package configuration.
- Pins CI formatting and linting to Ruff 0.16.0.
- Excludes Markdown files from Ruff formatting in the root and nested package configurations.
- Raises both package development dependency floors to Ruff 0.16.0.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking Ruff version mismatch remaining in the pre-commit configuration.

The CI pin and formatter exclusions are internally consistent, but contributors using the checked-in pre-commit hook still run Ruff v0.13.3 instead of the newly selected v0.16.0.

**Files Needing Attention:** .github/workflows/ci.yml and .pre-commit-config.yaml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Pins both Ruff CI commands to 0.16.0, although the repository's pre-commit Ruff version remains older. |
| pyproject.toml | Excludes Markdown from root-level Ruff formatting while leaving lint configuration unchanged. |
| libs/aegra-api/pyproject.toml | Repeats the Markdown formatter exclusion for the nested configuration and raises the Ruff development floor. |
| libs/aegra-cli/pyproject.toml | Repeats the Markdown formatter exclusion for the nested configuration and raises the Ruff development floor. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fci.yml%3A10-11%0A**Pre-commit%20Ruff%20pin%20remains%20stale**%0A%0ACI%20and%20the%20package%20manifests%20now%20select%20Ruff%200.16.0%2C%20while%20the%20checked-in%20pre-commit%20hook%20still%20installs%20v0.13.3.%20Contributors%20using%20the%20repository's%20local%20hook%20therefore%20run%20different%20formatting%20and%20lint%20behavior%20from%20CI%2C%20undermining%20the%20version%20synchronization%20introduced%20here.%0A%0A&repo=aegra%2Faegra&pr=469&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fci.yml%3A10-11%0A**Pre-commit%20Ruff%20pin%20remains%20stale**%0A%0ACI%20and%20the%20package%20manifests%20now%20select%20Ruff%200.16.0%2C%20while%20the%20checked-in%20pre-commit%20hook%20still%20installs%20v0.13.3.%20Contributors%20using%20the%20repository's%20local%20hook%20therefore%20run%20different%20formatting%20and%20lint%20behavior%20from%20CI%2C%20undermining%20the%20version%20synchronization%20introduced%20here.%0A%0A&pr=469&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fpin-ruff-and-exclude-markdown%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpin-ruff-and-exclude-markdown%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fci.yml%3A10-11%0A**Pre-commit%20Ruff%20pin%20remains%20stale**%0A%0ACI%20and%20the%20package%20manifests%20now%20select%20Ruff%200.16.0%2C%20while%20the%20checked-in%20pre-commit%20hook%20still%20installs%20v0.13.3.%20Contributors%20using%20the%20repository's%20local%20hook%20therefore%20run%20different%20formatting%20and%20lint%20behavior%20from%20CI%2C%20undermining%20the%20version%20synchronization%20introduced%20here.%0A%0A&repo=aegra%2Faegra&pr=469&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): pin ruff and exclude markdown f..."](https://github.com/aegra/aegra/commit/336b77eda3d82ea111cc44d981da1a7bb61ed990) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47359468)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->