### PR TITLE
fix(test): assert the typed 403 in the org-scope store e2e

### DIFF
--- a/libs/aegra-api/tests/e2e/test_store/test_store.py
+++ b/libs/aegra-api/tests/e2e/test_store/test_store.py
@@ -1,4 +1,5 @@
 import pytest
+from langgraph_sdk.errors import PermissionDeniedError
 
 from tests.e2e._utils import elog, get_e2e_client
 
@@ -51,10 +52,11 @@ async def test_org_prefix_without_org_membership_is_forbidden():
     """
     client = get_e2e_client()
 
-    with pytest.raises(Exception) as exc_info:  # noqa: B017 - SDK doesn't expose specific exception type
+    with pytest.raises(PermissionDeniedError) as exc_info:
         await client.store.put_item(["orgs", "shared-prompts"], key="greeting", value={"text": "hi"})
     elog("store.put_item orgs prefix rejected", str(exc_info.value))
-    assert "403" in str(exc_info.value) or "organization" in str(exc_info.value).lower()
+    # Names the attribute the scope needs, so the message stays actionable.
+    assert "org_id" in str(exc_info.value)
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## Problem

E2E has been red on `main` since #432 landed. `#448` inherited it, and both dev and prod mode fail on the same test.

```
FAILED tests/e2e/test_store/test_store.py::test_org_prefix_without_org_membership_is_forbidden
assert ('403' in "User has no 'org_id' required for 'orgs'-scoped store access"
        or 'organization' in "user has no 'org_id' required for 'orgs'-scoped store access")
```

**The server is behaving correctly.** It refuses the `orgs`-scoped write for a user with no `org_id`, which is exactly what #432 intended. Only the assertion is wrong: it matched on the substrings `"403"` or `"organization"`, and the real message contains neither. It says `org_id`, not `organization`, and the status code lives on the exception rather than in the message text.

CodeRabbit flagged this assertion as too permissive during the #432 review. I noted it as a non-blocking nit and let it through. It broke in the opposite direction, failing on a correct refusal.

## Fix

Assert on the typed exception instead of guessing at substrings:

```python
with pytest.raises(PermissionDeniedError) as exc_info:
    await client.store.put_item(["orgs", "shared-prompts"], key="greeting", value={"text": "hi"})
assert "org_id" in str(exc_info.value)
```

`langgraph_sdk.errors.PermissionDeniedError` declares `status_code: Literal[403] = 403`, so the type check proves the 403 by construction. The remaining string check keeps the message naming the attribute a caller has to supply, which is the part worth pinning.

This also drops a `# noqa: B017`, since the exception type is now specific.

## Verification

`ruff format --check` and `ruff check` both pass on the changed file. The assertion now matches the message the server actually produces, confirmed from the failing run logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission error validation to clearly identify missing organization access scope information.
  * Enhanced error handling checks for organization-prefixed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs the organization-scoped store E2E test by asserting the SDK’s typed permission exception rather than searching its message for a status code.
- Imports and expects `PermissionDeniedError` for the forbidden store write.
- Retains a focused message assertion requiring the actionable `org_id` attribute.
- Removes the no-longer-needed broad-exception lint suppression.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the revised assertion matches the pinned SDK’s typed handling of the expected 403 response.

The resolved SDK version exports `PermissionDeniedError` and maps HTTP 403 responses to that class, while the remaining assertion matches the documented server response naming `org_id`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/tests/e2e/test_store/test_store.py | Narrows the expected failure to the SDK’s typed 403 exception and aligns the message assertion with the server’s actual response. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): assert the typed 403 in the o..."](https://github.com/aegra/aegra/commit/0438263c922f0f317d3a1478d1a9c21c5d23f348) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49323615)</sub>

<!-- /greptile_comment -->