### PR TITLE
fix(test): give e2e pytest steps DB credentials and poll for cancel settlement

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,16 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+# Workflow-level so the pytest steps inherit them too. Tests that assert on
+# reconciliation read the database directly via settings.db.database_url; without
+# these they fall back to the postgres/postgres defaults and fail to connect.
+env:
+  POSTGRES_USER: "user"
+  POSTGRES_PASSWORD: "password"
+  POSTGRES_HOST: "localhost"
+  POSTGRES_PORT: "5432"
+  POSTGRES_DB: "aegra"
+
 jobs:
   e2e-dev-mode:
     name: E2E (Dev Mode — LocalExecutor)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,9 +6,8 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
-# Workflow-level so the pytest steps inherit them too. Tests that assert on
-# reconciliation read the database directly via settings.db.database_url; without
-# these they fall back to the postgres/postgres defaults and fail to connect.
+# Workflow-level so pytest steps inherit them: tests that read the database
+# directly fall back to the postgres/postgres defaults without these.
 env:
   POSTGRES_USER: "user"
   POSTGRES_PASSWORD: "password"

--- a/libs/aegra-api/tests/e2e/_utils.py
+++ b/libs/aegra-api/tests/e2e/_utils.py
@@ -1,9 +1,13 @@
+import asyncio
 import json
+from typing import Any
 
 import httpx
 import pytest
 
 from aegra_api.settings import settings
+
+TERMINAL_RUN_STATES = ("success", "error", "interrupted", "timeout")
 
 try:
     from langgraph_sdk import get_client
@@ -11,6 +15,28 @@ except Exception as e:
     raise RuntimeError(
         "langgraph-sdk is required for E2E tests. Install via extras 'e2e' or add to your environment."
     ) from e
+
+
+async def await_terminal_run(
+    client: Any,
+    thread_id: str,
+    run_id: str,
+    *,
+    timeout: float = 15.0,
+) -> dict:
+    """Poll a run until it settles.
+
+    Cancelling a run a live worker owns is asynchronous: the worker finalizes it,
+    so the state right after the cancel call is not guaranteed to be terminal.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    run = await client.runs.get(thread_id, run_id)
+    while run["status"] not in TERMINAL_RUN_STATES:
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError(f"Run {run_id} did not settle within {timeout}s, last status={run['status']!r}")
+        await asyncio.sleep(0.25)
+        run = await client.runs.get(thread_id, run_id)
+    return run
 
 
 def elog(title: str, payload):

--- a/libs/aegra-api/tests/e2e/_utils.py
+++ b/libs/aegra-api/tests/e2e/_utils.py
@@ -23,11 +23,10 @@ async def await_terminal_run(
     run_id: str,
     *,
     timeout: float = 15.0,
-) -> dict:
+) -> dict[str, Any]:
     """Poll a run until it settles.
 
-    Cancelling a run a live worker owns is asynchronous: the worker finalizes it,
-    so the state right after the cancel call is not guaranteed to be terminal.
+    Cancelling a live-owned run is asynchronous: the worker finalizes it.
     """
     deadline = asyncio.get_running_loop().time() + timeout
     run = await client.runs.get(thread_id, run_id)

--- a/libs/aegra-api/tests/e2e/test_runs/test_runs.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_runs.py
@@ -3,7 +3,7 @@ import pytest
 from aegra_api.settings import settings
 
 # Match import style used by other e2e tests when run as top-level modules
-from tests.e2e._utils import check_and_skip_if_geo_blocked, elog, get_e2e_client
+from tests.e2e._utils import await_terminal_run, check_and_skip_if_geo_blocked, elog, get_e2e_client
 
 
 @pytest.mark.e2e
@@ -152,10 +152,13 @@ async def test_runs_cancel_e2e():
     # It might have failed in background
     check_and_skip_if_geo_blocked(patched)
 
-    assert patched["status"] in ("interrupted", "success")
+    # A live worker finalizes the run itself, so the immediate response may
+    # still be non-terminal. Only the settled state below is guaranteed.
+    assert patched["status"] in ("pending", "running", "interrupted", "success")
 
-    # Verify final state
-    got = await client.runs.get(thread_id, run_id)
+    # Verify final state, polling because cancellation of a live-owned run settles
+    # asynchronously.
+    got = await await_terminal_run(client, thread_id, run_id)
     elog("Runs.get(post-cancel)", got)
     assert got["status"] in ("interrupted", "error", "success")
 

--- a/libs/aegra-api/tests/e2e/test_runs/test_runs.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_runs.py
@@ -154,7 +154,7 @@ async def test_runs_cancel_e2e():
 
     # A live worker finalizes the run itself, so the immediate response may
     # still be non-terminal. Only the settled state below is guaranteed.
-    assert patched["status"] in ("pending", "running", "interrupted", "success")
+    assert patched["status"] in ("pending", "running", "interrupted", "success", "error")
 
     # Verify final state, polling because cancellation of a live-owned run settles
     # asynchronously.

--- a/libs/aegra-api/tests/e2e/test_runs/test_worker_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_worker_e2e.py
@@ -130,6 +130,7 @@ async def test_worker_cancel_via_redis() -> None:
 
     # The worker owns this run, so it finalizes asynchronously after the cancel.
     final_run = await await_terminal_run(client, thread["thread_id"], run["run_id"])
+    check_and_skip_if_geo_blocked(final_run)
     elog("Final run state", final_run)
     assert final_run["status"] == "interrupted", f"Expected interrupted, got {final_run['status']}"
 

--- a/libs/aegra-api/tests/e2e/test_runs/test_worker_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_worker_e2e.py
@@ -19,7 +19,7 @@ import httpx
 import pytest
 
 from aegra_api.settings import settings
-from tests.e2e._utils import check_and_skip_if_geo_blocked, elog, get_e2e_client
+from tests.e2e._utils import await_terminal_run, check_and_skip_if_geo_blocked, elog, get_e2e_client
 
 
 async def _run_and_check_geo(client, thread_id: str, run_id: str) -> dict:
@@ -128,10 +128,8 @@ async def test_worker_cancel_via_redis() -> None:
     )
     elog("Cancel response", cancelled)
 
-    final_run = await client.runs.get(
-        thread_id=thread["thread_id"],
-        run_id=run["run_id"],
-    )
+    # The worker owns this run, so it finalizes asynchronously after the cancel.
+    final_run = await await_terminal_run(client, thread["thread_id"], run["run_id"])
     elog("Final run state", final_run)
     assert final_run["status"] == "interrupted", f"Expected interrupted, got {final_run['status']}"
 


### PR DESCRIPTION
Prod-mode E2E went red on `main` after #484. Two separate causes, **neither is a defect in the shipped code**. Dev-mode and auth-mode E2E both passed on the same commit.

## 1. The pytest steps had no database credentials

#484's reconciliation tests read run and thread rows directly, since they assert the database was actually reconciled. But the "Run E2E tests" step only exported `SERVER_URL` and `OPENAI_API_KEY`. So `settings.db.database_url` fell back to its defaults while the CI service runs as `user`/`password`:

```
asyncpg.exceptions.InvalidPasswordError: password authentication failed for user "postgres"
```

Every test in that file failed at connect time. Dev mode was unaffected because it skips prod-only tests with `-m "not prod_only"`, and those are the ones touching the DB directly.

Verified locally:

```
without POSTGRES_*  ->  postgresql+asyncpg://postgres:postgres@localhost:5432/aegra
with POSTGRES_*     ->  postgresql+asyncpg://user:password@localhost:5432/aegra
```

Fixed by moving `POSTGRES_*` to workflow level so every job and step inherits them, rather than repeating the block in each pytest step and having the next one drift the same way.

## 2. Two tests assumed cancel was synchronous

`test_runs_cancel_e2e` and `test_worker_cancel_via_redis` cancelled a run a live worker was executing, then asserted it was already terminal:

```python
assert patched["status"] in ("interrupted", "success")
```

#484 deliberately changed this. When a live worker owns the run, the API no longer writes the outcome; the worker finalizes it, so the response and an immediate re-read can still be `running`. These tests encoded the old behavior, where the API claimed `interrupted` regardless of whether any worker was alive, which is the bug #475 was about.

Both now poll through a shared `await_terminal_run` helper in `tests/e2e/_utils.py` and assert the settled state, with a 15s timeout that fails loudly rather than hanging.

## Notes

The helper is in `_utils.py` rather than duplicated so future cancel tests get the correct pattern by default. `ruff format --check` and `ruff check` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end run cancellation tests by waiting for runs to reach a final status before validating results.
  * Added timeout handling for asynchronous run completion checks.
  * Updated test environment configuration to use the correct PostgreSQL connection settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR supplies PostgreSQL credentials to all E2E workflow steps and updates cancellation tests to wait for worker-owned runs to settle.
- Adds a shared terminal-state polling helper with a bounded timeout.
- Uses settled run states in the direct and Redis-worker cancellation tests.
- Configures workflow-wide database connection values for prod-mode E2E tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/e2e.yml | Adds workflow-level PostgreSQL environment values inherited by the E2E jobs. |
| libs/aegra-api/tests/e2e/_utils.py | Adds a typed, timeout-bounded helper that polls runs until they reach a terminal state. |
| libs/aegra-api/tests/e2e/test_runs/test_runs.py | Updates cancellation coverage to accept asynchronous responses and assert the settled state. |
| libs/aegra-api/tests/e2e/test_runs/test_worker_e2e.py | Polls Redis-worker cancellations to completion before checking the final outcome. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test as E2E test
    participant API as Runs API
    participant Worker as Live worker
    Test->>API: Cancel run
    API-->>Test: Current run state
    loop Until terminal or timeout
        Test->>API: Get run
        API-->>Test: pending/running/terminal
    end
    Worker->>API: Finalize run
    API-->>Test: interrupted/success/error
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(test): address review feedback on e2..."](https://github.com/aegra/aegra/commit/d16ce96db694bec9e3b17af3904c0b92905b6794) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51136019)</sub>

<!-- /greptile_comment -->