### PR TITLE
fix(api): reconcile runs and threads after worker loss

### DIFF
--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -222,6 +222,10 @@ await client.runs.cancel(
 )
 ```
 
+Cancellation is asynchronous while a live worker owns the run.
+The cancel response may therefore still show `pending` or `running`; poll, join, or stream the run until it reaches a terminal status.
+Use the REST endpoint with `wait=1` when the caller needs the request to wait briefly for the worker to settle.
+
 ## SSE reconnection
 
 Aegra stores streaming events in a replay buffer (Redis Lists when `REDIS_BROKER_ENABLED=true`, in-memory list in dev mode) for replay. If your connection drops:

--- a/docs/guides/worker-architecture.mdx
+++ b/docs/guides/worker-architecture.mdx
@@ -186,7 +186,11 @@ sequenceDiagram
 
 ## Crash recovery
 
-Every instance runs a `LeaseReaper` background task that scans for runs with expired leases. When a worker crashes (OOM, kill signal, network partition), its heartbeat stops and the lease expires. The reaper resets the run to `pending` and re-enqueues it. The new worker resumes from the last checkpoint.
+Every instance runs a `LeaseReaper` background task that scans for runs with expired leases.
+When a worker crashes (OOM, kill signal, network partition), its heartbeat stops and the lease expires.
+The reaper resets the run to `pending` and re-enqueues it.
+The new worker resumes from the last checkpoint.
+Once retries are exhausted, the reaper marks the run `error`, clears ownership, and marks the thread `error` in the same transaction when no other run is active.
 
 <a href="https://mermaid.live/view#pako:eNptk09PwkAQxb_K2FOJiCbeGjVpocIBpRZJLyZm3Y6wge7W_aMkxO_uLK2CQE9N9r3fezPtbgKuSgwiCAx-OJQcB4LNNateJNBTM20FFzWTFooYmIFC6SVqiI_Ps6E_z5Sxc43Tp_GxIkdWk5dU7VuoJCSdE8JGUwpzokayVyN5kY2iiC_u7rJhBP0VExVoJyFcITN4K9XX-fWV6ezpijiCdI3cWQSatV70er0DzAgp8g2ZhRDXFmUJW1rnN-9RkVd9UgUP6-fxdAThZPJwuRSrVeeUZkc0VtXmGORjxz4EcF0LjQZIa333X22ztbbhNB2n_WcoRmmeEpJZZ25pbCnkHOLHQdMXboDmD9tC2ZC8DSSCe-Voqiaq9As7OxEyywbx8x--pj0Qvguc4LpJODDlEeTZjJZBwFdRQqjxAiX9WW63uyJphMk4m2St33-VJGpdezJfIuYfjkqCxK_9zO25N-VoXIXwrlUFfIF8WSsh7QHk_yTGcY7GBF0IKtQVEyVdgU1gF1htL0PJ9DL4_v4BvGz9cA==" target="_blank" rel="noopener">View fullscreen ↗</a>
 
@@ -223,9 +227,12 @@ The reaper runs on every instance (default every 15 seconds). This is safe — t
 
 ## Cross-instance cancellation
 
-Cancel requests can arrive at any instance, but the run may be executing on a different one. Aegra uses Redis pub/sub to propagate cancellation across instances.
-
-<a href="https://mermaid.live/view#pako:eNplkc1qwzAQhF9l0SmG_oQeBQ1YTkgDhrp2cstFsRZXSSy7khwoxu_edUWbBOs6386MdntWNgoZB-bwq0NT4lLLysp6b4BeK63XpW6l8ZCAdJCcNRo_FeNR3BjnJVlAPAXyEchRaTfVsvUoZo3zlcXiI50S4s5ewMx2xmhTgf9EODaHaG_CUPK4WMQcsvdiC8_lSJ8JbjqPCg7fkIoocDFxOXE7kW6KN5BIf-ZkysPMFcrWHHbZMt6ugNJ951718Wht15JlwHLCBIckpNXonKwQLJaoL3-MCIyX7vQUImbRVblpgkYBXv53PFZIOLzM59CHfA43BQb2AKxGW0ut6Ig9o33Uv-dU0p7YMPwA02SZhQ==" target="_blank" rel="noopener">View fullscreen ↗</a>
+Cancel requests can arrive at any instance, but the run may be executing on a different one.
+The API first tries an ownership-safe database update that succeeds only when the run is active and has no owner or an expired lease.
+That path interrupts the run, clears its lease, and marks the thread idle in one transaction when no other run is active.
+When the run has a live owner, the API leaves the database state unchanged and uses Redis pub/sub to ask that worker to cancel its task and finalize the run.
+Requests for runs that are already terminal are no-ops, so a late cancellation cannot overwrite a successful or failed result.
+The response contains the currently persisted state; set `wait=1` to wait for a live worker to finalize the run before returning.
 
 ```mermaid
 sequenceDiagram
@@ -236,12 +243,19 @@ sequenceDiagram
     participant B as Instance B (running the job)
 
     C->>A: POST /cancel (routed by LB)
-    A->>R: PUBLISH aegra:run:cancel
-    A->>PG: UPDATE status=interrupted
-    R->>B: Cancel message received
-    B->>B: task.cancel()
-    B->>R: PUBLISH end event
-    A->>C: 200 {status: interrupted}
+    A->>PG: UPDATE interrupted WHERE unowned or lease expired
+    alt no live owner
+        PG-->>A: run updated and lease cleared
+        A->>PG: UPDATE thread=idle if no active runs
+    else live owner
+        PG-->>A: no row updated
+        A->>R: PUBLISH aegra:run:cancel
+        R->>B: Cancel message received
+        B->>B: task.cancel()
+        B->>PG: Finalize run and thread
+        B->>R: PUBLISH end event
+    end
+    A->>C: 200 with persisted run state
 ```
 
 ## Dev vs production mode

--- a/docs/guides/worker-architecture.mdx
+++ b/docs/guides/worker-architecture.mdx
@@ -230,8 +230,11 @@ The reaper runs on every instance (default every 15 seconds). This is safe — t
 Cancel requests can arrive at any instance, but the run may be executing on a different one.
 The API first tries an ownership-safe database update that succeeds only when the run is active and has no owner or an expired lease.
 That path interrupts the run, clears its lease, and marks the thread idle in one transaction when no other run is active.
+The API still broadcasts a best-effort cancellation after this transaction because an expired worker may be delayed rather than dead.
+It emits the terminal stream event itself so connected clients always receive a definitive end event.
 When the run has a live owner, the API leaves the database state unchanged and uses Redis pub/sub to ask that worker to cancel its task and finalize the run.
 Requests for runs that are already terminal are no-ops, so a late cancellation cannot overwrite a successful or failed result.
+Worker finalization is also conditional on the run remaining active, which prevents a delayed worker from overwriting a terminal state committed by the API.
 The response contains the currently persisted state; set `wait=1` to wait for a live worker to finalize the run before returning.
 
 ```mermaid
@@ -247,6 +250,8 @@ sequenceDiagram
     alt no live owner
         PG-->>A: run updated and lease cleared
         A->>PG: UPDATE thread=idle if no active runs
+        A->>R: PUBLISH cancel without end event
+        A->>R: PUBLISH end event
     else live owner
         PG-->>A: no row updated
         A->>R: PUBLISH aegra:run:cancel

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.25"
+    "version": "0.9.26"
   },
   "paths": {
     "/info": {
@@ -2295,8 +2295,11 @@
             "in": "query",
             "required": false,
             "schema": {
+              "enum": [
+                "cancel",
+                "interrupt"
+              ],
               "type": "string",
-              "pattern": "^(cancel|interrupt)$",
               "description": "Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
               "default": "cancel",
               "title": "Action"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2255,7 +2255,7 @@
           "Thread Runs"
         ],
         "summary": "Cancel Run Endpoint",
-        "description": "Cancel or interrupt a running execution.\n\nUse `action=cancel` to hard-cancel the run immediately, or\n`action=interrupt` to cooperatively interrupt (the graph can handle the\ninterrupt and save partial state). Set `wait=1` to block until the\nbackground task has settled before returning the updated run. Without\n`wait=1`, a live-owned run is cancelled asynchronously, so the response\nmay still report `pending` or `running`.",
+        "description": "Cancel or interrupt a running execution.\n\nUse `action=cancel` to hard-cancel the run immediately, or\n`action=interrupt` to cooperatively interrupt (the graph can handle the\ninterrupt and save partial state). Set `wait=1` to wait up to 10 seconds\nfor the background task to settle before returning the updated run. The\nresponse may still report `pending` or `running` if the timeout expires.\nWithout `wait=1`, a live-owned run is cancelled asynchronously, so the\nresponse may still report `pending` or `running`.",
         "operationId": "cancel_run_endpoint_threads__thread_id__runs__run_id__cancel_post",
         "parameters": [
           {
@@ -2284,11 +2284,11 @@
               "type": "integer",
               "maximum": 1,
               "minimum": 0,
-              "description": "Set to 1 to wait for the run task to settle before returning.",
+              "description": "Set to 1 to wait up to 10 seconds for the run task to settle before returning.",
               "default": 0,
               "title": "Wait"
             },
-            "description": "Set to 1 to wait for the run task to settle before returning."
+            "description": "Set to 1 to wait up to 10 seconds for the run task to settle before returning."
           },
           {
             "name": "action",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.26"
+    "version": "0.10.0"
   },
   "paths": {
     "/info": {
@@ -1876,7 +1876,7 @@
           "Thread Runs"
         ],
         "summary": "Update Run",
-        "description": "Update a run's status.\n\nPrimarily used to interrupt a running execution. Set `status` to\n`\"interrupted\"` to cooperatively stop the run.",
+        "description": "Update a run's status.\n\nPrimarily used to interrupt a running execution. Set `status` to\n`\"interrupted\"` to cooperatively stop the run. When a live worker owns\nthe run, interruption is asynchronous and the response may still report\n`pending` or `running`. Poll or stream the run until it becomes terminal.",
         "operationId": "update_run_threads__thread_id__runs__run_id__patch",
         "parameters": [
           {
@@ -2255,7 +2255,7 @@
           "Thread Runs"
         ],
         "summary": "Cancel Run Endpoint",
-        "description": "Cancel or interrupt a running execution.\n\nUse `action=cancel` to hard-cancel the run immediately, or\n`action=interrupt` to cooperatively interrupt (the graph can handle the\ninterrupt and save partial state). Set `wait=1` to block until the\nbackground task has fully settled before returning the updated run.",
+        "description": "Cancel or interrupt a running execution.\n\nUse `action=cancel` to hard-cancel the run immediately, or\n`action=interrupt` to cooperatively interrupt (the graph can handle the\ninterrupt and save partial state). Set `wait=1` to block until the\nbackground task has settled before returning the updated run. Without\n`wait=1`, a live-owned run is cancelled asynchronously, so the response\nmay still report `pending` or `running`.",
         "operationId": "cancel_run_endpoint_threads__thread_id__runs__run_id__cancel_post",
         "parameters": [
           {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.26"
+version = "0.10.0"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.25"
+version = "0.9.26"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -21,6 +21,7 @@ from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import _get_session_maker, get_session
 from aegra_api.core.sse import create_end_event, get_sse_headers, make_sse_response, sse_to_bytes
 from aegra_api.models import Run, RunCreate, RunStatus, User
+from aegra_api.models.enums import RunCancellationAction
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.run_preparation import _prepare_run
@@ -44,7 +45,7 @@ DEFAULT_STREAM_MODES = ["values"]
 async def _request_run_interruption(
     session: AsyncSession,
     run_orm: RunORM,
-    action: str,
+    action: RunCancellationAction,
 ) -> None:
     """Interrupt a run without overwriting a terminal or live-owned run."""
     if run_orm.status in TERMINAL_STATES:
@@ -54,7 +55,12 @@ async def _request_run_interruption(
     has_live_local_task = task is not None and not task.done()
     reconciled = False
     if not has_live_local_task:
-        reconciled = await interrupt_unowned_run(session, run_orm.run_id, run_orm.thread_id)
+        reconciled = await interrupt_unowned_run(
+            session,
+            run_orm.run_id,
+            run_orm.thread_id,
+            user_id=run_orm.user_id,
+        )
 
     if reconciled:
         return
@@ -455,7 +461,7 @@ async def cancel_run_endpoint(
     thread_id: str,
     run_id: str,
     wait: int = Query(0, ge=0, le=1, description="Set to 1 to wait for the run task to settle before returning."),
-    action: str = Query(
+    action: RunCancellationAction = Query(
         "cancel",
         pattern="^(cancel|interrupt)$",
         description="Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -470,7 +470,12 @@ async def stream_run(
 async def cancel_run_endpoint(
     thread_id: str,
     run_id: str,
-    wait: int = Query(0, ge=0, le=1, description="Set to 1 to wait for the run task to settle before returning."),
+    wait: int = Query(
+        0,
+        ge=0,
+        le=1,
+        description="Set to 1 to wait up to 10 seconds for the run task to settle before returning.",
+    ),
     action: RunCancellationAction = Query(
         "cancel",
         description="Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
@@ -482,10 +487,11 @@ async def cancel_run_endpoint(
 
     Use `action=cancel` to hard-cancel the run immediately, or
     `action=interrupt` to cooperatively interrupt (the graph can handle the
-    interrupt and save partial state). Set `wait=1` to block until the
-    background task has settled before returning the updated run. Without
-    `wait=1`, a live-owned run is cancelled asynchronously, so the response
-    may still report `pending` or `running`.
+    interrupt and save partial state). Set `wait=1` to wait up to 10 seconds
+    for the background task to settle before returning the updated run. The
+    response may still report `pending` or `running` if the timeout expires.
+    Without `wait=1`, a live-owned run is cancelled asynchronously, so the
+    response may still report `pending` or `running`.
     """
     logger.info(f"[cancel_run] fetch run run_id={run_id} thread_id={thread_id} user={user.identity}")
     run_orm = await session.scalar(

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -3,14 +3,13 @@
 import asyncio
 import contextlib
 from collections.abc import AsyncGenerator, MutableMapping
-from datetime import UTC, datetime
 from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from redis import RedisError
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette import EventSourceResponse
 
@@ -25,6 +24,7 @@ from aegra_api.models import Run, RunCreate, RunStatus, User
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.run_preparation import _prepare_run
+from aegra_api.services.run_status import interrupt_unowned_run
 from aegra_api.services.run_waiters import TERMINAL_STATES, encode_output, heartbeat_wait_body
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.settings import settings
@@ -39,6 +39,34 @@ logger = structlog.getLogger(__name__)
 
 # Default stream modes for background run execution
 DEFAULT_STREAM_MODES = ["values"]
+
+
+async def _request_run_interruption(
+    session: AsyncSession,
+    run_orm: RunORM,
+    action: str,
+) -> None:
+    """Interrupt a run without overwriting a terminal or live-owned run."""
+    if run_orm.status in TERMINAL_STATES:
+        return
+
+    task = active_runs.get(run_orm.run_id)
+    has_live_local_task = task is not None and not task.done()
+    reconciled = False
+    if not has_live_local_task:
+        reconciled = await interrupt_unowned_run(session, run_orm.run_id, run_orm.thread_id)
+
+    if reconciled:
+        return
+
+    await session.refresh(run_orm)
+    if run_orm.status in TERMINAL_STATES:
+        return
+
+    if action == "interrupt":
+        await streaming_service.interrupt_run(run_orm.run_id)
+    else:
+        await streaming_service.cancel_run(run_orm.run_id)
 
 
 async def _apply_create_run_auth(user: User, thread_id: str, request: RunCreate) -> None:
@@ -244,22 +272,9 @@ async def update_run(
 
     if validated_status == "interrupted":
         logger.info(f"[update_run] cancelling/interrupting run_id={run_id} user={user.identity} thread_id={thread_id}")
-        # Handle interruption - use interrupt_run for cooperative interruption
-        await streaming_service.interrupt_run(run_id)
-        logger.info(f"[update_run] set DB status=interrupted run_id={run_id}")
-        await session.execute(
-            update(RunORM)
-            .where(RunORM.run_id == str(run_id))
-            .values(status="interrupted", updated_at=datetime.now(UTC))
-        )
-        await session.commit()
-        logger.info(f"[update_run] commit done (interrupted) run_id={run_id}")
+        await _request_run_interruption(session, run_orm, "interrupt")
 
     # Return final run state
-    run_orm = await session.scalar(select(RunORM).where(RunORM.run_id == run_id))
-    if not run_orm:
-        raise HTTPException(404, f"Run '{run_id}' not found")
-    # Refresh to ensure we have the latest data after our own update
     await session.refresh(run_orm)
     return Run.model_validate(run_orm)
 
@@ -466,32 +481,12 @@ async def cancel_run_endpoint(
     if not run_orm:
         raise HTTPException(404, f"Run '{run_id}' not found")
 
-    if action == "interrupt":
-        logger.info(f"[cancel_run] interrupt run_id={run_id} user={user.identity} thread_id={thread_id}")
-        await streaming_service.interrupt_run(run_id)
-        # Persist status as interrupted
-        await session.execute(
-            update(RunORM)
-            .where(RunORM.run_id == str(run_id))
-            .values(status="interrupted", updated_at=datetime.now(UTC))
-        )
-        await session.commit()
-    else:
-        logger.info(f"[cancel_run] cancel run_id={run_id} user={user.identity} thread_id={thread_id}")
-        await streaming_service.cancel_run(run_id)
-        # Persist status as interrupted
-        await session.execute(
-            update(RunORM)
-            .where(RunORM.run_id == str(run_id))
-            .values(status="interrupted", updated_at=datetime.now(UTC))
-        )
-        await session.commit()
+    logger.info(f"[cancel_run] request {action} run_id={run_id} user={user.identity} thread_id={thread_id}")
+    await _request_run_interruption(session, run_orm, action)
 
     # Optionally wait for the run to settle
     if wait:
         # Poll DB until the run reaches a terminal state (or 10s timeout).
-        # This is simpler and more reliable than pub/sub for cancel-with-wait
-        # since the cancel has already been issued and the status update committed.
         for _ in range(20):
             await asyncio.sleep(0.5)
             session.expire_all()  # sync method, clears cache
@@ -499,16 +494,7 @@ async def cancel_run_endpoint(
             if fresh and fresh.status in TERMINAL_STATES:
                 break
 
-    # Reload and return updated Run (do NOT delete here; deletion is a separate endpoint)
-    run_orm = await session.scalar(
-        select(RunORM).where(
-            RunORM.run_id == run_id,
-            RunORM.thread_id == thread_id,
-            RunORM.user_id == user.identity,
-        )
-    )
-    if not run_orm:
-        raise HTTPException(404, f"Run '{run_id}' not found after cancellation")
+    await session.refresh(run_orm)
     return Run.model_validate(run_orm)
 
 

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -59,9 +59,8 @@ async def _request_run_interruption(
     )
 
     if reconciled:
-        # A delayed worker may still be running after its lease expires. Tell
-        # it to stop, but keep terminal signaling here so the SSE stream is
-        # closed even when no executor currently owns the run.
+        # A delayed worker can outlive an expired lease, so request a stop.
+        # Signaling stays here to close streams when no executor owns the run.
         if action == "interrupt":
             await streaming_service.interrupt_run(run_orm.run_id, emit_end_event=False)
         else:
@@ -268,7 +267,9 @@ async def update_run(
     """Update a run's status.
 
     Primarily used to interrupt a running execution. Set `status` to
-    `"interrupted"` to cooperatively stop the run.
+    `"interrupted"` to cooperatively stop the run. When a live worker owns
+    the run, interruption is asynchronous and the response may still report
+    `pending` or `running`. Poll or stream the run until it becomes terminal.
     """
     logger.info(f"[update_run] fetch for update run_id={run_id} thread_id={thread_id} user={user.identity}")
     run_orm = await session.scalar(
@@ -472,7 +473,6 @@ async def cancel_run_endpoint(
     wait: int = Query(0, ge=0, le=1, description="Set to 1 to wait for the run task to settle before returning."),
     action: RunCancellationAction = Query(
         "cancel",
-        pattern="^(cancel|interrupt)$",
         description="Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
     ),
     user: User = Depends(get_current_user),
@@ -483,7 +483,9 @@ async def cancel_run_endpoint(
     Use `action=cancel` to hard-cancel the run immediately, or
     `action=interrupt` to cooperatively interrupt (the graph can handle the
     interrupt and save partial state). Set `wait=1` to block until the
-    background task has fully settled before returning the updated run.
+    background task has settled before returning the updated run. Without
+    `wait=1`, a live-owned run is cancelled asynchronously, so the response
+    may still report `pending` or `running`.
     """
     logger.info(f"[cancel_run] fetch run run_id={run_id} thread_id={thread_id} user={user.identity}")
     run_orm = await session.scalar(

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -51,18 +51,27 @@ async def _request_run_interruption(
     if run_orm.status in TERMINAL_STATES:
         return
 
-    task = active_runs.get(run_orm.run_id)
-    has_live_local_task = task is not None and not task.done()
-    reconciled = False
-    if not has_live_local_task:
-        reconciled = await interrupt_unowned_run(
-            session,
-            run_orm.run_id,
-            run_orm.thread_id,
-            user_id=run_orm.user_id,
-        )
+    reconciled = await interrupt_unowned_run(
+        session,
+        run_orm.run_id,
+        run_orm.thread_id,
+        user_id=run_orm.user_id,
+    )
 
     if reconciled:
+        # A delayed worker may still be running after its lease expires. Tell
+        # it to stop, but keep terminal signaling here so the SSE stream is
+        # closed even when no executor currently owns the run.
+        if action == "interrupt":
+            await streaming_service.interrupt_run(run_orm.run_id, emit_end_event=False)
+        else:
+            await streaming_service.cancel_run(run_orm.run_id, emit_end_event=False)
+        try:
+            await streaming_service.signal_run_cancelled(run_orm.run_id)
+        except (RedisError, OSError):
+            # Database reconciliation has already committed. A broker outage
+            # must not turn the successful interruption into an API error.
+            logger.exception("Failed to signal reconciled run interruption", run_id=run_orm.run_id)
         return
 
     await session.refresh(run_orm)

--- a/libs/aegra-api/src/aegra_api/core/active_runs.py
+++ b/libs/aegra-api/src/aegra_api/core/active_runs.py
@@ -8,7 +8,5 @@ import asyncio
 
 active_runs: dict[str, asyncio.Task[None]] = {}
 
-# Run IDs whose worker wrapper was cancelled by an explicit API request.
-# Worker shutdown cancellation deliberately does not add entries here, so a
-# graceful shutdown still leaves leased runs for crash recovery.
+# Explicit API cancellations are marked so worker shutdown remains recoverable.
 explicit_run_cancellations: set[str] = set()

--- a/libs/aegra-api/src/aegra_api/core/active_runs.py
+++ b/libs/aegra-api/src/aegra_api/core/active_runs.py
@@ -7,3 +7,8 @@ managers, streaming service) can import it without circular dependencies.
 import asyncio
 
 active_runs: dict[str, asyncio.Task[None]] = {}
+
+# Run IDs whose worker wrapper was cancelled by an explicit API request.
+# Worker shutdown cancellation deliberately does not add entries here, so a
+# graceful shutdown still leaves leased runs for crash recovery.
+explicit_run_cancellations: set[str] = set()

--- a/libs/aegra-api/src/aegra_api/models/enums.py
+++ b/libs/aegra-api/src/aegra_api/models/enums.py
@@ -27,3 +27,6 @@ MultitaskStrategy = Literal[
     "interrupt",
     "enqueue",
 ]
+
+# Run cancellation action enum
+RunCancellationAction = Literal["cancel", "interrupt"]

--- a/libs/aegra-api/src/aegra_api/models/enums.py
+++ b/libs/aegra-api/src/aegra_api/models/enums.py
@@ -28,5 +28,4 @@ MultitaskStrategy = Literal[
     "enqueue",
 ]
 
-# Run cancellation action enum
 RunCancellationAction = Literal["cancel", "interrupt"]

--- a/libs/aegra-api/src/aegra_api/services/base_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/base_broker.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from typing import Any
 
+from aegra_api.models.enums import RunCancellationAction
+
 
 class BaseRunBroker(ABC):
     """Abstract base class for a run-specific event broker.
@@ -75,7 +77,7 @@ class BaseBrokerManager(ABC):
         """Stop background tasks and release resources"""
 
     @abstractmethod
-    async def request_cancel(self, run_id: str, action: str = "cancel") -> None:
+    async def request_cancel(self, run_id: str, action: RunCancellationAction = "cancel") -> None:
         """Request cancellation of a run.
 
         In single-instance mode, cancels the local asyncio task directly.

--- a/libs/aegra-api/src/aegra_api/services/base_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/base_broker.py
@@ -77,12 +77,19 @@ class BaseBrokerManager(ABC):
         """Stop background tasks and release resources"""
 
     @abstractmethod
-    async def request_cancel(self, run_id: str, action: RunCancellationAction = "cancel") -> None:
+    async def request_cancel(
+        self,
+        run_id: str,
+        action: RunCancellationAction = "cancel",
+        *,
+        emit_end_event: bool = True,
+    ) -> None:
         """Request cancellation of a run.
 
         In single-instance mode, cancels the local asyncio task directly.
         In multi-instance mode, broadcasts via Redis pub/sub so the owning
-        instance can act on it.
+        instance can act on it. ``emit_end_event`` is disabled when the API
+        has already reconciled the database and owns terminal signaling.
         """
 
     @abstractmethod

--- a/libs/aegra-api/src/aegra_api/services/broker.py
+++ b/libs/aegra-api/src/aegra_api/services/broker.py
@@ -12,6 +12,7 @@ from typing import Any
 import structlog
 
 from aegra_api.core.active_runs import active_runs
+from aegra_api.models.enums import RunCancellationAction
 from aegra_api.services.base_broker import BaseBrokerManager, BaseRunBroker
 from aegra_api.settings import settings
 from aegra_api.utils import generate_event_id
@@ -145,7 +146,7 @@ class BrokerManager(BaseBrokerManager):
             with contextlib.suppress(asyncio.CancelledError):
                 await self._cleanup_task
 
-    async def request_cancel(self, run_id: str, action: str = "cancel") -> None:
+    async def request_cancel(self, run_id: str, action: RunCancellationAction = "cancel") -> None:
         """Cancel a run locally by cancelling its asyncio task."""
         task = active_runs.get(run_id)
         if task is None or task.done():

--- a/libs/aegra-api/src/aegra_api/services/broker.py
+++ b/libs/aegra-api/src/aegra_api/services/broker.py
@@ -146,7 +146,13 @@ class BrokerManager(BaseBrokerManager):
             with contextlib.suppress(asyncio.CancelledError):
                 await self._cleanup_task
 
-    async def request_cancel(self, run_id: str, action: RunCancellationAction = "cancel") -> None:
+    async def request_cancel(
+        self,
+        run_id: str,
+        action: RunCancellationAction = "cancel",
+        *,
+        emit_end_event: bool = True,
+    ) -> None:
         """Cancel a run locally by cancelling its asyncio task."""
         task = active_runs.get(run_id)
         if task is None or task.done():
@@ -156,7 +162,7 @@ class BrokerManager(BaseBrokerManager):
         task.cancel()
 
         broker = self.get_or_create_broker(run_id)
-        if not broker.is_finished():
+        if emit_end_event and not broker.is_finished():
             event_id = await self.allocate_event_id(run_id)
             await broker.put(event_id, ("end", {"status": "interrupted"}))
             self.cleanup_broker(run_id)

--- a/libs/aegra-api/src/aegra_api/services/lease_reaper.py
+++ b/libs/aegra-api/src/aegra_api/services/lease_reaper.py
@@ -1,9 +1,9 @@
 """Background task that recovers runs with expired worker leases.
 
 Periodically scans the runs table for rows where
-``status='running' AND lease_expires_at < now()``, resets them to
-``pending`` (clearing the lease), and re-enqueues their run_ids to the
-Redis job queue so another worker can pick them up.
+``status='running' AND lease_expires_at < now()``. It atomically either
+returns them to ``pending`` or marks their retry budget exhausted, then
+re-enqueues only retryable run IDs.
 """
 
 import asyncio
@@ -66,18 +66,14 @@ class LeaseReaper:
         if not crashed and not stuck_pending:
             return
 
-        # Crashed workers: reset first (atomic claim), then check retries
         if crashed:
             logger.warning("Reaping crashed worker runs", count=len(crashed), run_ids=crashed)
-            actually_reset = await self._reset_to_pending(crashed)
-            if actually_reset:
-                retryable, exhausted = await self._check_retry_limits(actually_reset)
-                if exhausted:
-                    failed = await self._mark_permanently_failed(exhausted)
-                    REAPER_RECOVERED_RUNS.labels(outcome="crashed_exhausted").inc(len(failed))
-                if retryable:
-                    pushed = await self._reenqueue(retryable)
-                    REAPER_RECOVERED_RUNS.labels(outcome="crashed_retried").inc(len(pushed))
+            retryable, exhausted = await self._recover_crashed_runs(crashed)
+            if exhausted:
+                REAPER_RECOVERED_RUNS.labels(outcome="crashed_exhausted").inc(len(exhausted))
+            if retryable:
+                pushed = await self._reenqueue(retryable)
+                REAPER_RECOVERED_RUNS.labels(outcome="crashed_retried").inc(len(pushed))
 
         # Stuck pending: just re-enqueue (never executed, no retry budget)
         if stuck_pending:
@@ -122,23 +118,93 @@ class LeaseReaper:
         return crashed, stuck_pending
 
     @staticmethod
-    async def _reset_to_pending(run_ids: list[str]) -> list[str]:
-        """Reset crashed runs to pending. Re-checks lease expiry atomically."""
+    async def _recover_crashed_runs(run_ids: list[str]) -> tuple[list[str], list[str]]:
+        """Atomically classify expired runs and apply their next state."""
+        now = datetime.now(UTC)
+        max_retries = settings.worker.BG_JOB_MAX_RETRIES
+        retryable: list[str] = []
+        exhausted: list[str] = []
+        exhausted_threads_by_user: dict[str, set[str]] = {}
+
         maker = _get_session_maker()
         async with maker() as session:
-            result = await session.execute(
-                update(RunORM)
+            locked_result = await session.execute(
+                select(
+                    RunORM.run_id,
+                    RunORM.thread_id,
+                    RunORM.user_id,
+                    RunORM.execution_params,
+                )
                 .where(
                     RunORM.run_id.in_(run_ids),
                     RunORM.status == "running",
-                    RunORM.lease_expires_at < datetime.now(UTC),
+                    RunORM.lease_expires_at < now,
                 )
-                .values(status="pending", claimed_by=None, lease_expires_at=None)
-                .returning(RunORM.run_id)
+                .with_for_update(skip_locked=True)
             )
-            reset_ids = [row[0] for row in result.fetchall()]
+
+            for run_id, thread_id, user_id, execution_params in locked_result.fetchall():
+                params = dict(execution_params or {})
+                retry_count = params.get("_retry_count", 0) + 1
+                params["_retry_count"] = retry_count
+
+                values: dict[str, object] = {
+                    "execution_params": params,
+                    "claimed_by": None,
+                    "lease_expires_at": None,
+                    "updated_at": now,
+                }
+                is_exhausted = retry_count > max_retries
+                if is_exhausted:
+                    values.update(
+                        status="error",
+                        error_message="Max retries exceeded after repeated worker failures",
+                    )
+                else:
+                    values["status"] = "pending"
+
+                update_result = await session.execute(
+                    update(RunORM)
+                    .where(
+                        RunORM.run_id == run_id,
+                        RunORM.user_id == user_id,
+                        RunORM.status == "running",
+                        RunORM.lease_expires_at < now,
+                    )
+                    .values(**values)
+                    .returning(RunORM.run_id)
+                )
+                if update_result.scalar_one_or_none() is None:
+                    continue
+
+                if is_exhausted:
+                    exhausted.append(run_id)
+                    exhausted_threads_by_user.setdefault(user_id, set()).add(thread_id)
+                    logger.error(
+                        "Run exceeded max retries, marking as permanently failed",
+                        run_id=run_id,
+                        retries=retry_count,
+                        max_retries=max_retries,
+                    )
+                else:
+                    retryable.append(run_id)
+                    logger.info(
+                        "Incrementing retry count",
+                        run_id=run_id,
+                        retry_count=retry_count,
+                        max_retries=max_retries,
+                    )
+
+            for user_id, thread_ids in exhausted_threads_by_user.items():
+                await set_thread_status_if_no_active_runs(
+                    session,
+                    thread_ids,
+                    "error",
+                    user_id=user_id,
+                )
             await session.commit()
-            return reset_ids
+
+        return retryable, exhausted
 
     @staticmethod
     async def _reenqueue(run_ids: list[str]) -> list[str]:
@@ -157,81 +223,6 @@ class LeaseReaper:
                 run_ids=run_ids[len(pushed) :],
             )
         return pushed
-
-    @staticmethod
-    async def _check_retry_limits(run_ids: list[str]) -> tuple[list[str], list[str]]:
-        """Split runs into retryable vs exhausted based on retry count.
-
-        Increments _retry_count in execution_params for each run.
-        Returns (retryable_ids, exhausted_ids).
-        """
-        max_retries = settings.worker.BG_JOB_MAX_RETRIES
-        retryable: list[str] = []
-        exhausted: list[str] = []
-
-        maker = _get_session_maker()
-        async with maker() as session:
-            for run_id in run_ids:
-                run_orm = await session.scalar(select(RunORM).where(RunORM.run_id == run_id))
-                if run_orm is None:
-                    continue
-
-                params = run_orm.execution_params or {}
-                retry_count = params.get("_retry_count", 0) + 1
-
-                if retry_count > max_retries:
-                    exhausted.append(run_id)
-                    logger.error(
-                        "Run exceeded max retries, marking as permanently failed",
-                        run_id=run_id,
-                        retries=retry_count,
-                        max_retries=max_retries,
-                    )
-                else:
-                    params["_retry_count"] = retry_count
-                    await session.execute(update(RunORM).where(RunORM.run_id == run_id).values(execution_params=params))
-                    retryable.append(run_id)
-                    logger.info(
-                        "Incrementing retry count",
-                        run_id=run_id,
-                        retry_count=retry_count,
-                        max_retries=max_retries,
-                    )
-
-            await session.commit()
-
-        return retryable, exhausted
-
-    @staticmethod
-    async def _mark_permanently_failed(run_ids: list[str]) -> list[str]:
-        """Mark exhausted runs and their now-inactive threads as failed."""
-        maker = _get_session_maker()
-        async with maker() as session:
-            result = await session.execute(
-                update(RunORM)
-                .where(
-                    RunORM.run_id.in_(run_ids),
-                    RunORM.status == "pending",
-                    RunORM.claimed_by.is_(None),
-                )
-                .values(
-                    status="error",
-                    error_message="Max retries exceeded after repeated worker failures",
-                    claimed_by=None,
-                    lease_expires_at=None,
-                    updated_at=datetime.now(UTC),
-                )
-                .returning(RunORM.run_id, RunORM.thread_id, RunORM.user_id)
-            )
-            failed_runs = result.fetchall()
-            failed_ids = [row[0] for row in failed_runs]
-            thread_ids_by_user: dict[str, set[str]] = {}
-            for _, thread_id, user_id in failed_runs:
-                thread_ids_by_user.setdefault(user_id, set()).add(thread_id)
-            for user_id, thread_ids in thread_ids_by_user.items():
-                await set_thread_status_if_no_active_runs(session, thread_ids, "error", user_id=user_id)
-            await session.commit()
-            return failed_ids
 
 
 lease_reaper = LeaseReaper()

--- a/libs/aegra-api/src/aegra_api/services/lease_reaper.py
+++ b/libs/aegra-api/src/aegra_api/services/lease_reaper.py
@@ -18,6 +18,7 @@ from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import _get_session_maker
 from aegra_api.core.redis_manager import redis_manager
 from aegra_api.observability.metrics import REAPER_RECOVERED_RUNS
+from aegra_api.services.run_status import set_thread_status_if_no_active_runs
 from aegra_api.settings import settings
 
 logger = structlog.getLogger(__name__)
@@ -203,21 +204,29 @@ class LeaseReaper:
 
     @staticmethod
     async def _mark_permanently_failed(run_ids: list[str]) -> list[str]:
-        """Mark runs as error with max retries exceeded message. Returns IDs actually updated."""
+        """Mark exhausted runs and their now-inactive threads as failed."""
         maker = _get_session_maker()
         async with maker() as session:
             result = await session.execute(
                 update(RunORM)
-                .where(RunORM.run_id.in_(run_ids))
+                .where(
+                    RunORM.run_id.in_(run_ids),
+                    RunORM.status == "pending",
+                    RunORM.claimed_by.is_(None),
+                )
                 .values(
                     status="error",
                     error_message="Max retries exceeded after repeated worker failures",
                     claimed_by=None,
                     lease_expires_at=None,
+                    updated_at=datetime.now(UTC),
                 )
-                .returning(RunORM.run_id)
+                .returning(RunORM.run_id, RunORM.thread_id)
             )
-            failed_ids = [row[0] for row in result.fetchall()]
+            failed_runs = result.fetchall()
+            failed_ids = [row[0] for row in failed_runs]
+            thread_ids = {row[1] for row in failed_runs}
+            await set_thread_status_if_no_active_runs(session, thread_ids, "error")
             await session.commit()
             return failed_ids
 

--- a/libs/aegra-api/src/aegra_api/services/lease_reaper.py
+++ b/libs/aegra-api/src/aegra_api/services/lease_reaper.py
@@ -221,12 +221,15 @@ class LeaseReaper:
                     lease_expires_at=None,
                     updated_at=datetime.now(UTC),
                 )
-                .returning(RunORM.run_id, RunORM.thread_id)
+                .returning(RunORM.run_id, RunORM.thread_id, RunORM.user_id)
             )
             failed_runs = result.fetchall()
             failed_ids = [row[0] for row in failed_runs]
-            thread_ids = {row[1] for row in failed_runs}
-            await set_thread_status_if_no_active_runs(session, thread_ids, "error")
+            thread_ids_by_user: dict[str, set[str]] = {}
+            for _, thread_id, user_id in failed_runs:
+                thread_ids_by_user.setdefault(user_id, set()).add(thread_id)
+            for user_id, thread_ids in thread_ids_by_user.items():
+                await set_thread_status_if_no_active_runs(session, thread_ids, "error", user_id=user_id)
             await session.commit()
             return failed_ids
 

--- a/libs/aegra-api/src/aegra_api/services/redis_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/redis_broker.py
@@ -19,7 +19,7 @@ from typing import Any
 import structlog
 from redis import RedisError
 
-from aegra_api.core.active_runs import active_runs
+from aegra_api.core.active_runs import active_runs, explicit_run_cancellations
 from aegra_api.core.redis_manager import redis_manager
 from aegra_api.core.serializers import GeneralSerializer
 from aegra_api.models.enums import RunCancellationAction
@@ -376,18 +376,30 @@ class RedisBrokerManager(BaseBrokerManager):
             self._listener_task = None
         logger.debug("Redis broker manager stopped")
 
-    async def request_cancel(self, run_id: str, action: RunCancellationAction = "cancel") -> None:
+    async def request_cancel(
+        self,
+        run_id: str,
+        action: RunCancellationAction = "cancel",
+        *,
+        emit_end_event: bool = True,
+    ) -> None:
         """Broadcast a cancel command via Redis pub/sub."""
-        message = json.dumps({"run_id": run_id, "action": action})
+        message = json.dumps(
+            {
+                "run_id": run_id,
+                "action": action,
+                "emit_end_event": emit_end_event,
+            }
+        )
         try:
             client = redis_manager.get_client()
             await client.publish(self._cancel_channel, message)
             logger.info(f"Published {action} command for run {run_id}")
         except RedisError as e:
             logger.error(f"Failed to publish {action} for run {run_id}: {e}")
-            # Fall back to local execution — if the task is on this instance,
+            # Fall back to local execution - if the task is on this instance,
             # we can still cancel it even if Redis publish fails.
-            await self._execute_cancel(run_id)
+            await self._execute_cancel(run_id, emit_end_event=emit_end_event)
 
     async def get_event_sequence(self, run_id: str) -> int:
         """Read the current event sequence counter from Redis (O(1) GET)."""
@@ -455,27 +467,31 @@ class RedisBrokerManager(BaseBrokerManager):
 
                 try:
                     data = json.loads(message["data"])
-                    await self._execute_cancel(data["run_id"])
-                except (json.JSONDecodeError, KeyError) as e:
+                    emit_end_event = data.get("emit_end_event", True)
+                    if not isinstance(emit_end_event, bool):
+                        raise ValueError("emit_end_event must be a boolean")
+                    await self._execute_cancel(data["run_id"], emit_end_event=emit_end_event)
+                except (json.JSONDecodeError, KeyError, ValueError) as e:
                     logger.warning(f"Invalid cancel message: {e}")
         finally:
             await pubsub.unsubscribe(self._cancel_channel)
             await pubsub.aclose()
 
-    async def _execute_cancel(self, run_id: str) -> None:
+    async def _execute_cancel(self, run_id: str, *, emit_end_event: bool = True) -> None:
         """Cancel a locally-owned task and signal the broker."""
         task = active_runs.get(run_id)
         if task is None or task.done():
             return
 
         logger.info(f"Cancelling run {run_id} (local task found)")
+        explicit_run_cancellations.add(run_id)
         task.cancel()
 
         broker = self.get_or_create_broker(run_id)
-        if not broker.is_finished():
+        if emit_end_event and not broker.is_finished():
             event_id = await self.allocate_event_id(run_id)
             await broker.put(event_id, ("end", {"status": "interrupted"}))
-            # Do NOT call cleanup_broker here — execute_run's finally block
+            # Do NOT call cleanup_broker here - execute_run's finally block
             # owns cleanup.  Leaving the finished broker in _brokers lets
             # signal_run_cancelled see is_finished() → True and skip the
             # duplicate end event.

--- a/libs/aegra-api/src/aegra_api/services/redis_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/redis_broker.py
@@ -22,6 +22,7 @@ from redis import RedisError
 from aegra_api.core.active_runs import active_runs
 from aegra_api.core.redis_manager import redis_manager
 from aegra_api.core.serializers import GeneralSerializer
+from aegra_api.models.enums import RunCancellationAction
 from aegra_api.services.base_broker import BaseBrokerManager, BaseRunBroker
 from aegra_api.settings import settings
 from aegra_api.utils import generate_event_id
@@ -146,7 +147,7 @@ class RedisRunBroker(BaseRunBroker):
         pipe.expire(self._cache_key, _REPLAY_TTL_SECONDS)
         pipe.incr(self._counter_key)
         pipe.expire(self._counter_key, _REPLAY_TTL_SECONDS)
-        await pipe.execute()  # type: ignore[invalid-await]
+        await pipe.execute()
 
     async def _publish_event(self, message: str) -> None:
         """Broadcast the event to live subscribers."""
@@ -375,7 +376,7 @@ class RedisBrokerManager(BaseBrokerManager):
             self._listener_task = None
         logger.debug("Redis broker manager stopped")
 
-    async def request_cancel(self, run_id: str, action: str = "cancel") -> None:
+    async def request_cancel(self, run_id: str, action: RunCancellationAction = "cancel") -> None:
         """Broadcast a cancel command via Redis pub/sub."""
         message = json.dumps({"run_id": run_id, "action": action})
         try:
@@ -392,7 +393,7 @@ class RedisBrokerManager(BaseBrokerManager):
         """Read the current event sequence counter from Redis (O(1) GET)."""
         try:
             client = redis_manager.get_client()
-            value = await client.get(f"{self._counter_prefix}{run_id}")  # type: ignore[invalid-await]
+            value = await client.get(f"{self._counter_prefix}{run_id}")
             if value is not None:
                 return int(value)
         except (RedisError, ValueError) as e:
@@ -409,8 +410,8 @@ class RedisBrokerManager(BaseBrokerManager):
         counter_key = f"{self._counter_prefix}{run_id}"
         try:
             client = redis_manager.get_client()
-            seq = await client.incr(counter_key)  # type: ignore[invalid-await]
-            await client.expire(counter_key, _REPLAY_TTL_SECONDS)  # type: ignore[invalid-await]
+            seq = await client.incr(counter_key)
+            await client.expire(counter_key, _REPLAY_TTL_SECONDS)
             return generate_event_id(run_id, int(seq))
         except RedisError as e:
             logger.warning(f"Failed to allocate event_id for run {run_id}: {e}")

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -19,7 +19,7 @@ from aegra_api.services.broker import broker_manager
 from aegra_api.services.event_streaming.native_stream import stream_native_v3_events
 from aegra_api.services.graph_streaming import stream_graph_events
 from aegra_api.services.langgraph_service import create_run_config, get_langgraph_service
-from aegra_api.services.run_status import finalize_run, update_run_status
+from aegra_api.services.run_status import finalize_run, start_run
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.settings import settings
 from aegra_api.utils.run_utils import map_command_to_langgraph
@@ -48,14 +48,17 @@ async def execute_run(job: RunJob) -> None:
     run_id = job.identity.run_id
     thread_id = job.identity.thread_id
     is_lease_loss = False
+    finalized = False
 
     try:
-        await update_run_status(run_id, "running")
+        if not await start_run(run_id):
+            logger.info("Run became terminal before execution started", run_id=run_id)
+            return
 
         final_output = await _stream_graph(job)
 
         if final_output.has_interrupt:
-            await finalize_run(
+            finalized = await finalize_run(
                 run_id,
                 thread_id,
                 status="interrupted",
@@ -63,7 +66,7 @@ async def execute_run(job: RunJob) -> None:
                 output=final_output.data,
             )
         else:
-            await finalize_run(
+            finalized = await finalize_run(
                 run_id,
                 thread_id,
                 status="success",
@@ -79,17 +82,33 @@ async def execute_run(job: RunJob) -> None:
             is_lease_loss = True
             logger.info("Lease-loss cancel, skipping finalize", run_id=run_id)
         else:
-            await finalize_run(run_id, thread_id, status="interrupted", thread_status="idle", output={})
-            await _best_effort_signal(streaming_service.signal_run_cancelled, run_id)
+            finalized = await finalize_run(
+                run_id,
+                thread_id,
+                status="interrupted",
+                thread_status="idle",
+                output={},
+            )
+            if finalized:
+                await _best_effort_signal(streaming_service.signal_run_cancelled, run_id)
         raise
     except Exception as exc:
         logger.exception("Run failed", run_id=run_id)
         safe_message = f"{type(exc).__name__}: execution failed"
-        await finalize_run(run_id, thread_id, status="error", thread_status="error", output={}, error=str(exc))
-        await _best_effort_signal(streaming_service.signal_run_error, run_id, safe_message, type(exc).__name__)
+        finalized = await finalize_run(
+            run_id,
+            thread_id,
+            status="error",
+            thread_status="error",
+            output={},
+            error=str(exc),
+        )
+        if finalized:
+            await _best_effort_signal(streaming_service.signal_run_error, run_id, safe_message, type(exc).__name__)
     else:
-        status = "interrupted" if final_output.has_interrupt else "success"
-        await _best_effort_signal(_signal_end_event, run_id, status)
+        if finalized:
+            status = "interrupted" if final_output.has_interrupt else "success"
+            await _best_effort_signal(_signal_end_event, run_id, status)
     finally:
         _lease_loss_cancellations.discard(run_id)
         active_runs.pop(run_id, None)

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -28,15 +28,12 @@ logger = structlog.getLogger(__name__)
 
 _DEFAULT_STREAM_MODES = ["values"]
 
-# Run IDs whose cancellation was triggered by lease loss (not user action).
-# When a heartbeat detects lease loss, it adds the run_id here before
-# cancelling the job task. execute_run's CancelledError handler checks
-# this set to skip finalize_run and SSE signaling — the reaper has already
-# re-enqueued the run and another worker will execute it. Without this,
-# the old worker would write status="interrupted" and send an SSE end event,
-# prematurely closing client streams and potentially overwriting the new
-# worker's status.
+# Cancellation provenance prevents infrastructure stops from looking user-initiated.
 _lease_loss_cancellations: set[str] = set()
+_timeout_cancellations: set[str] = set()
+
+_TIMEOUT_ERROR = "Job exceeded maximum execution time"
+_TIMEOUT_SAFE_MESSAGE = "TimeoutError: execution failed"
 
 
 async def execute_run(job: RunJob) -> None:
@@ -47,11 +44,12 @@ async def execute_run(job: RunJob) -> None:
     """
     run_id = job.identity.run_id
     thread_id = job.identity.thread_id
+    user_id = job.user.identity
     is_lease_loss = False
     finalized = False
 
     try:
-        if not await start_run(run_id):
+        if not await start_run(run_id, user_id=user_id):
             logger.info("Run became terminal before execution started", run_id=run_id)
             return
 
@@ -61,6 +59,7 @@ async def execute_run(job: RunJob) -> None:
             finalized = await finalize_run(
                 run_id,
                 thread_id,
+                user_id=user_id,
                 status="interrupted",
                 thread_status="interrupted",
                 output=final_output.data,
@@ -69,6 +68,7 @@ async def execute_run(job: RunJob) -> None:
             finalized = await finalize_run(
                 run_id,
                 thread_id,
+                user_id=user_id,
                 status="success",
                 thread_status="idle",
                 output=final_output.data,
@@ -76,15 +76,30 @@ async def execute_run(job: RunJob) -> None:
 
     except asyncio.CancelledError:
         if run_id in _lease_loss_cancellations:
-            # Lease was lost — the reaper re-enqueued this run for another
-            # worker.  Do NOT finalize, signal done, or clean up the broker.
-            # The new worker owns the run now.
             is_lease_loss = True
             logger.info("Lease-loss cancel, skipping finalize", run_id=run_id)
+        elif run_id in _timeout_cancellations:
+            finalized = await finalize_run(
+                run_id,
+                thread_id,
+                user_id=user_id,
+                status="error",
+                thread_status="error",
+                output={},
+                error=_TIMEOUT_ERROR,
+            )
+            if finalized:
+                await _best_effort_signal(
+                    streaming_service.signal_run_error,
+                    run_id,
+                    _TIMEOUT_SAFE_MESSAGE,
+                    "TimeoutError",
+                )
         else:
             finalized = await finalize_run(
                 run_id,
                 thread_id,
+                user_id=user_id,
                 status="interrupted",
                 thread_status="idle",
                 output={},
@@ -98,6 +113,7 @@ async def execute_run(job: RunJob) -> None:
         finalized = await finalize_run(
             run_id,
             thread_id,
+            user_id=user_id,
             status="error",
             thread_status="error",
             output={},
@@ -111,6 +127,7 @@ async def execute_run(job: RunJob) -> None:
             await _best_effort_signal(_signal_end_event, run_id, status)
     finally:
         _lease_loss_cancellations.discard(run_id)
+        _timeout_cancellations.discard(run_id)
         active_runs.pop(run_id, None)
         if not is_lease_loss:
             await streaming_service.cleanup_run(run_id)

--- a/libs/aegra-api/src/aegra_api/services/run_status.py
+++ b/libs/aegra-api/src/aegra_api/services/run_status.py
@@ -25,43 +25,6 @@ _serializer = GeneralSerializer()
 ACTIVE_RUN_STATES = ("pending", "running")
 
 
-async def update_run_status(
-    run_id: str,
-    status: str,
-    *,
-    user_id: str,
-    output: Any = None,
-    error: str | None = None,
-) -> None:
-    """Persist a run's status to the database.
-
-    Opens a short-lived session to avoid holding a connection during
-    long-running graph execution.
-    """
-    validated = validate_run_status(status)
-    maker = _get_session_maker()
-    async with maker() as session:
-        values: dict[str, Any] = {
-            "status": validated,
-            "updated_at": datetime.now(UTC),
-        }
-        if output is not None:
-            values["output"] = _safe_serialize(output, run_id)
-        if error is not None:
-            values["error_message"] = error
-
-        logger.info("Updating run status", run_id=run_id, status=validated)
-        await session.execute(
-            update(RunORM)
-            .where(
-                RunORM.run_id == run_id,
-                RunORM.user_id == user_id,
-            )
-            .values(**values)
-        )
-        await session.commit()
-
-
 async def start_run(run_id: str, *, user_id: str) -> bool:
     """Move an active run to running without reviving a terminal run."""
     maker = _get_session_maker()
@@ -193,7 +156,6 @@ async def finalize_run(
     thread_status: str,
     output: Any = None,
     error: str | None = None,
-    allowed_current_statuses: Collection[str] = ACTIVE_RUN_STATES,
 ) -> bool:
     """Conditionally update run and thread status in one transaction.
 
@@ -219,7 +181,7 @@ async def finalize_run(
             .where(
                 RunORM.run_id == run_id,
                 RunORM.user_id == user_id,
-                RunORM.status.in_(allowed_current_statuses),
+                RunORM.status.in_(ACTIVE_RUN_STATES),
             )
             .values(**run_values)
             .returning(RunORM.run_id)

--- a/libs/aegra-api/src/aegra_api/services/run_status.py
+++ b/libs/aegra-api/src/aegra_api/services/run_status.py
@@ -29,6 +29,7 @@ async def update_run_status(
     run_id: str,
     status: str,
     *,
+    user_id: str,
     output: Any = None,
     error: str | None = None,
 ) -> None:
@@ -50,11 +51,18 @@ async def update_run_status(
             values["error_message"] = error
 
         logger.info("Updating run status", run_id=run_id, status=validated)
-        await session.execute(update(RunORM).where(RunORM.run_id == run_id).values(**values))
+        await session.execute(
+            update(RunORM)
+            .where(
+                RunORM.run_id == run_id,
+                RunORM.user_id == user_id,
+            )
+            .values(**values)
+        )
         await session.commit()
 
 
-async def start_run(run_id: str) -> bool:
+async def start_run(run_id: str, *, user_id: str) -> bool:
     """Move an active run to running without reviving a terminal run."""
     maker = _get_session_maker()
     async with maker() as session:
@@ -62,6 +70,7 @@ async def start_run(run_id: str) -> bool:
             update(RunORM)
             .where(
                 RunORM.run_id == run_id,
+                RunORM.user_id == user_id,
                 RunORM.status.in_(ACTIVE_RUN_STATES),
             )
             .values(status="running", updated_at=datetime.now(UTC))
@@ -179,6 +188,7 @@ async def finalize_run(
     run_id: str,
     thread_id: str,
     *,
+    user_id: str,
     status: str,
     thread_status: str,
     output: Any = None,
@@ -208,13 +218,13 @@ async def finalize_run(
             update(RunORM)
             .where(
                 RunORM.run_id == run_id,
+                RunORM.user_id == user_id,
                 RunORM.status.in_(allowed_current_statuses),
             )
             .values(**run_values)
-            .returning(RunORM.user_id)
+            .returning(RunORM.run_id)
         )
-        user_id = result.scalar_one_or_none()
-        if user_id is None:
+        if result.scalar_one_or_none() is None:
             await session.rollback()
             logger.info("Skipped finalizing terminal run", run_id=run_id, status=validated_run)
             return False

--- a/libs/aegra-api/src/aegra_api/services/run_status.py
+++ b/libs/aegra-api/src/aegra_api/services/run_status.py
@@ -113,6 +113,8 @@ async def interrupt_unowned_run(
 
     The ownership predicate is checked in the UPDATE so a worker that renews
     or claims the run concurrently cannot be overwritten by the API process.
+    If a live worker merely missed its lease, the caller asks it to stop through
+    the broker, and guarded finalization rejects any late worker write.
     """
     now = datetime.now(UTC)
     result = cast(

--- a/libs/aegra-api/src/aegra_api/services/run_status.py
+++ b/libs/aegra-api/src/aegra_api/services/run_status.py
@@ -54,6 +54,27 @@ async def update_run_status(
         await session.commit()
 
 
+async def start_run(run_id: str) -> bool:
+    """Move an active run to running without reviving a terminal run."""
+    maker = _get_session_maker()
+    async with maker() as session:
+        result = await session.execute(
+            update(RunORM)
+            .where(
+                RunORM.run_id == run_id,
+                RunORM.status.in_(ACTIVE_RUN_STATES),
+            )
+            .values(status="running", updated_at=datetime.now(UTC))
+            .returning(RunORM.run_id)
+        )
+        started = result.scalar_one_or_none() is not None
+        if started:
+            await session.commit()
+        else:
+            await session.rollback()
+        return started
+
+
 async def set_thread_status(session: AsyncSession, thread_id: str, status: str) -> None:
     """Update a thread's status column.
 
@@ -162,11 +183,12 @@ async def finalize_run(
     thread_status: str,
     output: Any = None,
     error: str | None = None,
-) -> None:
-    """Update run status + thread status in a single transaction.
+    allowed_current_statuses: Collection[str] = ACTIVE_RUN_STATES,
+) -> bool:
+    """Conditionally update run and thread status in one transaction.
 
-    Batches two UPDATE statements into one DB round-trip instead of
-    opening separate sessions for update_run_status and set_thread_status.
+    Returns false when another actor has already made the run terminal. This
+    prevents an expired worker from overwriting a reconciled cancellation.
     """
     validated_run = validate_run_status(status)
     validated_thread = validate_thread_status(thread_status)
@@ -182,15 +204,31 @@ async def finalize_run(
         run_values["error_message"] = error
 
     async with maker() as session:
-        await session.execute(update(RunORM).where(RunORM.run_id == run_id).values(**run_values))
-        await session.execute(
-            update(ThreadORM)
-            .where(ThreadORM.thread_id == thread_id)
-            .values(status=validated_thread, updated_at=datetime.now(UTC))
+        result = await session.execute(
+            update(RunORM)
+            .where(
+                RunORM.run_id == run_id,
+                RunORM.status.in_(allowed_current_statuses),
+            )
+            .values(**run_values)
+            .returning(RunORM.user_id)
+        )
+        user_id = result.scalar_one_or_none()
+        if user_id is None:
+            await session.rollback()
+            logger.info("Skipped finalizing terminal run", run_id=run_id, status=validated_run)
+            return False
+
+        await set_thread_status_if_no_active_runs(
+            session,
+            [thread_id],
+            validated_thread,
+            user_id=user_id,
         )
         await session.commit()
 
     logger.info("Finalized run", run_id=run_id, status=validated_run, thread_status=validated_thread)
+    return True
 
 
 def _safe_serialize(output: Any, run_id: str) -> Any:

--- a/libs/aegra-api/src/aegra_api/services/run_status.py
+++ b/libs/aegra-api/src/aegra_api/services/run_status.py
@@ -6,11 +6,12 @@ worker_executor). Extracted from api/runs.py to eliminate the circular
 dependency where service code imported from the API module.
 """
 
+from collections.abc import Collection
 from datetime import UTC, datetime
 from typing import Any, cast
 
 import structlog
-from sqlalchemy import CursorResult, update
+from sqlalchemy import CursorResult, exists, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aegra_api.core.orm import Run as RunORM
@@ -21,6 +22,7 @@ from aegra_api.utils.status_compat import validate_run_status, validate_thread_s
 
 logger = structlog.getLogger(__name__)
 _serializer = GeneralSerializer()
+ACTIVE_RUN_STATES = ("pending", "running")
 
 
 async def update_run_status(
@@ -69,6 +71,80 @@ async def set_thread_status(session: AsyncSession, thread_id: str, status: str) 
     )
     if result.rowcount == 0:
         raise ValueError(f"Thread '{thread_id}' not found")
+
+
+async def set_thread_status_if_no_active_runs(
+    session: AsyncSession,
+    thread_ids: Collection[str],
+    status: str,
+) -> None:
+    """Update threads that no longer have a pending or running run.
+
+    Does not commit so callers can keep the run and thread transitions in
+    one transaction.
+    """
+    if not thread_ids:
+        return
+
+    validated = validate_thread_status(status)
+    active_run_exists = exists(
+        select(RunORM.run_id)
+        .where(
+            RunORM.thread_id == ThreadORM.thread_id,
+            RunORM.status.in_(ACTIVE_RUN_STATES),
+        )
+        .correlate(ThreadORM)
+    )
+    await session.execute(
+        update(ThreadORM)
+        .where(
+            ThreadORM.thread_id.in_(thread_ids),
+            ~active_run_exists,
+        )
+        .values(status=validated, updated_at=datetime.now(UTC))
+    )
+
+
+async def interrupt_unowned_run(
+    session: AsyncSession,
+    run_id: str,
+    thread_id: str,
+) -> bool:
+    """Interrupt an active run only when it has no live database owner.
+
+    The ownership predicate is checked in the UPDATE so a worker that renews
+    or claims the run concurrently cannot be overwritten by the API process.
+    """
+    now = datetime.now(UTC)
+    result = cast(
+        CursorResult,
+        await session.execute(
+            update(RunORM)
+            .where(
+                RunORM.run_id == run_id,
+                RunORM.thread_id == thread_id,
+                RunORM.status.in_(ACTIVE_RUN_STATES),
+                or_(
+                    RunORM.claimed_by.is_(None),
+                    RunORM.lease_expires_at < now,
+                ),
+            )
+            .values(
+                status="interrupted",
+                claimed_by=None,
+                lease_expires_at=None,
+                updated_at=now,
+            )
+            .returning(RunORM.run_id)
+        ),
+    )
+    if result.scalar_one_or_none() is None:
+        return False
+
+    await set_thread_status_if_no_active_runs(session, [thread_id], "idle")
+    await session.commit()
+    logger.info("Interrupted unowned run", run_id=run_id, thread_id=thread_id)
+    return True
 
 
 async def finalize_run(

--- a/libs/aegra-api/src/aegra_api/services/run_status.py
+++ b/libs/aegra-api/src/aegra_api/services/run_status.py
@@ -77,6 +77,8 @@ async def set_thread_status_if_no_active_runs(
     session: AsyncSession,
     thread_ids: Collection[str],
     status: str,
+    *,
+    user_id: str,
 ) -> None:
     """Update threads that no longer have a pending or running run.
 
@@ -91,6 +93,7 @@ async def set_thread_status_if_no_active_runs(
         select(RunORM.run_id)
         .where(
             RunORM.thread_id == ThreadORM.thread_id,
+            RunORM.user_id == user_id,
             RunORM.status.in_(ACTIVE_RUN_STATES),
         )
         .correlate(ThreadORM)
@@ -99,6 +102,7 @@ async def set_thread_status_if_no_active_runs(
         update(ThreadORM)
         .where(
             ThreadORM.thread_id.in_(thread_ids),
+            ThreadORM.user_id == user_id,
             ~active_run_exists,
         )
         .values(status=validated, updated_at=datetime.now(UTC))
@@ -109,6 +113,8 @@ async def interrupt_unowned_run(
     session: AsyncSession,
     run_id: str,
     thread_id: str,
+    *,
+    user_id: str,
 ) -> bool:
     """Interrupt an active run only when it has no live database owner.
 
@@ -123,6 +129,7 @@ async def interrupt_unowned_run(
             .where(
                 RunORM.run_id == run_id,
                 RunORM.thread_id == thread_id,
+                RunORM.user_id == user_id,
                 RunORM.status.in_(ACTIVE_RUN_STATES),
                 or_(
                     RunORM.claimed_by.is_(None),
@@ -141,7 +148,7 @@ async def interrupt_unowned_run(
     if result.scalar_one_or_none() is None:
         return False
 
-    await set_thread_status_if_no_active_runs(session, [thread_id], "idle")
+    await set_thread_status_if_no_active_runs(session, [thread_id], "idle", user_id=user_id)
     await session.commit()
     logger.info("Interrupted unowned run", run_id=run_id, thread_id=thread_id)
     return True

--- a/libs/aegra-api/src/aegra_api/services/streaming_service.py
+++ b/libs/aegra-api/src/aegra_api/services/streaming_service.py
@@ -163,25 +163,25 @@ class StreamingService:
                 yield sse_event
                 last_sent_sequence = current_sequence
 
-    async def interrupt_run(self, run_id: str) -> bool:
+    async def interrupt_run(self, run_id: str, *, emit_end_event: bool = True) -> bool:
         """Interrupt a running execution.
 
         Delegates to broker_manager for cross-instance support via Redis pub/sub.
         """
         try:
-            await broker_manager.request_cancel(run_id, "interrupt")
+            await broker_manager.request_cancel(run_id, "interrupt", emit_end_event=emit_end_event)
             return True
         except Exception as e:
             logger.error(f"Error interrupting run {run_id}: {e}")
             return False
 
-    async def cancel_run(self, run_id: str) -> bool:
+    async def cancel_run(self, run_id: str, *, emit_end_event: bool = True) -> bool:
         """Cancel a pending or running execution.
 
         Delegates to broker_manager for cross-instance support via Redis pub/sub.
         """
         try:
-            await broker_manager.request_cancel(run_id, "cancel")
+            await broker_manager.request_cancel(run_id, "cancel", emit_end_event=emit_end_event)
             return True
         except Exception as e:
             logger.error(f"Error cancelling run {run_id}: {e}")

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -22,7 +22,7 @@ from redis import RedisError
 from redis import TimeoutError as RedisTimeoutError
 from sqlalchemy import select, update
 
-from aegra_api.core.active_runs import active_runs
+from aegra_api.core.active_runs import active_runs, explicit_run_cancellations
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import _get_session_maker
 from aegra_api.core.redis_manager import redis_manager
@@ -30,7 +30,7 @@ from aegra_api.models.run_job import RunJob
 from aegra_api.observability.span_enrichment import merge_run_metadata, set_trace_context
 from aegra_api.services.base_executor import BaseExecutor
 from aegra_api.services.run_executor import _lease_loss_cancellations, execute_run
-from aegra_api.services.run_status import finalize_run, update_run_status
+from aegra_api.services.run_status import ACTIVE_RUN_STATES, finalize_run, update_run_status
 from aegra_api.settings import settings
 
 logger = structlog.getLogger(__name__)
@@ -229,6 +229,7 @@ class WorkerExecutor(BaseExecutor):
                     status="error",
                     thread_status="error",
                     error="Job exceeded maximum execution time",
+                    allowed_current_statuses=(*ACTIVE_RUN_STATES, "interrupted"),
                 )
             else:
                 # Fallback: update run status only (thread_id lookup failed)
@@ -236,10 +237,21 @@ class WorkerExecutor(BaseExecutor):
             await _release_lease(run_id, worker_name)
         except asyncio.CancelledError:
             logger.info("Job task cancelled", worker=worker_name, run_id=run_id)
+            if run_id in explicit_run_cancellations:
+                thread_id = await _get_thread_id_for_run(run_id)
+                if thread_id is not None:
+                    await finalize_run(
+                        run_id,
+                        thread_id,
+                        status="interrupted",
+                        thread_status="idle",
+                        output={},
+                    )
             raise
         except Exception:
             logger.exception("Unexpected error in job execution", run_id=run_id)
         finally:
+            explicit_run_cancellations.discard(run_id)
             active_runs.pop(run_id, None)
             semaphore.release()
 

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -29,8 +29,8 @@ from aegra_api.core.redis_manager import redis_manager
 from aegra_api.models.run_job import RunJob
 from aegra_api.observability.span_enrichment import merge_run_metadata, set_trace_context
 from aegra_api.services.base_executor import BaseExecutor
-from aegra_api.services.run_executor import _lease_loss_cancellations, execute_run
-from aegra_api.services.run_status import ACTIVE_RUN_STATES, finalize_run, update_run_status
+from aegra_api.services.run_executor import _lease_loss_cancellations, _timeout_cancellations, execute_run
+from aegra_api.services.run_status import finalize_run
 from aegra_api.settings import settings
 
 logger = structlog.getLogger(__name__)
@@ -206,43 +206,51 @@ class WorkerExecutor(BaseExecutor):
         current_task = asyncio.current_task()
         if current_task is not None:
             active_runs[run_id] = current_task
+        execution_task = asyncio.create_task(self._execute_with_lease(run_id, worker_name))
         try:
-            await asyncio.wait_for(
-                self._execute_with_lease(run_id, worker_name),
+            done, _ = await asyncio.wait(
+                {execution_task},
                 timeout=settings.worker.BG_JOB_TIMEOUT_SECS,
             )
-        except TimeoutError:
-            logger.error(
-                "Job exceeded timeout, killing",
-                worker=worker_name,
-                run_id=run_id,
-                timeout_secs=settings.worker.BG_JOB_TIMEOUT_SECS,
-            )
-            # Look up thread_id so we can set thread status to "error" too.
-            # When wait_for fires, execute_run's CancelledError handler runs first
-            # and sets thread_status="idle" — we must correct that to "error".
-            thread_id = await _get_thread_id_for_run(run_id)
-            if thread_id is not None:
-                await finalize_run(
-                    run_id,
-                    thread_id,
-                    status="error",
-                    thread_status="error",
-                    error="Job exceeded maximum execution time",
-                    allowed_current_statuses=(*ACTIVE_RUN_STATES, "interrupted"),
-                )
+            if execution_task in done:
+                await execution_task
             else:
-                # Fallback: update run status only (thread_id lookup failed)
-                await update_run_status(run_id, "error", error="Job exceeded maximum execution time")
-            await _release_lease(run_id, worker_name)
-        except asyncio.CancelledError:
-            logger.info("Job task cancelled", worker=worker_name, run_id=run_id)
-            if run_id in explicit_run_cancellations:
-                thread_id = await _get_thread_id_for_run(run_id)
-                if thread_id is not None:
+                logger.error(
+                    "Job exceeded timeout, killing",
+                    worker=worker_name,
+                    run_id=run_id,
+                    timeout_secs=settings.worker.BG_JOB_TIMEOUT_SECS,
+                )
+                _timeout_cancellations.add(run_id)
+                execution_task.cancel()
+                await asyncio.gather(execution_task, return_exceptions=True)
+
+                identity = await _get_run_identity(run_id)
+                if identity is not None:
+                    thread_id, user_id = identity
                     await finalize_run(
                         run_id,
                         thread_id,
+                        user_id=user_id,
+                        status="error",
+                        thread_status="error",
+                        error="Job exceeded maximum execution time",
+                    )
+                await _release_lease(run_id, worker_name)
+        except asyncio.CancelledError:
+            logger.info("Job task cancelled", worker=worker_name, run_id=run_id)
+            if not execution_task.done():
+                execution_task.cancel()
+            await asyncio.gather(execution_task, return_exceptions=True)
+
+            if run_id in explicit_run_cancellations:
+                identity = await _get_run_identity(run_id)
+                if identity is not None:
+                    thread_id, user_id = identity
+                    await finalize_run(
+                        run_id,
+                        thread_id,
+                        user_id=user_id,
                         status="interrupted",
                         thread_status="idle",
                         output={},
@@ -251,6 +259,7 @@ class WorkerExecutor(BaseExecutor):
         except Exception:
             logger.exception("Unexpected error in job execution", run_id=run_id)
         finally:
+            _timeout_cancellations.discard(run_id)
             explicit_run_cancellations.discard(run_id)
             active_runs.pop(run_id, None)
             semaphore.release()
@@ -344,11 +353,15 @@ class WorkerExecutor(BaseExecutor):
 # ------------------------------------------------------------------
 
 
-async def _get_thread_id_for_run(run_id: str) -> str | None:
-    """Look up the thread_id for a run. Returns None if the row is missing."""
+async def _get_run_identity(run_id: str) -> tuple[str, str] | None:
+    """Look up the thread and tenant identity for a run."""
     maker = _get_session_maker()
     async with maker() as session:
-        return await session.scalar(select(RunORM.thread_id).where(RunORM.run_id == run_id))
+        result = await session.execute(select(RunORM.thread_id, RunORM.user_id).where(RunORM.run_id == run_id))
+        row = result.one_or_none()
+        if row is None:
+            return None
+        return row.thread_id, row.user_id
 
 
 # ------------------------------------------------------------------

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -54,19 +54,22 @@ async def _cleanup_cancelled_execution(run_id: str, execution_task: asyncio.Task
     if run_id not in explicit_run_cancellations:
         return
 
-    identity = await _get_run_identity(run_id)
-    if identity is None:
-        return
+    try:
+        identity = await _get_run_identity(run_id)
+        if identity is None:
+            return
 
-    thread_id, user_id = identity
-    await finalize_run(
-        run_id,
-        thread_id,
-        user_id=user_id,
-        status="interrupted",
-        thread_status="idle",
-        output={},
-    )
+        thread_id, user_id = identity
+        await finalize_run(
+            run_id,
+            thread_id,
+            user_id=user_id,
+            status="interrupted",
+            thread_status="idle",
+            output={},
+        )
+    except Exception:
+        logger.exception("Failed to persist explicit run cancellation", run_id=run_id)
 
 
 async def _await_cancellation_cleanup(cleanup_task: asyncio.Task[None]) -> None:

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -45,6 +45,41 @@ def _is_valid_run_id(value: str) -> bool:
     return bool(_RUN_ID_PATTERN.match(value))
 
 
+async def _cleanup_cancelled_execution(run_id: str, execution_task: asyncio.Task[None]) -> None:
+    """Stop execution and persist an explicit cancellation when applicable."""
+    if not execution_task.done():
+        execution_task.cancel()
+    await asyncio.gather(execution_task, return_exceptions=True)
+
+    if run_id not in explicit_run_cancellations:
+        return
+
+    identity = await _get_run_identity(run_id)
+    if identity is None:
+        return
+
+    thread_id, user_id = identity
+    await finalize_run(
+        run_id,
+        thread_id,
+        user_id=user_id,
+        status="interrupted",
+        thread_status="idle",
+        output={},
+    )
+
+
+async def _await_cancellation_cleanup(cleanup_task: asyncio.Task[None]) -> None:
+    """Let cleanup finish even if the owning task is cancelled repeatedly."""
+    while not cleanup_task.done():
+        try:
+            await asyncio.shield(cleanup_task)
+        except asyncio.CancelledError:
+            if cleanup_task.cancelled():
+                raise
+    await cleanup_task
+
+
 class WorkerExecutor(BaseExecutor):
     """Dispatches runs via Redis List; workers consume with BLPOP + semaphore."""
 
@@ -239,22 +274,8 @@ class WorkerExecutor(BaseExecutor):
                 await _release_lease(run_id, worker_name)
         except asyncio.CancelledError:
             logger.info("Job task cancelled", worker=worker_name, run_id=run_id)
-            if not execution_task.done():
-                execution_task.cancel()
-            await asyncio.gather(execution_task, return_exceptions=True)
-
-            if run_id in explicit_run_cancellations:
-                identity = await _get_run_identity(run_id)
-                if identity is not None:
-                    thread_id, user_id = identity
-                    await finalize_run(
-                        run_id,
-                        thread_id,
-                        user_id=user_id,
-                        status="interrupted",
-                        thread_status="idle",
-                        output={},
-                    )
+            cleanup_task = asyncio.create_task(_cleanup_cancelled_execution(run_id, execution_task))
+            await _await_cancellation_cleanup(cleanup_task)
             raise
         except Exception:
             logger.exception("Unexpected error in job execution", run_id=run_id)

--- a/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
@@ -17,6 +17,7 @@ from aegra_api.core.orm import Assistant as AssistantORM
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.services.run_status import finalize_run
+from aegra_api.services.worker_executor import WorkerExecutor
 from aegra_api.settings import settings
 from tests.e2e._utils import elog
 
@@ -227,6 +228,7 @@ async def test_stale_worker_cannot_overwrite_reconciled_interruption() -> None:
                 finalized = await finalize_run(
                     run_id,
                     thread_id,
+                    user_id="anonymous",
                     status="success",
                     thread_status="idle",
                     output={"late": True},
@@ -238,6 +240,36 @@ async def test_stale_worker_cannot_overwrite_reconciled_interruption() -> None:
         assert finalized is False
         assert run.status == "interrupted"
         assert run.output is None
+        assert thread.status == "idle"
+
+
+@pytest.mark.e2e
+@pytest.mark.prod_only
+async def test_worker_timeout_cannot_overwrite_reconciled_interruption() -> None:
+    async with _seed_run(run_status="interrupted", thread_status="idle") as (thread_id, run_id):
+        engine = create_async_engine(settings.db.database_url)
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        executor = WorkerExecutor()
+        semaphore = asyncio.Semaphore(1)
+        await semaphore.acquire()
+
+        async def slow_execution(_run_id: str, _worker_name: str) -> None:
+            await asyncio.sleep(60)
+
+        try:
+            with (
+                patch.object(executor, "_execute_with_lease", side_effect=slow_execution),
+                patch("aegra_api.services.worker_executor.settings") as mock_settings,
+                patch("aegra_api.services.worker_executor._get_session_maker", return_value=maker),
+                patch("aegra_api.services.run_status._get_session_maker", return_value=maker),
+            ):
+                mock_settings.worker.BG_JOB_TIMEOUT_SECS = 0.01
+                await executor._execute_and_release(run_id, "delayed-worker", semaphore)
+        finally:
+            await engine.dispose()
+
+        run, thread = await _read_state(thread_id, run_id)
+        assert run.status == "interrupted"
         assert thread.status == "idle"
 
 

--- a/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 import httpx
@@ -18,6 +18,8 @@ from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.settings import settings
 from tests.e2e._utils import elog
 
+InterruptionEndpoint = Literal["cancel", "patch"]
+
 
 @asynccontextmanager
 async def _seed_run(
@@ -27,6 +29,7 @@ async def _seed_run(
     claimed_by: str | None = None,
     lease_expires_at: datetime | None = None,
     execution_params: dict[str, Any] | None = None,
+    additional_run_status: str | None = None,
 ) -> AsyncIterator[tuple[str, str]]:
     engine = create_async_engine(settings.db.database_url)
     maker = async_sessionmaker(engine, expire_on_commit=False)
@@ -76,17 +79,45 @@ async def _seed_run(
                 updated_at=now,
             )
         )
+        if additional_run_status is not None:
+            session.add(
+                RunORM(
+                    run_id=str(uuid4()),
+                    thread_id=thread_id,
+                    assistant_id=assistant_id,
+                    status=additional_run_status,
+                    input={},
+                    user_id="anonymous",
+                    execution_params=None,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
         await session.commit()
 
     try:
         yield thread_id, run_id
     finally:
         async with maker() as session:
-            await session.execute(delete(RunORM).where(RunORM.run_id == run_id))
+            await session.execute(delete(RunORM).where(RunORM.thread_id == thread_id))
             await session.execute(delete(ThreadORM).where(ThreadORM.thread_id == thread_id))
             await session.execute(delete(AssistantORM).where(AssistantORM.assistant_id == assistant_id))
             await session.commit()
         await engine.dispose()
+
+
+async def _request_interruption(
+    client: httpx.AsyncClient,
+    endpoint: InterruptionEndpoint,
+    thread_id: str,
+    run_id: str,
+) -> httpx.Response:
+    if endpoint == "cancel":
+        return await client.post(f"/threads/{thread_id}/runs/{run_id}/cancel")
+    return await client.patch(
+        f"/threads/{thread_id}/runs/{run_id}",
+        json={"run_id": run_id, "status": "interrupted"},
+    )
 
 
 async def _read_state(thread_id: str, run_id: str) -> tuple[RunORM, ThreadORM]:
@@ -106,7 +137,9 @@ async def _read_state(thread_id: str, run_id: str) -> tuple[RunORM, ThreadORM]:
 @pytest.mark.e2e
 @pytest.mark.prod_only
 @pytest.mark.parametrize("endpoint", ["cancel", "patch"])
-async def test_stale_owner_interruption_reconciles_run_thread_and_lease(endpoint: str) -> None:
+async def test_stale_owner_interruption_reconciles_run_thread_and_lease(
+    endpoint: InterruptionEndpoint,
+) -> None:
     expired = datetime.now(UTC) - timedelta(minutes=1)
     async with _seed_run(
         run_status="running",
@@ -115,13 +148,7 @@ async def test_stale_owner_interruption_reconciles_run_thread_and_lease(endpoint
         lease_expires_at=expired,
     ) as (thread_id, run_id):
         async with httpx.AsyncClient(base_url=settings.app.SERVER_URL, timeout=10.0) as client:
-            if endpoint == "cancel":
-                response = await client.post(f"/threads/{thread_id}/runs/{run_id}/cancel")
-            else:
-                response = await client.patch(
-                    f"/threads/{thread_id}/runs/{run_id}",
-                    json={"run_id": run_id, "status": "interrupted"},
-                )
+            response = await _request_interruption(client, endpoint, thread_id, run_id)
 
         response.raise_for_status()
         run, thread = await _read_state(thread_id, run_id)
@@ -140,16 +167,10 @@ async def test_stale_owner_interruption_reconciles_run_thread_and_lease(endpoint
 @pytest.mark.e2e
 @pytest.mark.prod_only
 @pytest.mark.parametrize("endpoint", ["cancel", "patch"])
-async def test_interruption_does_not_overwrite_terminal_run(endpoint: str) -> None:
+async def test_interruption_does_not_overwrite_terminal_run(endpoint: InterruptionEndpoint) -> None:
     async with _seed_run(run_status="success", thread_status="idle") as (thread_id, run_id):
         async with httpx.AsyncClient(base_url=settings.app.SERVER_URL, timeout=10.0) as client:
-            if endpoint == "cancel":
-                response = await client.post(f"/threads/{thread_id}/runs/{run_id}/cancel")
-            else:
-                response = await client.patch(
-                    f"/threads/{thread_id}/runs/{run_id}",
-                    json={"run_id": run_id, "status": "interrupted"},
-                )
+            response = await _request_interruption(client, endpoint, thread_id, run_id)
 
         response.raise_for_status()
         run, thread = await _read_state(thread_id, run_id)
@@ -161,6 +182,32 @@ async def test_interruption_does_not_overwrite_terminal_run(endpoint: str) -> No
         assert response.json()["status"] == "success"
         assert run.status == "success"
         assert thread.status == "idle"
+
+
+@pytest.mark.e2e
+@pytest.mark.prod_only
+@pytest.mark.parametrize("endpoint", ["cancel", "patch"])
+async def test_interruption_keeps_thread_busy_when_another_run_is_active(
+    endpoint: InterruptionEndpoint,
+) -> None:
+    async with _seed_run(
+        run_status="pending",
+        thread_status="busy",
+        additional_run_status="running",
+    ) as (thread_id, run_id):
+        async with httpx.AsyncClient(base_url=settings.app.SERVER_URL, timeout=10.0) as client:
+            response = await _request_interruption(client, endpoint, thread_id, run_id)
+
+        response.raise_for_status()
+        run, thread = await _read_state(thread_id, run_id)
+        elog(
+            "Concurrent-run interruption state",
+            {"endpoint": endpoint, "run_status": run.status, "thread_status": thread.status},
+        )
+
+        assert response.json()["status"] == "interrupted"
+        assert run.status == "interrupted"
+        assert thread.status == "busy"
 
 
 @pytest.mark.e2e

--- a/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
@@ -331,9 +331,9 @@ async def test_retry_exhaustion_marks_run_and_thread_error() -> None:
         execution_params={"_retry_count": settings.worker.BG_JOB_MAX_RETRIES},
     ) as (thread_id, run_id):
         deadline = asyncio.get_running_loop().time() + settings.worker.REAPER_INTERVAL_SECONDS * 2 + 5
-        while asyncio.get_running_loop().time() < deadline:
+        while True:
             run, thread = await _read_state(thread_id, run_id)
-            if run.status == "error":
+            if run.status == "error" or asyncio.get_running_loop().time() >= deadline:
                 break
             await asyncio.sleep(0.5)
 

--- a/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
+from unittest.mock import patch
 from uuid import uuid4
 
 import httpx
@@ -15,6 +16,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from aegra_api.core.orm import Assistant as AssistantORM
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.services.run_status import finalize_run
 from aegra_api.settings import settings
 from tests.e2e._utils import elog
 
@@ -134,6 +136,24 @@ async def _read_state(thread_id: str, run_id: str) -> tuple[RunORM, ThreadORM]:
         await engine.dispose()
 
 
+async def _wait_for_end_event(
+    thread_id: str,
+    run_id: str,
+    stream_started: asyncio.Event,
+) -> str:
+    timeout = httpx.Timeout(10.0, read=None)
+    async with (
+        httpx.AsyncClient(base_url=settings.app.SERVER_URL, timeout=timeout) as client,
+        client.stream("GET", f"/threads/{thread_id}/runs/{run_id}/stream") as response,
+    ):
+        response.raise_for_status()
+        stream_started.set()
+        async for line in response.aiter_lines():
+            if line.strip() == "event: end":
+                return "end"
+    return "closed"
+
+
 @pytest.mark.e2e
 @pytest.mark.prod_only
 @pytest.mark.parametrize("endpoint", ["cancel", "patch"])
@@ -161,6 +181,63 @@ async def test_stale_owner_interruption_reconciles_run_thread_and_lease(
         assert run.status == "interrupted"
         assert run.claimed_by is None
         assert run.lease_expires_at is None
+        assert thread.status == "idle"
+
+
+@pytest.mark.e2e
+@pytest.mark.prod_only
+async def test_stale_owner_interruption_closes_existing_stream() -> None:
+    expired = datetime.now(UTC) - timedelta(minutes=1)
+    async with _seed_run(
+        run_status="running",
+        thread_status="busy",
+        claimed_by="delayed-worker",
+        lease_expires_at=expired,
+    ) as (thread_id, run_id):
+        stream_started = asyncio.Event()
+        stream_task = asyncio.create_task(_wait_for_end_event(thread_id, run_id, stream_started))
+        await asyncio.wait_for(stream_started.wait(), timeout=5.0)
+        await asyncio.sleep(0.25)
+
+        async with httpx.AsyncClient(base_url=settings.app.SERVER_URL, timeout=10.0) as client:
+            response = await client.post(f"/threads/{thread_id}/runs/{run_id}/cancel")
+
+        response.raise_for_status()
+        assert await asyncio.wait_for(stream_task, timeout=5.0) == "end"
+
+
+@pytest.mark.e2e
+@pytest.mark.prod_only
+async def test_stale_worker_cannot_overwrite_reconciled_interruption() -> None:
+    expired = datetime.now(UTC) - timedelta(minutes=1)
+    async with _seed_run(
+        run_status="running",
+        thread_status="busy",
+        claimed_by="delayed-worker",
+        lease_expires_at=expired,
+    ) as (thread_id, run_id):
+        async with httpx.AsyncClient(base_url=settings.app.SERVER_URL, timeout=10.0) as client:
+            response = await client.post(f"/threads/{thread_id}/runs/{run_id}/cancel")
+        response.raise_for_status()
+
+        engine = create_async_engine(settings.db.database_url)
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        try:
+            with patch("aegra_api.services.run_status._get_session_maker", return_value=maker):
+                finalized = await finalize_run(
+                    run_id,
+                    thread_id,
+                    status="success",
+                    thread_status="idle",
+                    output={"late": True},
+                )
+        finally:
+            await engine.dispose()
+
+        run, thread = await _read_state(thread_id, run_id)
+        assert finalized is False
+        assert run.status == "interrupted"
+        assert run.output is None
         assert thread.status == "idle"
 
 

--- a/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
@@ -1,0 +1,188 @@
+"""End-to-end coverage for terminal run and thread reconciliation."""
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from aegra_api.core.orm import Assistant as AssistantORM
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.settings import settings
+from tests.e2e._utils import elog
+
+
+@asynccontextmanager
+async def _seed_run(
+    *,
+    run_status: str,
+    thread_status: str,
+    claimed_by: str | None = None,
+    lease_expires_at: datetime | None = None,
+    execution_params: dict[str, Any] | None = None,
+) -> AsyncIterator[tuple[str, str]]:
+    engine = create_async_engine(settings.db.database_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    assistant_id = str(uuid4())
+    thread_id = str(uuid4())
+    run_id = str(uuid4())
+    now = datetime.now(UTC)
+
+    async with maker() as session:
+        session.add(
+            AssistantORM(
+                assistant_id=assistant_id,
+                name="Run reconciliation test",
+                graph_id="stress_test",
+                config={"test_id": assistant_id},
+                context={},
+                user_id="anonymous",
+                metadata_dict={},
+                version=1,
+                created_at=now,
+            )
+        )
+        await session.flush()
+        session.add(
+            ThreadORM(
+                thread_id=thread_id,
+                status=thread_status,
+                user_id="anonymous",
+                metadata_json={},
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await session.flush()
+        session.add(
+            RunORM(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=assistant_id,
+                status=run_status,
+                input={},
+                user_id="anonymous",
+                execution_params=execution_params,
+                claimed_by=claimed_by,
+                lease_expires_at=lease_expires_at,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await session.commit()
+
+    try:
+        yield thread_id, run_id
+    finally:
+        async with maker() as session:
+            await session.execute(delete(RunORM).where(RunORM.run_id == run_id))
+            await session.execute(delete(ThreadORM).where(ThreadORM.thread_id == thread_id))
+            await session.execute(delete(AssistantORM).where(AssistantORM.assistant_id == assistant_id))
+            await session.commit()
+        await engine.dispose()
+
+
+async def _read_state(thread_id: str, run_id: str) -> tuple[RunORM, ThreadORM]:
+    engine = create_async_engine(settings.db.database_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with maker() as session:
+            run = await session.get(RunORM, run_id)
+            thread = await session.get(ThreadORM, thread_id)
+            assert run is not None
+            assert thread is not None
+            return run, thread
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.e2e
+@pytest.mark.prod_only
+@pytest.mark.parametrize("endpoint", ["cancel", "patch"])
+async def test_stale_owner_interruption_reconciles_run_thread_and_lease(endpoint: str) -> None:
+    expired = datetime.now(UTC) - timedelta(minutes=1)
+    async with _seed_run(
+        run_status="running",
+        thread_status="busy",
+        claimed_by="dead-worker",
+        lease_expires_at=expired,
+    ) as (thread_id, run_id):
+        async with httpx.AsyncClient(base_url=settings.app.SERVER_URL, timeout=10.0) as client:
+            if endpoint == "cancel":
+                response = await client.post(f"/threads/{thread_id}/runs/{run_id}/cancel")
+            else:
+                response = await client.patch(
+                    f"/threads/{thread_id}/runs/{run_id}",
+                    json={"run_id": run_id, "status": "interrupted"},
+                )
+
+        response.raise_for_status()
+        run, thread = await _read_state(thread_id, run_id)
+        elog(
+            "Stale-owner interruption state",
+            {"endpoint": endpoint, "run_status": run.status, "thread_status": thread.status},
+        )
+
+        assert response.json()["status"] == "interrupted"
+        assert run.status == "interrupted"
+        assert run.claimed_by is None
+        assert run.lease_expires_at is None
+        assert thread.status == "idle"
+
+
+@pytest.mark.e2e
+@pytest.mark.prod_only
+@pytest.mark.parametrize("endpoint", ["cancel", "patch"])
+async def test_interruption_does_not_overwrite_terminal_run(endpoint: str) -> None:
+    async with _seed_run(run_status="success", thread_status="idle") as (thread_id, run_id):
+        async with httpx.AsyncClient(base_url=settings.app.SERVER_URL, timeout=10.0) as client:
+            if endpoint == "cancel":
+                response = await client.post(f"/threads/{thread_id}/runs/{run_id}/cancel")
+            else:
+                response = await client.patch(
+                    f"/threads/{thread_id}/runs/{run_id}",
+                    json={"run_id": run_id, "status": "interrupted"},
+                )
+
+        response.raise_for_status()
+        run, thread = await _read_state(thread_id, run_id)
+        elog(
+            "Terminal interruption guard state",
+            {"endpoint": endpoint, "run_status": run.status, "thread_status": thread.status},
+        )
+
+        assert response.json()["status"] == "success"
+        assert run.status == "success"
+        assert thread.status == "idle"
+
+
+@pytest.mark.e2e
+@pytest.mark.prod_only
+async def test_retry_exhaustion_marks_run_and_thread_error() -> None:
+    expired = datetime.now(UTC) - timedelta(minutes=1)
+    async with _seed_run(
+        run_status="running",
+        thread_status="busy",
+        claimed_by="dead-worker",
+        lease_expires_at=expired,
+        execution_params={"_retry_count": settings.worker.BG_JOB_MAX_RETRIES},
+    ) as (thread_id, run_id):
+        deadline = asyncio.get_running_loop().time() + settings.worker.REAPER_INTERVAL_SECONDS * 2 + 5
+        while asyncio.get_running_loop().time() < deadline:
+            run, thread = await _read_state(thread_id, run_id)
+            if run.status == "error":
+                break
+            await asyncio.sleep(0.5)
+
+        elog("Retry exhaustion state", {"run_status": run.status, "thread_status": thread.status})
+        assert run.status == "error"
+        assert run.claimed_by is None
+        assert run.lease_expires_at is None
+        assert thread.status == "error"

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -338,11 +338,13 @@ class TestCancelRun:
             ),
         ):
             mock_streaming.cancel_run = AsyncMock()
+            mock_streaming.signal_run_cancelled = AsyncMock()
 
             resp = client.post("/threads/test-thread-123/runs/test-run-123/cancel")
 
             assert resp.status_code == 200
-            mock_streaming.cancel_run.assert_not_awaited()
+            mock_streaming.cancel_run.assert_awaited_once_with("test-run-123", emit_end_event=False)
+            mock_streaming.signal_run_cancelled.assert_awaited_once_with("test-run-123")
 
 
 class TestDeleteRun:

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -329,12 +329,20 @@ class TestCancelRun:
         override_session_dependency(app, Session)
         client = make_client(app)
 
-        with patch("aegra_api.api.runs.streaming_service") as mock_streaming:
+        with (
+            patch("aegra_api.api.runs.streaming_service") as mock_streaming,
+            patch(
+                "aegra_api.api.runs.interrupt_unowned_run",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
             mock_streaming.cancel_run = AsyncMock()
 
             resp = client.post("/threads/test-thread-123/runs/test-run-123/cancel")
 
             assert resp.status_code == 200
+            mock_streaming.cancel_run.assert_not_awaited()
 
 
 class TestDeleteRun:

--- a/libs/aegra-api/tests/integration/test_streaming_errors.py
+++ b/libs/aegra-api/tests/integration/test_streaming_errors.py
@@ -68,8 +68,8 @@ class TestStreamingErrorHandling:
                 "aegra_api.services.run_executor.stream_graph_events",
                 return_value=failing_stream(),
             ),
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
-            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.start_run", new_callable=AsyncMock, return_value=True),
+            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock, return_value=True),
         ):
             mock_lg_service.return_value.get_graph.return_value.__aenter__ = AsyncMock(return_value=mock_graph)
             mock_lg_service.return_value.get_graph.return_value.__aexit__ = AsyncMock(return_value=None)
@@ -134,8 +134,8 @@ class TestStreamingErrorHandling:
                 "aegra_api.services.run_executor.stream_graph_events",
                 return_value=failing_stream(),
             ),
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
-            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.start_run", new_callable=AsyncMock, return_value=True),
+            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock, return_value=True),
         ):
             mock_graph = MagicMock()
             mock_lg_service.return_value.get_graph.return_value.__aenter__ = AsyncMock(return_value=mock_graph)
@@ -183,8 +183,8 @@ class TestStreamingErrorHandling:
             patch(
                 "aegra_api.services.run_executor.stream_graph_events",
             ) as mock_stream_graph,
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
-            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.start_run", new_callable=AsyncMock, return_value=True),
+            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock, return_value=True),
         ):
             # Set up the mock to return the async generator
             mock_stream_graph.return_value = failing_stream()
@@ -243,8 +243,8 @@ class TestStreamingErrorHandling:
                 "aegra_api.services.run_executor.stream_graph_events",
                 return_value=failing_stream(),
             ),
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
-            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.start_run", new_callable=AsyncMock, return_value=True),
+            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock, return_value=True),
         ):
             mock_graph = MagicMock()
             mock_lg_service.return_value.get_graph.return_value.__aenter__ = AsyncMock(return_value=mock_graph)

--- a/libs/aegra-api/tests/unit/test_api/test_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs.py
@@ -84,7 +84,10 @@ class TestRunsEndpoints:
             patch("aegra_api.services.run_preparation.update_thread_metadata", new_callable=AsyncMock),
             patch("aegra_api.services.run_preparation.set_thread_status", new_callable=AsyncMock),
             patch("aegra_api.services.run_preparation.uuid4", return_value=run_id),
-            patch("aegra_api.api.runs.asyncio.create_task") as mock_create_task,
+            patch(
+                "aegra_api.services.run_preparation.executor.submit",
+                new_callable=AsyncMock,
+            ) as mock_submit,
             patch("aegra_api.api.runs.active_runs", {}),
         ):
             mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
@@ -105,8 +108,8 @@ class TestRunsEndpoints:
             mock_session.add.assert_called_once()
             mock_session.commit.assert_called_once()
 
-            # Verify background task creation
-            mock_create_task.assert_called_once()
+            # Verify background execution submission
+            mock_submit.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_create_run_assistant_not_found(
@@ -383,6 +386,40 @@ class TestRunsEndpoints:
         mock_signal.assert_awaited_once_with(run_orm.run_id)
 
     @pytest.mark.asyncio
+    async def test_reconciled_interrupt_uses_cooperative_stop(
+        self,
+        mock_session: AsyncMock,
+    ) -> None:
+        run_orm = RunORM(
+            run_id="run-123",
+            thread_id="test-thread",
+            assistant_id="agent",
+            user_id="test-user",
+            status="pending",
+            input={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+        with (
+            patch("aegra_api.api.runs.interrupt_unowned_run", new_callable=AsyncMock, return_value=True),
+            patch("aegra_api.api.runs.streaming_service.cancel_run", new_callable=AsyncMock) as mock_cancel,
+            patch(
+                "aegra_api.api.runs.streaming_service.interrupt_run",
+                new_callable=AsyncMock,
+            ) as mock_interrupt,
+            patch(
+                "aegra_api.api.runs.streaming_service.signal_run_cancelled",
+                new_callable=AsyncMock,
+            ) as mock_signal,
+        ):
+            await _request_run_interruption(mock_session, run_orm, "interrupt")
+
+        mock_interrupt.assert_awaited_once_with(run_orm.run_id, emit_end_event=False)
+        mock_cancel.assert_not_awaited()
+        mock_signal.assert_awaited_once_with(run_orm.run_id)
+
+    @pytest.mark.asyncio
     async def test_reconciled_interruption_survives_terminal_signal_outage(
         self,
         mock_session: AsyncMock,
@@ -400,14 +437,20 @@ class TestRunsEndpoints:
 
         with (
             patch("aegra_api.api.runs.interrupt_unowned_run", new_callable=AsyncMock, return_value=True),
-            patch("aegra_api.api.runs.streaming_service.cancel_run", new_callable=AsyncMock),
+            patch(
+                "aegra_api.api.runs.streaming_service.cancel_run",
+                new_callable=AsyncMock,
+            ) as mock_cancel,
             patch(
                 "aegra_api.api.runs.streaming_service.signal_run_cancelled",
                 new_callable=AsyncMock,
                 side_effect=RedisError("unavailable"),
-            ),
+            ) as mock_signal,
         ):
             await _request_run_interruption(mock_session, run_orm, "cancel")
+
+        mock_cancel.assert_awaited_once_with(run_orm.run_id, emit_end_event=False)
+        mock_signal.assert_awaited_once_with(run_orm.run_id)
 
     @pytest.mark.asyncio
     async def test_update_run_not_found(self, mock_user: User, mock_session: AsyncMock) -> None:

--- a/libs/aegra-api/tests/unit/test_api/test_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs.py
@@ -342,7 +342,7 @@ class TestRunsEndpoints:
         mock_interrupt.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_interruption_reconciles_registered_task_before_it_starts(
+    async def test_interruption_reconciles_unowned_run_before_it_starts(
         self,
         mock_session: AsyncMock,
     ) -> None:
@@ -356,11 +356,7 @@ class TestRunsEndpoints:
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
         )
-        registered_task = MagicMock()
-        registered_task.done.return_value = False
-
         with (
-            patch.dict("aegra_api.api.runs.active_runs", {run_orm.run_id: registered_task}, clear=True),
             patch(
                 "aegra_api.api.runs.interrupt_unowned_run",
                 new_callable=AsyncMock,

--- a/libs/aegra-api/tests/unit/test_api/test_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs.py
@@ -270,13 +270,19 @@ class TestRunsEndpoints:
             updated_at=datetime.now(UTC),
         )
 
-        # scalar called twice: first to find for update, second to return
-        mock_session.scalar.side_effect = [run_orm, run_orm]
+        mock_session.scalar.return_value = run_orm
 
-        with patch(
-            "aegra_api.api.runs.streaming_service.interrupt_run",
-            new_callable=AsyncMock,
-        ) as mock_interrupt:
+        with (
+            patch(
+                "aegra_api.api.runs.interrupt_unowned_run",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as mock_reconcile,
+            patch(
+                "aegra_api.api.runs.streaming_service.interrupt_run",
+                new_callable=AsyncMock,
+            ) as mock_interrupt,
+        ):
             result = await update_run(
                 thread_id,
                 run_id,
@@ -285,10 +291,46 @@ class TestRunsEndpoints:
                 mock_session,
             )
 
+            mock_reconcile.assert_awaited_once_with(mock_session, run_id, thread_id)
             mock_interrupt.assert_called_once_with(run_id)
-            mock_session.execute.assert_called_once()  # Update statement
-            mock_session.commit.assert_called_once()
+            mock_session.execute.assert_not_awaited()
+            mock_session.commit.assert_not_awaited()
             assert result.run_id == run_id
+
+    @pytest.mark.asyncio
+    async def test_update_run_does_not_overwrite_terminal_status(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+    ) -> None:
+        """A late interrupt request must leave a completed run unchanged."""
+        run_orm = RunORM(
+            run_id="run-123",
+            thread_id="test-thread",
+            assistant_id="agent",
+            user_id=mock_user.identity,
+            status="success",
+            input={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        mock_session.scalar.return_value = run_orm
+
+        with (
+            patch("aegra_api.api.runs.interrupt_unowned_run", new_callable=AsyncMock) as mock_reconcile,
+            patch("aegra_api.api.runs.streaming_service.interrupt_run", new_callable=AsyncMock) as mock_interrupt,
+        ):
+            result = await update_run(
+                "test-thread",
+                "run-123",
+                RunStatus(run_id="run-123", status="interrupted"),
+                mock_user,
+                mock_session,
+            )
+
+        assert result.status == "success"
+        mock_reconcile.assert_not_awaited()
+        mock_interrupt.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_update_run_not_found(self, mock_user: User, mock_session: AsyncMock) -> None:

--- a/libs/aegra-api/tests/unit/test_api/test_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs.py
@@ -6,8 +6,17 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+from redis import RedisError
 
-from aegra_api.api.runs import _apply_create_run_auth, create_run, get_run, join_run, list_runs, update_run
+from aegra_api.api.runs import (
+    _apply_create_run_auth,
+    _request_run_interruption,
+    create_run,
+    get_run,
+    join_run,
+    list_runs,
+    update_run,
+)
 from aegra_api.core.orm import Assistant as AssistantORM
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
@@ -331,6 +340,78 @@ class TestRunsEndpoints:
         assert result.status == "success"
         mock_reconcile.assert_not_awaited()
         mock_interrupt.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_interruption_reconciles_registered_task_before_it_starts(
+        self,
+        mock_session: AsyncMock,
+    ) -> None:
+        run_orm = RunORM(
+            run_id="run-123",
+            thread_id="test-thread",
+            assistant_id="agent",
+            user_id="test-user",
+            status="pending",
+            input={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        registered_task = MagicMock()
+        registered_task.done.return_value = False
+
+        with (
+            patch.dict("aegra_api.api.runs.active_runs", {run_orm.run_id: registered_task}, clear=True),
+            patch(
+                "aegra_api.api.runs.interrupt_unowned_run",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_reconcile,
+            patch(
+                "aegra_api.api.runs.streaming_service.cancel_run",
+                new_callable=AsyncMock,
+            ) as mock_cancel,
+            patch(
+                "aegra_api.api.runs.streaming_service.signal_run_cancelled",
+                new_callable=AsyncMock,
+            ) as mock_signal,
+        ):
+            await _request_run_interruption(mock_session, run_orm, "cancel")
+
+        mock_reconcile.assert_awaited_once_with(
+            mock_session,
+            run_orm.run_id,
+            run_orm.thread_id,
+            user_id=run_orm.user_id,
+        )
+        mock_cancel.assert_awaited_once_with(run_orm.run_id, emit_end_event=False)
+        mock_signal.assert_awaited_once_with(run_orm.run_id)
+
+    @pytest.mark.asyncio
+    async def test_reconciled_interruption_survives_terminal_signal_outage(
+        self,
+        mock_session: AsyncMock,
+    ) -> None:
+        run_orm = RunORM(
+            run_id="run-123",
+            thread_id="test-thread",
+            assistant_id="agent",
+            user_id="test-user",
+            status="pending",
+            input={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+        with (
+            patch("aegra_api.api.runs.interrupt_unowned_run", new_callable=AsyncMock, return_value=True),
+            patch("aegra_api.api.runs.streaming_service.cancel_run", new_callable=AsyncMock),
+            patch(
+                "aegra_api.api.runs.streaming_service.signal_run_cancelled",
+                new_callable=AsyncMock,
+                side_effect=RedisError("unavailable"),
+            ),
+        ):
+            await _request_run_interruption(mock_session, run_orm, "cancel")
 
     @pytest.mark.asyncio
     async def test_update_run_not_found(self, mock_user: User, mock_session: AsyncMock) -> None:

--- a/libs/aegra-api/tests/unit/test_api/test_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs.py
@@ -291,7 +291,7 @@ class TestRunsEndpoints:
                 mock_session,
             )
 
-            mock_reconcile.assert_awaited_once_with(mock_session, run_id, thread_id)
+            mock_reconcile.assert_awaited_once_with(mock_session, run_id, thread_id, user_id=mock_user.identity)
             mock_interrupt.assert_called_once_with(run_id)
             mock_session.execute.assert_not_awaited()
             mock_session.commit.assert_not_awaited()

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -464,8 +464,8 @@ class TestRunsStreamingEndpoints:
                 "aegra_api.services.run_executor.stream_graph_events",
                 return_value=failing_stream(),
             ),
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
-            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.start_run", new_callable=AsyncMock, return_value=True),
+            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock, return_value=True),
         ):
             mock_graph = MagicMock()
             mock_lg_service.return_value.get_graph.return_value.__aenter__ = AsyncMock(return_value=mock_graph)

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -79,7 +79,10 @@ class TestRunsStreamingEndpoints:
             patch("aegra_api.services.run_preparation.update_thread_metadata", new_callable=AsyncMock),
             patch("aegra_api.services.run_preparation.set_thread_status", new_callable=AsyncMock),
             patch("aegra_api.services.run_preparation.uuid4", return_value=run_id),
-            patch("aegra_api.api.runs.asyncio.create_task") as mock_create_task,
+            patch(
+                "aegra_api.services.run_preparation.executor.submit",
+                new_callable=AsyncMock,
+            ) as mock_submit,
             patch("aegra_api.api.runs.active_runs", {}),
             patch("aegra_api.api.runs.streaming_service.stream_run_execution") as mock_stream_exec,
             patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
@@ -109,8 +112,8 @@ class TestRunsStreamingEndpoints:
             mock_session.add.assert_called_once()
             mock_session.commit.assert_called_once()
 
-            # Verify background task creation
-            mock_create_task.assert_called_once()
+            # Verify background execution submission
+            mock_submit.assert_awaited_once()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -158,7 +161,10 @@ class TestRunsStreamingEndpoints:
             patch("aegra_api.services.run_preparation.update_thread_metadata", new_callable=AsyncMock),
             patch("aegra_api.services.run_preparation.set_thread_status", new_callable=AsyncMock),
             patch("aegra_api.services.run_preparation.uuid4", return_value=run_id),
-            patch("aegra_api.api.runs.asyncio.create_task"),
+            patch(
+                "aegra_api.services.run_preparation.executor.submit",
+                new_callable=AsyncMock,
+            ),
             patch("aegra_api.api.runs.active_runs", {}),
             patch("aegra_api.api.runs.streaming_service.stream_run_execution", return_value=_fake_stream()),
             patch("aegra_api.api.runs.broker_manager.request_cancel", new_callable=AsyncMock) as mock_cancel,
@@ -209,7 +215,10 @@ class TestRunsStreamingEndpoints:
             patch("aegra_api.services.run_preparation.update_thread_metadata", new_callable=AsyncMock),
             patch("aegra_api.services.run_preparation.set_thread_status", new_callable=AsyncMock),
             patch("aegra_api.services.run_preparation.uuid4", return_value=run_id),
-            patch("aegra_api.api.runs.asyncio.create_task"),
+            patch(
+                "aegra_api.services.run_preparation.executor.submit",
+                new_callable=AsyncMock,
+            ),
             patch("aegra_api.api.runs.active_runs", {}),
             patch("aegra_api.api.runs.streaming_service.stream_run_execution", return_value=_fake_stream()),
             patch(

--- a/libs/aegra-api/tests/unit/test_services/test_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_executor.py
@@ -111,8 +111,8 @@ class TestRunExecutorBoundaryConditions:
 
         with (
             patch("aegra_api.services.run_executor.get_langgraph_service", return_value=mock_service),
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
-            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.start_run", new_callable=AsyncMock, return_value=True),
+            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock, return_value=True),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor.stream_graph_events", return_value=_empty_async_gen()),
         ):

--- a/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
@@ -107,6 +107,35 @@ class TestRecoverCrashedRuns:
         assert exhausted == []
         session.commit.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_skips_run_when_guarded_transition_loses_race(self) -> None:
+        session = AsyncMock()
+        locked = MagicMock()
+        locked.fetchall.return_value = [
+            ("run-1", "thread-1", "user-1", {"_retry_count": 1}),
+        ]
+        unchanged = MagicMock()
+        unchanged.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(side_effect=[locked, unchanged])
+        session.commit = AsyncMock()
+        maker = _make_session_maker(session)
+
+        with (
+            patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker),
+            patch("aegra_api.services.lease_reaper.settings") as mock_settings,
+            patch(
+                "aegra_api.services.lease_reaper.set_thread_status_if_no_active_runs",
+                new_callable=AsyncMock,
+            ) as mock_set_thread,
+        ):
+            mock_settings.worker.BG_JOB_MAX_RETRIES = 1
+            retryable, exhausted = await LeaseReaper._recover_crashed_runs(["run-1"])
+
+        assert retryable == []
+        assert exhausted == []
+        mock_set_thread.assert_not_awaited()
+        session.commit.assert_awaited_once()
+
 
 class TestReenqueue:
     @pytest.mark.asyncio

--- a/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
@@ -158,16 +158,22 @@ class TestMarkPermanentlyFailed:
         """A run deleted between retry check and update must not count as failed."""
         session = AsyncMock()
         mock_result = MagicMock()
-        mock_result.fetchall.return_value = [("run-1", "thread-1")]
+        mock_result.fetchall.return_value = [("run-1", "thread-1", "user-1")]
         session.execute = AsyncMock(return_value=mock_result)
         session.commit = AsyncMock()
         maker = _make_session_maker(session)
 
-        with patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker):
+        with (
+            patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker),
+            patch(
+                "aegra_api.services.lease_reaper.set_thread_status_if_no_active_runs",
+                new_callable=AsyncMock,
+            ) as mock_set_thread,
+        ):
             failed = await LeaseReaper._mark_permanently_failed(["run-1", "run-gone"])
 
         assert failed == ["run-1"]
-        assert session.execute.await_count == 2
+        mock_set_thread.assert_awaited_once_with(session, {"thread-1"}, "error", user_id="user-1")
         session.commit.assert_awaited_once()
 
 

--- a/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
@@ -55,36 +55,57 @@ class TestFindRecoverable:
         assert stuck == []
 
 
-class TestResetToPending:
+class TestRecoverCrashedRuns:
     @pytest.mark.asyncio
-    async def test_returns_actually_reset_ids(self) -> None:
+    async def test_classifies_and_transitions_under_one_transaction(self) -> None:
         session = AsyncMock()
-        mock_result = MagicMock()
-        # Only run-1 was actually reset (run-2 may have been claimed by another worker)
-        mock_result.fetchall.return_value = [("run-1",)]
-        session.execute = AsyncMock(return_value=mock_result)
+        locked = MagicMock()
+        locked.fetchall.return_value = [
+            ("run-1", "thread-1", "user-1", {"_retry_count": 0}),
+            ("run-2", "thread-2", "user-2", {"_retry_count": 1}),
+        ]
+        updated_run_1 = MagicMock()
+        updated_run_1.scalar_one_or_none.return_value = "run-1"
+        updated_run_2 = MagicMock()
+        updated_run_2.scalar_one_or_none.return_value = "run-2"
+        session.execute = AsyncMock(side_effect=[locked, updated_run_1, updated_run_2])
         session.commit = AsyncMock()
         maker = _make_session_maker(session)
 
-        with patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker):
-            result = await LeaseReaper._reset_to_pending(["run-1", "run-2"])
+        with (
+            patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker),
+            patch("aegra_api.services.lease_reaper.settings") as mock_settings,
+            patch(
+                "aegra_api.services.lease_reaper.set_thread_status_if_no_active_runs",
+                new_callable=AsyncMock,
+            ) as mock_set_thread,
+        ):
+            mock_settings.worker.BG_JOB_MAX_RETRIES = 1
+            retryable, exhausted = await LeaseReaper._recover_crashed_runs(["run-1", "run-2"])
 
-        assert result == ["run-1"]
+        assert retryable == ["run-1"]
+        assert exhausted == ["run-2"]
+        for call in session.execute.await_args_list[1:]:
+            compiled = call.args[0].compile()
+            assert "runs.user_id" in str(compiled)
+        mock_set_thread.assert_awaited_once_with(session, {"thread-2"}, "error", user_id="user-2")
         session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_returns_empty_when_none_reset(self) -> None:
+    async def test_returns_empty_when_rows_are_no_longer_expired(self) -> None:
         session = AsyncMock()
-        mock_result = MagicMock()
-        mock_result.fetchall.return_value = []
-        session.execute = AsyncMock(return_value=mock_result)
+        locked = MagicMock()
+        locked.fetchall.return_value = []
+        session.execute = AsyncMock(return_value=locked)
         session.commit = AsyncMock()
         maker = _make_session_maker(session)
 
         with patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker):
-            result = await LeaseReaper._reset_to_pending(["run-1"])
+            retryable, exhausted = await LeaseReaper._recover_crashed_runs(["run-1"])
 
-        assert result == []
+        assert retryable == []
+        assert exhausted == []
+        session.commit.assert_awaited_once()
 
 
 class TestReenqueue:
@@ -152,35 +173,9 @@ class TestReenqueue:
         assert pushed == []
 
 
-class TestMarkPermanentlyFailed:
-    @pytest.mark.asyncio
-    async def test_returns_only_ids_actually_updated(self) -> None:
-        """A run deleted between retry check and update must not count as failed."""
-        session = AsyncMock()
-        mock_result = MagicMock()
-        mock_result.fetchall.return_value = [("run-1", "thread-1", "user-1")]
-        session.execute = AsyncMock(return_value=mock_result)
-        session.commit = AsyncMock()
-        maker = _make_session_maker(session)
-
-        with (
-            patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker),
-            patch(
-                "aegra_api.services.lease_reaper.set_thread_status_if_no_active_runs",
-                new_callable=AsyncMock,
-            ) as mock_set_thread,
-        ):
-            failed = await LeaseReaper._mark_permanently_failed(["run-1", "run-gone"])
-
-        assert failed == ["run-1"]
-        mock_set_thread.assert_awaited_once_with(session, {"thread-1"}, "error", user_id="user-1")
-        session.commit.assert_awaited_once()
-
-
 class TestReap:
     @pytest.mark.asyncio
-    async def test_crashed_runs_reset_before_retry_check(self) -> None:
-        """Reset claims ownership atomically, then retry check runs on claimed set only."""
+    async def test_crashed_runs_are_classified_before_becoming_claimable(self) -> None:
         reaper = LeaseReaper()
 
         with (
@@ -188,24 +183,14 @@ class TestReap:
                 LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=(["run-1", "run-2"], [])
             ),
             patch.object(
-                LeaseReaper, "_reset_to_pending", new_callable=AsyncMock, return_value=["run-1", "run-2"]
-            ) as mock_reset,
-            patch.object(
-                LeaseReaper, "_check_retry_limits", new_callable=AsyncMock, return_value=(["run-1"], ["run-2"])
-            ) as mock_retry,
+                LeaseReaper, "_recover_crashed_runs", new_callable=AsyncMock, return_value=(["run-1"], ["run-2"])
+            ) as mock_recover,
             patch.object(LeaseReaper, "_reenqueue", new_callable=AsyncMock, return_value=["run-1"]) as mock_reenqueue,
-            patch.object(
-                LeaseReaper, "_mark_permanently_failed", new_callable=AsyncMock, return_value=["run-2"]
-            ) as mock_fail,
         ):
             await reaper._reap()
 
-        # Reset called with ALL crashed (atomic ownership claim)
-        mock_reset.assert_awaited_once_with(["run-1", "run-2"])
-        # Retry check only runs on actually_reset set
-        mock_retry.assert_awaited_once_with(["run-1", "run-2"])
+        mock_recover.assert_awaited_once_with(["run-1", "run-2"])
         mock_reenqueue.assert_awaited_once_with(["run-1"])
-        mock_fail.assert_awaited_once_with(["run-2"])
 
     @pytest.mark.asyncio
     async def test_stuck_pending_reenqueued_without_retry_charge(self) -> None:
@@ -214,12 +199,12 @@ class TestReap:
 
         with (
             patch.object(LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=([], ["run-3"])),
-            patch.object(LeaseReaper, "_check_retry_limits", new_callable=AsyncMock) as mock_retry,
+            patch.object(LeaseReaper, "_recover_crashed_runs", new_callable=AsyncMock) as mock_recover,
             patch.object(LeaseReaper, "_reenqueue", new_callable=AsyncMock, return_value=["run-3"]) as mock_reenqueue,
         ):
             await reaper._reap()
 
-        mock_retry.assert_not_awaited()
+        mock_recover.assert_not_awaited()
         mock_reenqueue.assert_awaited_once_with(["run-3"])
 
     @pytest.mark.asyncio
@@ -228,12 +213,12 @@ class TestReap:
 
         with (
             patch.object(LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=([], [])),
-            patch.object(LeaseReaper, "_reset_to_pending", new_callable=AsyncMock) as mock_reset,
+            patch.object(LeaseReaper, "_recover_crashed_runs", new_callable=AsyncMock) as mock_recover,
             patch.object(LeaseReaper, "_reenqueue", new_callable=AsyncMock) as mock_reenqueue,
         ):
             await reaper._reap()
 
-        mock_reset.assert_not_awaited()
+        mock_recover.assert_not_awaited()
         mock_reenqueue.assert_not_awaited()
 
 
@@ -249,12 +234,10 @@ class TestReapMetrics:
             patch.object(
                 LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=(["run-1", "run-2"], [])
             ),
-            patch.object(LeaseReaper, "_reset_to_pending", new_callable=AsyncMock, return_value=["run-1", "run-2"]),
             patch.object(
-                LeaseReaper, "_check_retry_limits", new_callable=AsyncMock, return_value=(["run-1"], ["run-2"])
+                LeaseReaper, "_recover_crashed_runs", new_callable=AsyncMock, return_value=(["run-1"], ["run-2"])
             ),
             patch.object(LeaseReaper, "_reenqueue", new_callable=AsyncMock, return_value=["run-1"]),
-            patch.object(LeaseReaper, "_mark_permanently_failed", new_callable=AsyncMock, return_value=["run-2"]),
         ):
             await reaper._reap()
 
@@ -295,12 +278,13 @@ class TestReapMetrics:
 
         with (
             patch.object(LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=(["run-1"], [])),
-            patch.object(LeaseReaper, "_reset_to_pending", new_callable=AsyncMock, return_value=[]),
-            patch.object(LeaseReaper, "_check_retry_limits", new_callable=AsyncMock) as mock_retry,
+            patch.object(
+                LeaseReaper, "_recover_crashed_runs", new_callable=AsyncMock, return_value=([], [])
+            ) as mock_recover,
         ):
             await reaper._reap()
 
-        mock_retry.assert_not_awaited()
+        mock_recover.assert_awaited_once_with(["run-1"])
         assert _recovered_count("crashed_retried") == before
 
     @pytest.mark.asyncio
@@ -327,9 +311,8 @@ class TestReapMetrics:
             patch.object(
                 LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=(["run-1", "run-2"], [])
             ),
-            patch.object(LeaseReaper, "_reset_to_pending", new_callable=AsyncMock, return_value=["run-1", "run-2"]),
             patch.object(
-                LeaseReaper, "_check_retry_limits", new_callable=AsyncMock, return_value=(["run-1", "run-2"], [])
+                LeaseReaper, "_recover_crashed_runs", new_callable=AsyncMock, return_value=(["run-1", "run-2"], [])
             ),
             patch.object(LeaseReaper, "_reenqueue", new_callable=AsyncMock, return_value=["run-1"]),
         ):
@@ -338,16 +321,13 @@ class TestReapMetrics:
         assert _recovered_count("crashed_retried") == before + 1
 
     @pytest.mark.asyncio
-    async def test_crashed_exhausted_counts_only_rows_actually_updated(self) -> None:
-        """A run deleted before the failed-update lands must not count as exhausted."""
+    async def test_crashed_exhausted_counts_only_rows_atomically_failed(self) -> None:
         reaper = LeaseReaper()
         before = _recovered_count("crashed_exhausted")
 
         with (
             patch.object(LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=(["run-1"], [])),
-            patch.object(LeaseReaper, "_reset_to_pending", new_callable=AsyncMock, return_value=["run-1"]),
-            patch.object(LeaseReaper, "_check_retry_limits", new_callable=AsyncMock, return_value=([], ["run-1"])),
-            patch.object(LeaseReaper, "_mark_permanently_failed", new_callable=AsyncMock, return_value=[]),
+            patch.object(LeaseReaper, "_recover_crashed_runs", new_callable=AsyncMock, return_value=([], [])),
         ):
             await reaper._reap()
 

--- a/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
@@ -158,7 +158,7 @@ class TestMarkPermanentlyFailed:
         """A run deleted between retry check and update must not count as failed."""
         session = AsyncMock()
         mock_result = MagicMock()
-        mock_result.fetchall.return_value = [("run-1",)]
+        mock_result.fetchall.return_value = [("run-1", "thread-1")]
         session.execute = AsyncMock(return_value=mock_result)
         session.commit = AsyncMock()
         maker = _make_session_maker(session)
@@ -167,6 +167,7 @@ class TestMarkPermanentlyFailed:
             failed = await LeaseReaper._mark_permanently_failed(["run-1", "run-gone"])
 
         assert failed == ["run-1"]
+        assert session.execute.await_count == 2
         session.commit.assert_awaited_once()
 
 

--- a/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
@@ -690,7 +690,7 @@ class TestRedisBrokerManager:
             channel, message = mock_client.publish.call_args[0]
             assert channel == "aegra:run:cancel"
             payload = json.loads(message)
-            assert payload == {"run_id": "run-123", "action": "cancel"}
+            assert payload == {"run_id": "run-123", "action": "cancel", "emit_end_event": True}
 
     @pytest.mark.asyncio
     async def test_request_cancel_falls_back_on_redis_error(self) -> None:
@@ -707,7 +707,7 @@ class TestRedisBrokerManager:
 
             await manager.request_cancel("run-123", "cancel")
 
-            mock_exec.assert_awaited_once_with("run-123")
+            mock_exec.assert_awaited_once_with("run-123", emit_end_event=True)
 
     @pytest.mark.asyncio
     async def test_execute_cancel_cancels_local_task(self) -> None:
@@ -722,6 +722,7 @@ class TestRedisBrokerManager:
 
         with (
             patch.dict("aegra_api.core.active_runs.active_runs", {"run-123": mock_task}, clear=True),
+            patch("aegra_api.services.redis_broker.explicit_run_cancellations", set()) as cancellations,
             patch.object(manager, "get_or_create_broker", return_value=mock_broker),
             patch.object(manager, "allocate_event_id", new_callable=AsyncMock, return_value="run-123_event_6"),
         ):
@@ -729,6 +730,26 @@ class TestRedisBrokerManager:
 
             mock_task.cancel.assert_called_once()
             mock_broker.put.assert_awaited_once()
+            assert cancellations == {"run-123"}
+
+    @pytest.mark.asyncio
+    async def test_execute_cancel_can_leave_terminal_signaling_to_api(self) -> None:
+        manager = self._make_manager()
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        mock_broker = MagicMock()
+        mock_broker.put = AsyncMock()
+
+        with (
+            patch.dict("aegra_api.core.active_runs.active_runs", {"run-123": mock_task}, clear=True),
+            patch("aegra_api.services.redis_broker.explicit_run_cancellations", set()) as cancellations,
+            patch.object(manager, "get_or_create_broker", return_value=mock_broker),
+        ):
+            await manager._execute_cancel("run-123", emit_end_event=False)
+
+        mock_task.cancel.assert_called_once()
+        mock_broker.put.assert_not_awaited()
+        assert cancellations == {"run-123"}
 
     @pytest.mark.asyncio
     async def test_execute_cancel_ignores_missing_task(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_run_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_executor.py
@@ -7,6 +7,16 @@ import pytest
 
 from aegra_api.models.auth import User
 from aegra_api.models.run_job import RunExecution, RunIdentity, RunJob
+from aegra_api.services import run_executor as run_executor_module
+from aegra_api.services.run_executor import (
+    _GraphResult,
+    _lease_loss_cancellations,
+    _signal_end_event,
+    _signal_run_done,
+    _stream_native_v2,
+    _timeout_cancellations,
+    execute_run,
+)
 
 
 async def _empty_async_gen():  # type: ignore[no-untyped-def]
@@ -57,11 +67,9 @@ class TestExecuteRunSuccess:
             mock_auth.return_value = mock_auth_ctx
             mock_streaming.cleanup_run = AsyncMock()
 
-            from aegra_api.services.run_executor import execute_run
-
             await execute_run(_make_job())
 
-        mock_start.assert_awaited_once_with("run-1")
+        mock_start.assert_awaited_once_with("run-1", user_id="user-1")
 
         # finalize_run called once for success
         mock_finalize.assert_awaited_once()
@@ -90,16 +98,54 @@ class TestExecuteRunCancelledError:
             mock_streaming.signal_run_cancelled = AsyncMock()
             mock_streaming.cleanup_run = AsyncMock()
 
-            from aegra_api.services.run_executor import execute_run
-
             with pytest.raises(asyncio.CancelledError):
                 await execute_run(_make_job())
 
-        mock_start.assert_awaited_once_with("run-1")
+        mock_start.assert_awaited_once_with("run-1", user_id="user-1")
         # finalize_run called for "interrupted"
         mock_finalize.assert_awaited_once()
         assert mock_finalize.await_args.kwargs["status"] == "interrupted"
+        assert mock_finalize.await_args.kwargs["user_id"] == "user-1"
         mock_streaming.signal_run_cancelled.assert_awaited_once_with("run-1")
+
+    @pytest.mark.asyncio
+    async def test_timeout_cancel_sets_error_and_signals(self) -> None:
+        mock_finalize = AsyncMock(return_value=True)
+
+        with (
+            patch("aegra_api.services.run_executor.start_run", new_callable=AsyncMock, return_value=True),
+            patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
+            patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
+            patch("aegra_api.services.run_executor._signal_run_done", new_callable=AsyncMock),
+            patch(
+                "aegra_api.services.run_executor._stream_graph",
+                new_callable=AsyncMock,
+                side_effect=asyncio.CancelledError,
+            ),
+        ):
+            mock_streaming.signal_run_error = AsyncMock()
+            mock_streaming.cleanup_run = AsyncMock()
+            _timeout_cancellations.add("run-1")
+            try:
+                with pytest.raises(asyncio.CancelledError):
+                    await execute_run(_make_job())
+            finally:
+                _timeout_cancellations.discard("run-1")
+
+        mock_finalize.assert_awaited_once_with(
+            "run-1",
+            "thread-1",
+            user_id="user-1",
+            status="error",
+            thread_status="error",
+            output={},
+            error="Job exceeded maximum execution time",
+        )
+        mock_streaming.signal_run_error.assert_awaited_once_with(
+            "run-1",
+            "TimeoutError: execution failed",
+            "TimeoutError",
+        )
 
 
 class TestExecuteRunException:
@@ -122,15 +168,14 @@ class TestExecuteRunException:
             mock_streaming.signal_run_error = AsyncMock()
             mock_streaming.cleanup_run = AsyncMock()
 
-            from aegra_api.services.run_executor import execute_run
-
             await execute_run(_make_job())
 
-        mock_start.assert_awaited_once_with("run-1")
+        mock_start.assert_awaited_once_with("run-1", user_id="user-1")
         # finalize_run called for "error"
         mock_finalize.assert_awaited_once()
         assert mock_finalize.await_args.kwargs["status"] == "error"
         assert mock_finalize.await_args.kwargs["thread_status"] == "error"
+        assert mock_finalize.await_args.kwargs["user_id"] == "user-1"
         mock_streaming.signal_run_error.assert_awaited_once()
         # Verify sanitized message used (not raw exception)
         error_args = mock_streaming.signal_run_error.await_args
@@ -151,14 +196,11 @@ class TestStreamNativeV2InterruptDetection:
     the run finalizes 'success' and the client gets input.requested + completed."""
 
     async def _run(self, *events: tuple[str, dict]) -> bool:
-        from aegra_api.services import run_executor as mod
-        from aegra_api.services.run_executor import _GraphResult, _stream_native_v2
-
         result = _GraphResult()
         with (
-            patch.object(mod, "stream_native_v3_events", _v3_stream(*events)),
-            patch.object(mod, "broker_manager") as bm,
-            patch.object(mod, "streaming_service") as ss,
+            patch.object(run_executor_module, "stream_native_v3_events", _v3_stream(*events)),
+            patch.object(run_executor_module, "broker_manager") as bm,
+            patch.object(run_executor_module, "streaming_service") as ss,
         ):
             bm.allocate_event_id = AsyncMock(return_value="run-1_event_1")
             ss.put_to_broker = AsyncMock()
@@ -193,8 +235,6 @@ class TestSignalEndEvent:
             mock_bm.get_broker.return_value = mock_broker
             mock_bm.allocate_event_id = AsyncMock(return_value="run-1_event_5")
 
-            from aegra_api.services.run_executor import _signal_end_event
-
             await _signal_end_event("run-1", "success")
 
         mock_broker.put.assert_awaited_once_with("run-1_event_5", ("end", {"status": "success"}))
@@ -203,8 +243,6 @@ class TestSignalEndEvent:
     async def test_noop_when_broker_is_none(self) -> None:
         with patch("aegra_api.services.run_executor.broker_manager") as mock_bm:
             mock_bm.get_broker.return_value = None
-
-            from aegra_api.services.run_executor import _signal_end_event
 
             await _signal_end_event("run-1", "success")
             # No error, no put call
@@ -217,8 +255,6 @@ class TestSignalEndEvent:
         with patch("aegra_api.services.run_executor.broker_manager") as mock_bm:
             mock_bm.get_broker.return_value = mock_broker
 
-            from aegra_api.services.run_executor import _signal_end_event
-
             await _signal_end_event("run-1", "success")
 
 
@@ -229,8 +265,6 @@ class TestSignalRunDone:
 
         with patch("aegra_api.services.run_executor.redis_manager") as mock_rm:
             mock_rm.get_client.return_value = mock_client
-
-            from aegra_api.services.run_executor import _signal_run_done
 
             await _signal_run_done("run-1")
 
@@ -251,8 +285,6 @@ class TestSignalRunDone:
             mock_rm.get_client.return_value = mock_client
             mock_settings.redis.REDIS_CHANNEL_PREFIX = "aegra:agent-foo:run:"
 
-            from aegra_api.services.run_executor import _signal_run_done
-
             await _signal_run_done("run-1")
 
         key = mock_client.set.await_args.args[0]
@@ -262,8 +294,6 @@ class TestSignalRunDone:
     async def test_logs_debug_on_redis_failure(self) -> None:
         with patch("aegra_api.services.run_executor.redis_manager") as mock_rm:
             mock_rm.get_client.side_effect = Exception("connection refused")
-
-            from aegra_api.services.run_executor import _signal_run_done
 
             # Should not raise
             await _signal_run_done("run-1")
@@ -292,8 +322,6 @@ class TestLeaseLossCancellation:
         ):
             mock_streaming.signal_run_cancelled = AsyncMock()
             mock_streaming.cleanup_run = AsyncMock()
-
-            from aegra_api.services.run_executor import _lease_loss_cancellations, execute_run
 
             # Simulate heartbeat marking this as a lease-loss cancel
             _lease_loss_cancellations.add("run-1")
@@ -333,8 +361,6 @@ class TestLeaseLossCancellation:
             mock_streaming.signal_run_cancelled = AsyncMock()
             mock_streaming.cleanup_run = AsyncMock()
 
-            from aegra_api.services.run_executor import execute_run
-
             with pytest.raises(asyncio.CancelledError):
                 await execute_run(_make_job())
 
@@ -359,8 +385,6 @@ class TestTerminalStateRaces:
         ):
             mock_streaming.cleanup_run = AsyncMock()
 
-            from aegra_api.services.run_executor import execute_run
-
             await execute_run(_make_job())
 
         mock_stream.assert_not_awaited()
@@ -378,8 +402,6 @@ class TestTerminalStateRaces:
             patch("aegra_api.services.run_executor._signal_run_done", new_callable=AsyncMock),
         ):
             mock_streaming.cleanup_run = AsyncMock()
-
-            from aegra_api.services.run_executor import execute_run
 
             await execute_run(_make_job())
 

--- a/libs/aegra-api/tests/unit/test_services/test_run_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_executor.py
@@ -38,12 +38,12 @@ class TestExecuteRunSuccess:
         mock_service = MagicMock()
         mock_service.get_graph = MagicMock(return_value=mock_graph)
 
-        mock_update = AsyncMock()
-        mock_finalize = AsyncMock()
+        mock_start = AsyncMock(return_value=True)
+        mock_finalize = AsyncMock(return_value=True)
 
         with (
             patch("aegra_api.services.run_executor.get_langgraph_service", return_value=mock_service),
-            patch("aegra_api.services.run_executor.update_run_status", mock_update),
+            patch("aegra_api.services.run_executor.start_run", mock_start),
             patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor.stream_graph_events", return_value=_empty_async_gen()),
@@ -61,9 +61,7 @@ class TestExecuteRunSuccess:
 
             await execute_run(_make_job())
 
-        # update_run_status called once for "running"
-        assert mock_update.await_count == 1
-        assert mock_update.await_args_list[0].args == ("run-1", "running")
+        mock_start.assert_awaited_once_with("run-1")
 
         # finalize_run called once for success
         mock_finalize.assert_awaited_once()
@@ -75,11 +73,11 @@ class TestExecuteRunSuccess:
 class TestExecuteRunCancelledError:
     @pytest.mark.asyncio
     async def test_cancelled_error_sets_interrupted_and_signals(self) -> None:
-        mock_update = AsyncMock()
-        mock_finalize = AsyncMock()
+        mock_start = AsyncMock(return_value=True)
+        mock_finalize = AsyncMock(return_value=True)
 
         with (
-            patch("aegra_api.services.run_executor.update_run_status", mock_update),
+            patch("aegra_api.services.run_executor.start_run", mock_start),
             patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor._signal_run_done", new_callable=AsyncMock),
@@ -97,9 +95,7 @@ class TestExecuteRunCancelledError:
             with pytest.raises(asyncio.CancelledError):
                 await execute_run(_make_job())
 
-        # update_run_status called once for "running"
-        assert mock_update.await_count == 1
-        assert mock_update.await_args_list[0].args == ("run-1", "running")
+        mock_start.assert_awaited_once_with("run-1")
         # finalize_run called for "interrupted"
         mock_finalize.assert_awaited_once()
         assert mock_finalize.await_args.kwargs["status"] == "interrupted"
@@ -109,11 +105,11 @@ class TestExecuteRunCancelledError:
 class TestExecuteRunException:
     @pytest.mark.asyncio
     async def test_exception_sets_error_and_signals(self) -> None:
-        mock_update = AsyncMock()
-        mock_finalize = AsyncMock()
+        mock_start = AsyncMock(return_value=True)
+        mock_finalize = AsyncMock(return_value=True)
 
         with (
-            patch("aegra_api.services.run_executor.update_run_status", mock_update),
+            patch("aegra_api.services.run_executor.start_run", mock_start),
             patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor._signal_run_done", new_callable=AsyncMock),
@@ -130,9 +126,7 @@ class TestExecuteRunException:
 
             await execute_run(_make_job())
 
-        # update_run_status called once for "running"
-        assert mock_update.await_count == 1
-        assert mock_update.await_args_list[0].args == ("run-1", "running")
+        mock_start.assert_awaited_once_with("run-1")
         # finalize_run called for "error"
         mock_finalize.assert_awaited_once()
         assert mock_finalize.await_args.kwargs["status"] == "error"
@@ -280,13 +274,13 @@ class TestLeaseLossCancellation:
     async def test_lease_loss_cancel_skips_finalize_and_signal(self) -> None:
         """Regression: when cancellation is due to lease loss (not user action),
         execute_run must NOT finalize the run, send SSE events, signal done,
-        or clean up the broker — another worker will re-execute it."""
-        mock_update = AsyncMock()
+        or clean up the broker - another worker will re-execute it."""
+        mock_start = AsyncMock(return_value=True)
         mock_finalize = AsyncMock()
         mock_signal_done = AsyncMock()
 
         with (
-            patch("aegra_api.services.run_executor.update_run_status", mock_update),
+            patch("aegra_api.services.run_executor.start_run", mock_start),
             patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor._signal_run_done", mock_signal_done),
@@ -321,12 +315,12 @@ class TestLeaseLossCancellation:
     @pytest.mark.asyncio
     async def test_user_cancel_still_finalizes(self) -> None:
         """Normal (user-initiated) cancellation must still finalize and signal."""
-        mock_update = AsyncMock()
-        mock_finalize = AsyncMock()
+        mock_start = AsyncMock(return_value=True)
+        mock_finalize = AsyncMock(return_value=True)
         mock_signal_done = AsyncMock()
 
         with (
-            patch("aegra_api.services.run_executor.update_run_status", mock_update),
+            patch("aegra_api.services.run_executor.start_run", mock_start),
             patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor._signal_run_done", mock_signal_done),
@@ -351,3 +345,42 @@ class TestLeaseLossCancellation:
         # Done-key and cleanup MUST happen on normal cancel
         mock_signal_done.assert_awaited_once_with("run-1")
         mock_streaming.cleanup_run.assert_awaited_once_with("run-1")
+
+
+class TestTerminalStateRaces:
+    @pytest.mark.asyncio
+    async def test_terminal_run_does_not_start_graph_execution(self) -> None:
+        with (
+            patch("aegra_api.services.run_executor.start_run", new_callable=AsyncMock, return_value=False),
+            patch("aegra_api.services.run_executor._stream_graph", new_callable=AsyncMock) as mock_stream,
+            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock) as mock_finalize,
+            patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
+            patch("aegra_api.services.run_executor._signal_run_done", new_callable=AsyncMock),
+        ):
+            mock_streaming.cleanup_run = AsyncMock()
+
+            from aegra_api.services.run_executor import execute_run
+
+            await execute_run(_make_job())
+
+        mock_stream.assert_not_awaited()
+        mock_finalize.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_lost_finalization_race_does_not_signal_success(self) -> None:
+        graph_result = MagicMock(has_interrupt=False, data={"late": True})
+        with (
+            patch("aegra_api.services.run_executor.start_run", new_callable=AsyncMock, return_value=True),
+            patch("aegra_api.services.run_executor._stream_graph", new_callable=AsyncMock, return_value=graph_result),
+            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock, return_value=False),
+            patch("aegra_api.services.run_executor._signal_end_event", new_callable=AsyncMock) as mock_signal_end,
+            patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
+            patch("aegra_api.services.run_executor._signal_run_done", new_callable=AsyncMock),
+        ):
+            mock_streaming.cleanup_run = AsyncMock()
+
+            from aegra_api.services.run_executor import execute_run
+
+            await execute_run(_make_job())
+
+        mock_signal_end.assert_not_awaited()

--- a/libs/aegra-api/tests/unit/test_services/test_run_status.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_status.py
@@ -6,9 +6,11 @@ import pytest
 
 from aegra_api.services.run_status import (
     _safe_serialize,
+    finalize_run,
     interrupt_unowned_run,
     set_thread_status,
     set_thread_status_if_no_active_runs,
+    start_run,
     update_run_status,
 )
 
@@ -79,6 +81,79 @@ class TestUpdateRunStatus:
             await update_run_status("run-1", "running")
 
         mock_ser.assert_not_called()
+
+
+class TestStartRun:
+    @pytest.mark.asyncio
+    async def test_starts_active_run(self) -> None:
+        session = _make_mock_session()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = "run-1"
+        session.execute = AsyncMock(return_value=result)
+
+        with patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)):
+            started = await start_run("run-1")
+
+        assert started is True
+        session.commit.assert_awaited_once()
+        session.rollback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_does_not_revive_terminal_run(self) -> None:
+        session = _make_mock_session()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=result)
+
+        with patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)):
+            started = await start_run("run-1")
+
+        assert started is False
+        session.commit.assert_not_awaited()
+        session.rollback.assert_awaited_once()
+
+
+class TestFinalizeRun:
+    @pytest.mark.asyncio
+    async def test_finalizes_only_an_active_run(self) -> None:
+        session = _make_mock_session()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = "user-1"
+        session.execute = AsyncMock(return_value=result)
+
+        with (
+            patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)),
+            patch(
+                "aegra_api.services.run_status.set_thread_status_if_no_active_runs",
+                new_callable=AsyncMock,
+            ) as mock_set_thread,
+        ):
+            finalized = await finalize_run("run-1", "thread-1", status="success", thread_status="idle")
+
+        assert finalized is True
+        mock_set_thread.assert_awaited_once_with(session, ["thread-1"], "idle", user_id="user-1")
+        session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_run_that_is_already_terminal(self) -> None:
+        session = _make_mock_session()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=result)
+
+        with (
+            patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)),
+            patch(
+                "aegra_api.services.run_status.set_thread_status_if_no_active_runs",
+                new_callable=AsyncMock,
+            ) as mock_set_thread,
+        ):
+            finalized = await finalize_run("run-1", "thread-1", status="success", thread_status="idle")
+
+        assert finalized is False
+        mock_set_thread.assert_not_awaited()
+        session.commit.assert_not_awaited()
+        session.rollback.assert_awaited_once()
 
 
 class TestSetThreadStatus:

--- a/libs/aegra-api/tests/unit/test_services/test_run_status.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_status.py
@@ -4,7 +4,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from aegra_api.services.run_status import _safe_serialize, interrupt_unowned_run, set_thread_status, update_run_status
+from aegra_api.services.run_status import (
+    _safe_serialize,
+    interrupt_unowned_run,
+    set_thread_status,
+    set_thread_status_if_no_active_runs,
+    update_run_status,
+)
 
 
 def _make_mock_session() -> AsyncMock:
@@ -99,6 +105,36 @@ class TestSetThreadStatus:
             await set_thread_status(session, "thread-missing", "idle")
 
 
+class TestSetThreadStatusIfNoActiveRuns:
+    @pytest.mark.asyncio
+    async def test_updates_owned_threads_without_committing(self) -> None:
+        session = _make_mock_session()
+
+        await set_thread_status_if_no_active_runs(
+            session,
+            ["thread-1"],
+            "idle",
+            user_id="user-1",
+        )
+
+        session.execute.assert_awaited_once()
+        statement = session.execute.await_args.args[0]
+        compiled = statement.compile()
+        sql = str(compiled)
+        assert "thread.user_id" in sql
+        assert "runs.user_id" in sql
+        assert list(compiled.params.values()).count("user-1") == 2
+        session.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_database_when_thread_ids_are_empty(self) -> None:
+        session = _make_mock_session()
+
+        await set_thread_status_if_no_active_runs(session, [], "idle", user_id="user-1")
+
+        session.execute.assert_not_awaited()
+
+
 class TestInterruptUnownedRun:
     @pytest.mark.asyncio
     async def test_reconciles_run_and_thread_in_one_transaction(self) -> None:
@@ -111,10 +147,14 @@ class TestInterruptUnownedRun:
             "aegra_api.services.run_status.set_thread_status_if_no_active_runs",
             new_callable=AsyncMock,
         ) as mock_set_thread:
-            interrupted = await interrupt_unowned_run(session, "run-1", "thread-1")
+            interrupted = await interrupt_unowned_run(session, "run-1", "thread-1", user_id="user-1")
 
         assert interrupted is True
-        mock_set_thread.assert_awaited_once_with(session, ["thread-1"], "idle")
+        statement = session.execute.await_args.args[0]
+        compiled = statement.compile()
+        assert "runs.user_id" in str(compiled)
+        assert "user-1" in compiled.params.values()
+        mock_set_thread.assert_awaited_once_with(session, ["thread-1"], "idle", user_id="user-1")
         session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -128,7 +168,7 @@ class TestInterruptUnownedRun:
             "aegra_api.services.run_status.set_thread_status_if_no_active_runs",
             new_callable=AsyncMock,
         ) as mock_set_thread:
-            interrupted = await interrupt_unowned_run(session, "run-1", "thread-1")
+            interrupted = await interrupt_unowned_run(session, "run-1", "thread-1", user_id="user-1")
 
         assert interrupted is False
         mock_set_thread.assert_not_awaited()

--- a/libs/aegra-api/tests/unit/test_services/test_run_status.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_status.py
@@ -11,7 +11,6 @@ from aegra_api.services.run_status import (
     set_thread_status,
     set_thread_status_if_no_active_runs,
     start_run,
-    update_run_status,
 )
 
 
@@ -30,61 +29,6 @@ def _make_mock_session_maker(session: AsyncMock) -> MagicMock:
     ctx.__aexit__ = AsyncMock(return_value=False)
     maker = MagicMock(return_value=ctx)
     return maker
-
-
-class TestUpdateRunStatus:
-    @pytest.mark.asyncio
-    async def test_updates_db_with_status(self) -> None:
-        session = _make_mock_session()
-        maker = _make_mock_session_maker(session)
-
-        with patch("aegra_api.services.run_status._get_session_maker", return_value=maker):
-            await update_run_status("run-1", "running", user_id="user-1")
-
-        session.execute.assert_awaited_once()
-        statement = session.execute.await_args.args[0]
-        compiled = statement.compile()
-        assert "runs.user_id" in str(compiled)
-        assert "user-1" in compiled.params.values()
-        session.commit.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_includes_output_when_provided(self) -> None:
-        session = _make_mock_session()
-        maker = _make_mock_session_maker(session)
-
-        with (
-            patch("aegra_api.services.run_status._get_session_maker", return_value=maker),
-            patch("aegra_api.services.run_status._safe_serialize", return_value={"key": "val"}) as mock_ser,
-        ):
-            await update_run_status("run-1", "success", user_id="user-1", output={"key": "val"})
-
-        mock_ser.assert_called_once_with({"key": "val"}, "run-1")
-        session.execute.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_includes_error_when_provided(self) -> None:
-        session = _make_mock_session()
-        maker = _make_mock_session_maker(session)
-
-        with patch("aegra_api.services.run_status._get_session_maker", return_value=maker):
-            await update_run_status("run-1", "error", user_id="user-1", error="something broke")
-
-        session.execute.assert_awaited_once()
-        session.commit.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_omits_output_and_error_when_not_provided(self) -> None:
-        session = _make_mock_session()
-        maker = _make_mock_session_maker(session)
-
-        with (
-            patch("aegra_api.services.run_status._get_session_maker", return_value=maker),
-            patch("aegra_api.services.run_status._safe_serialize") as mock_ser,
-        ):
-            await update_run_status("run-1", "running", user_id="user-1")
-
-        mock_ser.assert_not_called()
 
 
 class TestStartRun:
@@ -151,6 +95,61 @@ class TestFinalizeRun:
         assert "user-1" in compiled.params.values()
         mock_set_thread.assert_awaited_once_with(session, ["thread-1"], "idle", user_id="user-1")
         session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_serializes_output_and_records_error_when_provided(self) -> None:
+        session = _make_mock_session()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = "run-1"
+        session.execute = AsyncMock(return_value=result)
+
+        with (
+            patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)),
+            patch("aegra_api.services.run_status._safe_serialize", return_value={"key": "val"}) as mock_ser,
+            patch(
+                "aegra_api.services.run_status.set_thread_status_if_no_active_runs",
+                new_callable=AsyncMock,
+            ),
+        ):
+            finalized = await finalize_run(
+                "run-1",
+                "thread-1",
+                user_id="user-1",
+                status="error",
+                thread_status="error",
+                output={"key": "val"},
+                error="something broke",
+            )
+
+        assert finalized is True
+        mock_ser.assert_called_once_with({"key": "val"}, "run-1")
+        params = session.execute.await_args.args[0].compile().params
+        assert params["error_message"] == "something broke"
+
+    @pytest.mark.asyncio
+    async def test_omits_output_serialization_when_not_provided(self) -> None:
+        session = _make_mock_session()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = "run-1"
+        session.execute = AsyncMock(return_value=result)
+
+        with (
+            patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)),
+            patch("aegra_api.services.run_status._safe_serialize") as mock_ser,
+            patch(
+                "aegra_api.services.run_status.set_thread_status_if_no_active_runs",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await finalize_run(
+                "run-1",
+                "thread-1",
+                user_id="user-1",
+                status="success",
+                thread_status="idle",
+            )
+
+        mock_ser.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_skips_run_that_is_already_terminal(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_run_status.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_status.py
@@ -39,9 +39,13 @@ class TestUpdateRunStatus:
         maker = _make_mock_session_maker(session)
 
         with patch("aegra_api.services.run_status._get_session_maker", return_value=maker):
-            await update_run_status("run-1", "running")
+            await update_run_status("run-1", "running", user_id="user-1")
 
         session.execute.assert_awaited_once()
+        statement = session.execute.await_args.args[0]
+        compiled = statement.compile()
+        assert "runs.user_id" in str(compiled)
+        assert "user-1" in compiled.params.values()
         session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -53,7 +57,7 @@ class TestUpdateRunStatus:
             patch("aegra_api.services.run_status._get_session_maker", return_value=maker),
             patch("aegra_api.services.run_status._safe_serialize", return_value={"key": "val"}) as mock_ser,
         ):
-            await update_run_status("run-1", "success", output={"key": "val"})
+            await update_run_status("run-1", "success", user_id="user-1", output={"key": "val"})
 
         mock_ser.assert_called_once_with({"key": "val"}, "run-1")
         session.execute.assert_awaited_once()
@@ -64,7 +68,7 @@ class TestUpdateRunStatus:
         maker = _make_mock_session_maker(session)
 
         with patch("aegra_api.services.run_status._get_session_maker", return_value=maker):
-            await update_run_status("run-1", "error", error="something broke")
+            await update_run_status("run-1", "error", user_id="user-1", error="something broke")
 
         session.execute.assert_awaited_once()
         session.commit.assert_awaited_once()
@@ -78,7 +82,7 @@ class TestUpdateRunStatus:
             patch("aegra_api.services.run_status._get_session_maker", return_value=maker),
             patch("aegra_api.services.run_status._safe_serialize") as mock_ser,
         ):
-            await update_run_status("run-1", "running")
+            await update_run_status("run-1", "running", user_id="user-1")
 
         mock_ser.assert_not_called()
 
@@ -92,9 +96,13 @@ class TestStartRun:
         session.execute = AsyncMock(return_value=result)
 
         with patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)):
-            started = await start_run("run-1")
+            started = await start_run("run-1", user_id="user-1")
 
         assert started is True
+        statement = session.execute.await_args.args[0]
+        compiled = statement.compile()
+        assert "runs.user_id" in str(compiled)
+        assert "user-1" in compiled.params.values()
         session.commit.assert_awaited_once()
         session.rollback.assert_not_awaited()
 
@@ -106,7 +114,7 @@ class TestStartRun:
         session.execute = AsyncMock(return_value=result)
 
         with patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)):
-            started = await start_run("run-1")
+            started = await start_run("run-1", user_id="user-1")
 
         assert started is False
         session.commit.assert_not_awaited()
@@ -118,7 +126,7 @@ class TestFinalizeRun:
     async def test_finalizes_only_an_active_run(self) -> None:
         session = _make_mock_session()
         result = MagicMock()
-        result.scalar_one_or_none.return_value = "user-1"
+        result.scalar_one_or_none.return_value = "run-1"
         session.execute = AsyncMock(return_value=result)
 
         with (
@@ -128,9 +136,19 @@ class TestFinalizeRun:
                 new_callable=AsyncMock,
             ) as mock_set_thread,
         ):
-            finalized = await finalize_run("run-1", "thread-1", status="success", thread_status="idle")
+            finalized = await finalize_run(
+                "run-1",
+                "thread-1",
+                user_id="user-1",
+                status="success",
+                thread_status="idle",
+            )
 
         assert finalized is True
+        statement = session.execute.await_args.args[0]
+        compiled = statement.compile()
+        assert "runs.user_id" in str(compiled)
+        assert "user-1" in compiled.params.values()
         mock_set_thread.assert_awaited_once_with(session, ["thread-1"], "idle", user_id="user-1")
         session.commit.assert_awaited_once()
 
@@ -148,7 +166,13 @@ class TestFinalizeRun:
                 new_callable=AsyncMock,
             ) as mock_set_thread,
         ):
-            finalized = await finalize_run("run-1", "thread-1", status="success", thread_status="idle")
+            finalized = await finalize_run(
+                "run-1",
+                "thread-1",
+                user_id="user-1",
+                status="success",
+                thread_status="idle",
+            )
 
         assert finalized is False
         mock_set_thread.assert_not_awaited()

--- a/libs/aegra-api/tests/unit/test_services/test_run_status.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_status.py
@@ -250,7 +250,10 @@ class TestInterruptUnownedRun:
         assert interrupted is True
         statement = session.execute.await_args.args[0]
         compiled = statement.compile()
-        assert "runs.user_id" in str(compiled)
+        sql = str(compiled)
+        assert "runs.user_id" in sql
+        assert "runs.claimed_by IS NULL" in sql
+        assert "runs.lease_expires_at <" in sql
         assert "user-1" in compiled.params.values()
         mock_set_thread.assert_awaited_once_with(session, ["thread-1"], "idle", user_id="user-1")
         session.commit.assert_awaited_once()

--- a/libs/aegra-api/tests/unit/test_services/test_run_status.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_status.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from aegra_api.services.run_status import _safe_serialize, set_thread_status, update_run_status
+from aegra_api.services.run_status import _safe_serialize, interrupt_unowned_run, set_thread_status, update_run_status
 
 
 def _make_mock_session() -> AsyncMock:
@@ -97,6 +97,42 @@ class TestSetThreadStatus:
 
         with pytest.raises(ValueError, match="Thread 'thread-missing' not found"):
             await set_thread_status(session, "thread-missing", "idle")
+
+
+class TestInterruptUnownedRun:
+    @pytest.mark.asyncio
+    async def test_reconciles_run_and_thread_in_one_transaction(self) -> None:
+        session = _make_mock_session()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = "run-1"
+        session.execute = AsyncMock(return_value=result)
+
+        with patch(
+            "aegra_api.services.run_status.set_thread_status_if_no_active_runs",
+            new_callable=AsyncMock,
+        ) as mock_set_thread:
+            interrupted = await interrupt_unowned_run(session, "run-1", "thread-1")
+
+        assert interrupted is True
+        mock_set_thread.assert_awaited_once_with(session, ["thread-1"], "idle")
+        session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_does_not_commit_when_live_owner_wins_race(self) -> None:
+        session = _make_mock_session()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=result)
+
+        with patch(
+            "aegra_api.services.run_status.set_thread_status_if_no_active_runs",
+            new_callable=AsyncMock,
+        ) as mock_set_thread:
+            interrupted = await interrupt_unowned_run(session, "run-1", "thread-1")
+
+        assert interrupted is False
+        mock_set_thread.assert_not_awaited()
+        session.commit.assert_not_awaited()
 
 
 class TestSafeSerialize:

--- a/libs/aegra-api/tests/unit/test_services/test_streaming_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_streaming_service.py
@@ -347,7 +347,7 @@ class TestStreamingService:
             success = await service.interrupt_run(run_id)
 
             assert success is True
-            mock_bm.request_cancel.assert_awaited_once_with(run_id, "interrupt")
+            mock_bm.request_cancel.assert_awaited_once_with(run_id, "interrupt", emit_end_event=True)
 
     async def test_cancel_run_delegates_to_broker_manager(self) -> None:
         """Test run cancellation delegates to broker_manager"""
@@ -359,7 +359,7 @@ class TestStreamingService:
             success = await service.cancel_run(run_id)
 
             assert success is True
-            mock_bm.request_cancel.assert_awaited_once_with(run_id, "cancel")
+            mock_bm.request_cancel.assert_awaited_once_with(run_id, "cancel", emit_end_event=True)
 
     async def test_is_run_streaming(self) -> None:
         """Test fetching if run is streaming"""

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -1,6 +1,7 @@
 """Unit tests for worker_executor service."""
 
 import asyncio
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -564,6 +565,19 @@ class TestWorkerExecutorStop:
 
 
 class TestExecuteAndRelease:
+    @pytest.fixture(autouse=True)
+    def _clear_cancellation_state(self) -> Iterator[None]:
+        active_runs.clear()
+        explicit_run_cancellations.clear()
+        _timeout_cancellations.clear()
+        yield
+        for task in active_runs.values():
+            if not task.done():
+                task.cancel()
+        active_runs.clear()
+        explicit_run_cancellations.clear()
+        _timeout_cancellations.clear()
+
     @pytest.mark.asyncio
     async def test_registers_in_active_runs_and_cleans_up(self) -> None:
         run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
@@ -667,6 +681,75 @@ class TestExecuteAndRelease:
             with pytest.raises(asyncio.CancelledError):
                 await executor._execute_and_release(run_id, "worker-0", semaphore)
 
+        mock_finalize.assert_awaited_once_with(
+            run_id,
+            thread_id,
+            user_id="user-1",
+            status="interrupted",
+            thread_status="idle",
+            output={},
+        )
+        assert run_id not in explicit_run_cancellations
+        assert run_id not in active_runs
+        assert not semaphore.locked()
+
+    @pytest.mark.asyncio
+    async def test_repeated_external_cancel_waits_for_database_reconciliation(self) -> None:
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        thread_id = "tttttttt-tttt-tttt-tttt-tttttttttttt"
+        semaphore = asyncio.Semaphore(1)
+        await semaphore.acquire()
+        executor = WorkerExecutor()
+        execution_started = asyncio.Event()
+        finalize_started = asyncio.Event()
+        allow_finalize = asyncio.Event()
+        inner_cancelled = False
+
+        async def long_running(rid: str, worker_name: str) -> None:
+            nonlocal inner_cancelled
+            execution_started.set()
+            try:
+                await asyncio.sleep(9999)
+            except asyncio.CancelledError:
+                inner_cancelled = True
+                raise
+
+        async def delayed_finalize(*args: object, **kwargs: object) -> bool:
+            finalize_started.set()
+            await allow_finalize.wait()
+            return True
+
+        executor._execute_with_lease = AsyncMock(side_effect=long_running)  # type: ignore[method-assign]
+        explicit_run_cancellations.add(run_id)
+
+        with (
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(
+                f"{MODULE}._get_run_identity",
+                new_callable=AsyncMock,
+                return_value=(thread_id, "user-1"),
+            ),
+            patch(
+                f"{MODULE}.finalize_run",
+                new_callable=AsyncMock,
+                side_effect=delayed_finalize,
+            ) as mock_finalize,
+        ):
+            mock_settings.worker.BG_JOB_TIMEOUT_SECS = 60
+            task = asyncio.create_task(executor._execute_and_release(run_id, "worker-0", semaphore))
+            await asyncio.wait_for(execution_started.wait(), timeout=1)
+
+            task.cancel()
+            await asyncio.wait_for(finalize_started.wait(), timeout=1)
+            task.cancel()
+            await asyncio.sleep(0)
+
+            assert not task.done()
+            allow_finalize.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert inner_cancelled is True
         mock_finalize.assert_awaited_once_with(
             run_id,
             thread_id,

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -10,6 +10,7 @@ from redis import TimeoutError as RedisTimeoutError
 from aegra_api.core.active_runs import active_runs, explicit_run_cancellations
 from aegra_api.models.auth import User
 from aegra_api.models.run_job import RunBehavior, RunExecution, RunIdentity, RunJob
+from aegra_api.services.run_executor import _timeout_cancellations
 from aegra_api.services.worker_executor import (
     WorkerExecutor,
     _acquire_and_load,
@@ -598,9 +599,15 @@ class TestExecuteAndRelease:
         await semaphore.acquire()
 
         executor = WorkerExecutor()
+        timeout_marker_seen = False
 
         async def slow_execute(rid: str, wn: str) -> None:
-            await asyncio.sleep(9999)
+            nonlocal timeout_marker_seen
+            try:
+                await asyncio.sleep(9999)
+            except asyncio.CancelledError:
+                timeout_marker_seen = run_id in _timeout_cancellations
+                raise
 
         executor._execute_with_lease = AsyncMock(side_effect=slow_execute)  # type: ignore[method-assign]
 
@@ -608,7 +615,11 @@ class TestExecuteAndRelease:
 
         with (
             patch(f"{MODULE}.settings") as mock_settings,
-            patch(f"{MODULE}._get_thread_id_for_run", new_callable=AsyncMock, return_value=thread_id),
+            patch(
+                f"{MODULE}._get_run_identity",
+                new_callable=AsyncMock,
+                return_value=(thread_id, "user-1"),
+            ),
             patch(f"{MODULE}.finalize_run", new_callable=AsyncMock) as mock_finalize,
             patch(f"{MODULE}._release_lease") as mock_release,
         ):
@@ -620,16 +631,18 @@ class TestExecuteAndRelease:
         mock_finalize.assert_awaited_once_with(
             run_id,
             thread_id,
+            user_id="user-1",
             status="error",
             thread_status="error",
             error="Job exceeded maximum execution time",
-            allowed_current_statuses=("pending", "running", "interrupted"),
         )
         mock_release.assert_awaited_once_with(run_id, "worker-0")
+        assert timeout_marker_seen is True
         # Semaphore released even on timeout
         assert not semaphore.locked()
         # Cleaned up
         assert run_id not in active_runs
+        assert run_id not in _timeout_cancellations
 
     @pytest.mark.asyncio
     async def test_explicit_cancel_before_execution_reconciles_database(self) -> None:
@@ -643,7 +656,11 @@ class TestExecuteAndRelease:
 
         with (
             patch(f"{MODULE}.settings") as mock_settings,
-            patch(f"{MODULE}._get_thread_id_for_run", new_callable=AsyncMock, return_value=thread_id),
+            patch(
+                f"{MODULE}._get_run_identity",
+                new_callable=AsyncMock,
+                return_value=(thread_id, "user-1"),
+            ),
             patch(f"{MODULE}.finalize_run", new_callable=AsyncMock, return_value=True) as mock_finalize,
         ):
             mock_settings.worker.BG_JOB_TIMEOUT_SECS = 60
@@ -653,6 +670,7 @@ class TestExecuteAndRelease:
         mock_finalize.assert_awaited_once_with(
             run_id,
             thread_id,
+            user_id="user-1",
             status="interrupted",
             thread_status="idle",
             output={},

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -694,6 +694,44 @@ class TestExecuteAndRelease:
         assert not semaphore.locked()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("failure_source", ["identity", "finalize"])
+    async def test_cleanup_failure_preserves_cancellation(self, failure_source: str) -> None:
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        thread_id = "tttttttt-tttt-tttt-tttt-tttttttttttt"
+        semaphore = asyncio.Semaphore(1)
+        await semaphore.acquire()
+        executor = WorkerExecutor()
+        executor._execute_with_lease = AsyncMock(side_effect=asyncio.CancelledError)  # type: ignore[method-assign]
+        explicit_run_cancellations.add(run_id)
+
+        with (
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(
+                f"{MODULE}._get_run_identity",
+                new_callable=AsyncMock,
+                return_value=(thread_id, "user-1"),
+                side_effect=RuntimeError("database unavailable") if failure_source == "identity" else None,
+            ),
+            patch(
+                f"{MODULE}.finalize_run",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("database unavailable") if failure_source == "finalize" else None,
+            ),
+            patch(f"{MODULE}.logger.exception") as mock_log_exception,
+        ):
+            mock_settings.worker.BG_JOB_TIMEOUT_SECS = 60
+            with pytest.raises(asyncio.CancelledError):
+                await executor._execute_and_release(run_id, "worker-0", semaphore)
+
+        mock_log_exception.assert_called_once_with(
+            "Failed to persist explicit run cancellation",
+            run_id=run_id,
+        )
+        assert run_id not in explicit_run_cancellations
+        assert run_id not in active_runs
+        assert not semaphore.locked()
+
+    @pytest.mark.asyncio
     async def test_repeated_external_cancel_waits_for_database_reconciliation(self) -> None:
         run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         thread_id = "tttttttt-tttt-tttt-tttt-tttttttttttt"

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -7,7 +7,7 @@ import pytest
 from redis import ConnectionError as RedisConnectionError
 from redis import TimeoutError as RedisTimeoutError
 
-from aegra_api.core.active_runs import active_runs
+from aegra_api.core.active_runs import active_runs, explicit_run_cancellations
 from aegra_api.models.auth import User
 from aegra_api.models.run_job import RunBehavior, RunExecution, RunIdentity, RunJob
 from aegra_api.services.worker_executor import (
@@ -623,12 +623,43 @@ class TestExecuteAndRelease:
             status="error",
             thread_status="error",
             error="Job exceeded maximum execution time",
+            allowed_current_statuses=("pending", "running", "interrupted"),
         )
         mock_release.assert_awaited_once_with(run_id, "worker-0")
         # Semaphore released even on timeout
         assert not semaphore.locked()
         # Cleaned up
         assert run_id not in active_runs
+
+    @pytest.mark.asyncio
+    async def test_explicit_cancel_before_execution_reconciles_database(self) -> None:
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        thread_id = "tttttttt-tttt-tttt-tttt-tttttttttttt"
+        semaphore = asyncio.Semaphore(1)
+        await semaphore.acquire()
+        executor = WorkerExecutor()
+        executor._execute_with_lease = AsyncMock(side_effect=asyncio.CancelledError)  # type: ignore[method-assign]
+        explicit_run_cancellations.add(run_id)
+
+        with (
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(f"{MODULE}._get_thread_id_for_run", new_callable=AsyncMock, return_value=thread_id),
+            patch(f"{MODULE}.finalize_run", new_callable=AsyncMock, return_value=True) as mock_finalize,
+        ):
+            mock_settings.worker.BG_JOB_TIMEOUT_SECS = 60
+            with pytest.raises(asyncio.CancelledError):
+                await executor._execute_and_release(run_id, "worker-0", semaphore)
+
+        mock_finalize.assert_awaited_once_with(
+            run_id,
+            thread_id,
+            status="interrupted",
+            thread_status="idle",
+            output={},
+        )
+        assert run_id not in explicit_run_cancellations
+        assert run_id not in active_runs
+        assert not semaphore.locked()
 
 
 class TestExecuteWithLease:

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.26"
+version = "0.10.0"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -24,7 +24,7 @@ dependencies = [
     "python-dotenv>=1.2.2",
 
     # Server (always included)
-    "aegra-api~=0.9.0",
+    "aegra-api~=0.10.0",
 ]
 
 [project.optional-dependencies]

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.25"
+version = "0.9.26"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.25"
+version = "0.9.26"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.25"
+version = "0.9.26"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.26"
+version = "0.10.0"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.26"
+version = "0.10.0"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary

- Reconcile stale or unowned run cancellation with the owning thread in one transaction.
- Preserve terminal run states and leave live-owned runs to the existing Redis pub/sub cancellation path.
- Reconcile the thread when the lease reaper exhausts a run's retry budget.
- Add real PostgreSQL, API, reaper, and killed-worker regression coverage.
- Update the worker architecture documentation and bump both packages to `0.10.0`.

## Root cause

The cancellation endpoints wrote `interrupted` directly to the run without clearing stale ownership or updating the thread.
That terminal run could no longer be recovered by the lease reaper, leaving its thread permanently `busy`.
The reaper's retry-exhaustion path had the same split-state problem because it marked only the run as `error`.
Late cancellation requests could also overwrite a run that had already reached a terminal state.

## Behavior

- A terminal run is left unchanged by cancellation or interruption requests.
- An active run with no owner or an expired lease is atomically interrupted, has its ownership cleared, and leaves its thread idle when no other run is active.
- A run with a live lease is not rewritten by the API process, and its worker remains responsible for finalization after Redis pub/sub cancellation.
- A retry-exhausted run and its inactive thread are marked `error` in the same transaction.

## Validation

- `1800` API unit and integration tests passed.
- `181` CLI tests passed.
- `10` focused production-mode reconciliation E2E tests passed.
- A deterministic two-instance killed-worker replay confirmed that both failure paths clear ownership and no longer leave the thread busy.
- Repository-wide Ruff and Bandit checks passed.
- The three changed source files pass `ty` type checking.
- The repository-wide `ty` check still reports `60` pre-existing diagnostics outside this change.

Fixes #473
Fixes #475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added asynchronous cancellation with `cancel` and `interrupt` actions.
  - Cancellation responses support optional waiting and accurately reflect non-terminal states.
  - Streams close with definitive completion events after cancellation.

- **Bug Fixes**
  - Prevented stale workers from overwriting completed runs.
  - Improved expired-run retries and retry-exhaustion handling.
  - Preserved terminal run and thread states during reconciliation.

- **Documentation**
  - Updated streaming, worker architecture, and API documentation.
  - Released version 0.10.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes run cancellation and worker-loss recovery reconcile run ownership, terminal state, and thread state atomically while preventing delayed workers from overwriting terminal results.
- Routes stale or unowned cancellation through transactional reconciliation while preserving live-owned and terminal runs.
- Makes worker startup and finalization conditional on active run state and distinguishes explicit cancellation from lease-loss or shutdown cancellation.
- Reworks retry-exhaustion recovery to update the run and inactive thread in one transaction.
- Extends broker cancellation signaling, terminal stream handling, documentation, and regression coverage.
- Bumps the API and CLI packages to 0.10.0.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/runs.py | Centralizes cancellation handling so terminal runs are preserved, stale ownership is reconciled transactionally, and live-worker cancellation remains asynchronous. |
| libs/aegra-api/src/aegra_api/services/run_status.py | Adds conditional run-start, stale-run interruption, active-run-aware thread updates, and guarded terminal finalization. |
| libs/aegra-api/src/aegra_api/services/lease_reaper.py | Atomically classifies expired leases, applies retry or exhaustion state, and reconciles exhausted runs with their threads. |
| libs/aegra-api/src/aegra_api/services/run_executor.py | Prevents execution and terminal signaling after another path has already transitioned the run out of its active state. |
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Distinguishes explicit cancellation from worker shutdown and preserves cancellation even if cleanup reconciliation fails. |
| libs/aegra-api/src/aegra_api/services/redis_broker.py | Propagates cancellation signaling policy across instances and records explicit cancellation before cancelling the owning task. |
| libs/aegra-api/src/aegra_api/services/streaming_service.py | Supports caller-controlled terminal-event emission so API reconciliation and worker cancellation do not duplicate stream completion. |
| uv.lock | Updates workspace package metadata for the coordinated 0.10.0 release without establishing a new reachable dependency vulnerability. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API
    participant DB as PostgreSQL
    participant Redis
    participant Worker
    participant Reaper

    Client->>API: Cancel active run
    API->>DB: Reconcile only if unowned or lease expired
    alt stale or unowned run
        DB-->>API: Run interrupted, ownership cleared
        API->>DB: Mark thread idle if no active runs
        API->>Redis: Best-effort cancel and terminal event
    else live-owned run
        DB-->>API: Conditional update rejected
        API->>Redis: Publish cancellation request
        Redis->>Worker: Cancel local execution task
        Worker->>DB: Conditionally finalize run and thread
    end

    Reaper->>DB: Lock expired running run
    alt retry budget remains
        Reaper->>DB: Reset to pending and clear ownership
        Reaper->>Redis: Re-enqueue run
    else retry budget exhausted
        Reaper->>DB: Mark run error and clear ownership
        Reaper->>DB: Mark inactive thread error
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(api): preserve cancellation after cl..."](https://github.com/aegra/aegra/commit/8d5896e4999d01a46f5fe2a0bea587111c48991c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49462943)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Threads and Runs](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/threads-and-runs.md)
- Knowledge Base — [Execution Engine: Broker, Executors, Leases, and Cleanup](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/execution-engine.md)
- Knowledge Base — [Streaming: from LangGraph execution to SSE wire events](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/streaming.md)
</details>

<!-- /greptile_comment -->