### PR TITLE
fix(redis): retry + health checks for pooled connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,8 @@ REDIS_URL=redis://localhost:6379/0
 # Ping pooled connections idle longer than this (seconds) before reuse;
 # survives server-side idle disconnects (e.g. ElastiCache `timeout`). 0 disables.
 # REDIS_HEALTH_CHECK_INTERVAL=30
-# Command retry attempts on connection errors (exponential backoff 50ms..1s).
+# Retries after the initial attempt (up to 4 calls total) on connection and
+# timeout errors, with exponential backoff 50ms..1s.
 # REDIS_RETRY_ATTEMPTS=3
 
 # --- Worker Configuration ---

--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,11 @@ REDIS_BROKER_ENABLED=false
 REDIS_URL=redis://localhost:6379/0
 # REDIS_CHANNEL_PREFIX=aegra:run:
 # REDIS_MAX_CONNECTIONS=250
+# Ping pooled connections idle longer than this (seconds) before reuse;
+# survives server-side idle disconnects (e.g. ElastiCache `timeout`). 0 disables.
+# REDIS_HEALTH_CHECK_INTERVAL=30
+# Command retry attempts on connection errors (exponential backoff 50ms..1s).
+# REDIS_RETRY_ATTEMPTS=3
 
 # --- Worker Configuration ---
 # Controls worker concurrency when REDIS_BROKER_ENABLED=true.

--- a/.env.example
+++ b/.env.example
@@ -65,8 +65,8 @@ REDIS_URL=redis://localhost:6379/0
 # Ping pooled connections idle longer than this (seconds) before reuse;
 # survives server-side idle disconnects (e.g. ElastiCache `timeout`). 0 disables.
 # REDIS_HEALTH_CHECK_INTERVAL=30
-# Retries after the initial attempt (up to 4 calls total) on connection and
-# timeout errors, with exponential backoff 50ms..1s.
+# Non-negative retries after the initial attempt (default 3, up to 4 calls total)
+# on connection and timeout errors, with exponential backoff 50ms..1s.
 # REDIS_RETRY_ATTEMPTS=3
 
 # --- Worker Configuration ---

--- a/libs/aegra-api/src/aegra_api/core/redis_manager.py
+++ b/libs/aegra-api/src/aegra_api/core/redis_manager.py
@@ -4,6 +4,10 @@ from urllib.parse import urlparse
 
 import redis.asyncio as aioredis
 import structlog
+from redis.asyncio.retry import Retry
+from redis.backoff import ExponentialBackoff
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from aegra_api.settings import settings
 
@@ -26,10 +30,28 @@ class RedisManager:
         if self._client is not None:
             return
 
+        # Retry + health checks make pooled connections survive server-side
+        # idle disconnects (e.g. ElastiCache/Valkey `timeout`), failovers and
+        # network resets: a dead connection is discarded and the command is
+        # re-run on a fresh one instead of surfacing ConnectionError out of
+        # run submission. redis-py's *sync* client retries this way by
+        # default; the asyncio client defaults to Retry(NoBackoff(), 0), so
+        # it must be configured explicitly (see #505).
+        #
+        # Retrying RPUSH (non-idempotent) is safe here: the job queue is
+        # at-least-once by contract — workers dedup via lease acquisition
+        # and replay de-duplication, so a duplicated run_id costs one empty
+        # BLPOP.
         self._pool = aioredis.ConnectionPool.from_url(
             settings.redis.REDIS_URL,
             max_connections=settings.redis.REDIS_MAX_CONNECTIONS,
             decode_responses=True,
+            health_check_interval=settings.redis.REDIS_HEALTH_CHECK_INTERVAL,
+            retry=Retry(
+                ExponentialBackoff(cap=1.0, base=0.05),
+                settings.redis.REDIS_RETRY_ATTEMPTS,
+            ),
+            retry_on_error=[RedisConnectionError, RedisTimeoutError],
         )
         self._client = aioredis.Redis(connection_pool=self._pool)
 

--- a/libs/aegra-api/src/aegra_api/core/redis_manager.py
+++ b/libs/aegra-api/src/aegra_api/core/redis_manager.py
@@ -30,10 +30,8 @@ class RedisManager:
         if self._client is not None:
             return
 
-        # Survive server-side idle disconnects/failovers: retry discards the dead
-        # pooled connection and re-runs on a fresh one — asyncio redis-py defaults
-        # to zero retries, unlike the sync client (#505). RPUSH replay is safe:
-        # the queue is at-least-once and workers dedup via lease acquisition.
+        # Directly constructed pools default to zero retries; bounded retries survive
+        # idle disconnects/failovers. Lease acquisition deduplicates RPUSH replays (#505).
         self._pool = aioredis.ConnectionPool.from_url(
             settings.redis.REDIS_URL,
             max_connections=settings.redis.REDIS_MAX_CONNECTIONS,

--- a/libs/aegra-api/src/aegra_api/core/redis_manager.py
+++ b/libs/aegra-api/src/aegra_api/core/redis_manager.py
@@ -30,18 +30,10 @@ class RedisManager:
         if self._client is not None:
             return
 
-        # Retry + health checks make pooled connections survive server-side
-        # idle disconnects (e.g. ElastiCache/Valkey `timeout`), failovers and
-        # network resets: a dead connection is discarded and the command is
-        # re-run on a fresh one instead of surfacing ConnectionError out of
-        # run submission. redis-py's *sync* client retries this way by
-        # default; the asyncio client defaults to Retry(NoBackoff(), 0), so
-        # it must be configured explicitly (see #505).
-        #
-        # Retrying RPUSH (non-idempotent) is safe here: the job queue is
-        # at-least-once by contract — workers dedup via lease acquisition
-        # and replay de-duplication, so a duplicated run_id costs one empty
-        # BLPOP.
+        # Survive server-side idle disconnects/failovers: retry discards the dead
+        # pooled connection and re-runs on a fresh one — asyncio redis-py defaults
+        # to zero retries, unlike the sync client (#505). RPUSH replay is safe:
+        # the queue is at-least-once and workers dedup via lease acquisition.
         self._pool = aioredis.ConnectionPool.from_url(
             settings.redis.REDIS_URL,
             max_connections=settings.redis.REDIS_MAX_CONNECTIONS,

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -341,15 +341,11 @@ class RedisSettings(EnvBase):
     REDIS_URL: str = "redis://localhost:6379/0"
     REDIS_CHANNEL_PREFIX: str = "aegra:run:"
     REDIS_MAX_CONNECTIONS: int = 250
-    # Ping pooled connections idle longer than this (seconds) before reuse,
-    # reconnecting dead ones transparently. Redis servers commonly close idle
-    # clients (e.g. ElastiCache `timeout`); without health checks the first
-    # command after a quiet period writes into a dead socket. 0 disables.
+    # PING pooled connections idle longer than this (seconds) before reuse, so
+    # server-side idle disconnects don't surface as ConnectionError. 0 disables.
     REDIS_HEALTH_CHECK_INTERVAL: int = 30
-    # Command retry attempts on ConnectionError/TimeoutError (exponential
-    # backoff, 50ms..1s). The first failed attempt discards the dead
-    # connection; the retry runs on a fresh one. Matches the sync redis-py
-    # client, which retries connection errors by default.
+    # Retries after the initial attempt (up to 4 calls total) on connection and
+    # timeout errors, with exponential backoff 50ms..1s.
     REDIS_RETRY_ATTEMPTS: int = 3
 
 

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -341,6 +341,16 @@ class RedisSettings(EnvBase):
     REDIS_URL: str = "redis://localhost:6379/0"
     REDIS_CHANNEL_PREFIX: str = "aegra:run:"
     REDIS_MAX_CONNECTIONS: int = 250
+    # Ping pooled connections idle longer than this (seconds) before reuse,
+    # reconnecting dead ones transparently. Redis servers commonly close idle
+    # clients (e.g. ElastiCache `timeout`); without health checks the first
+    # command after a quiet period writes into a dead socket. 0 disables.
+    REDIS_HEALTH_CHECK_INTERVAL: int = 30
+    # Command retry attempts on ConnectionError/TimeoutError (exponential
+    # backoff, 50ms..1s). The first failed attempt discards the dead
+    # connection; the retry runs on a fresh one. Matches the sync redis-py
+    # client, which retries connection errors by default.
+    REDIS_RETRY_ATTEMPTS: int = 3
 
 
 class WorkerSettings(EnvBase):

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -3,7 +3,7 @@ import re
 from typing import Annotated
 from urllib.parse import parse_qsl, quote_plus, urlencode
 
-from pydantic import BeforeValidator, computed_field, model_validator
+from pydantic import BeforeValidator, Field, computed_field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from aegra_api import __version__
@@ -343,10 +343,10 @@ class RedisSettings(EnvBase):
     REDIS_MAX_CONNECTIONS: int = 250
     # PING pooled connections idle longer than this (seconds) before reuse, so
     # server-side idle disconnects don't surface as ConnectionError. 0 disables.
-    REDIS_HEALTH_CHECK_INTERVAL: int = 30
-    # Retries after the initial attempt (up to 4 calls total) on connection and
-    # timeout errors, with exponential backoff 50ms..1s.
-    REDIS_RETRY_ATTEMPTS: int = 3
+    REDIS_HEALTH_CHECK_INTERVAL: int = Field(default=30, ge=0)
+    # Non-negative retries after the initial attempt (up to 4 calls total) on
+    # connection and timeout errors, with exponential backoff 50ms..1s.
+    REDIS_RETRY_ATTEMPTS: int = Field(default=3, ge=0)
 
 
 class WorkerSettings(EnvBase):

--- a/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
+++ b/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
@@ -39,9 +39,7 @@ class TestRedisManager:
         manager._pool = None
 
     @pytest.mark.asyncio
-    async def test_initialize_configures_retry_and_health_checks(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_initialize_configures_retry_and_health_checks(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Pooled connections must survive server-side idle disconnects (#505).
 
         Every connection — including the one created by initialize()'s own
@@ -75,9 +73,7 @@ class TestRedisManager:
         manager._pool = None
 
     @pytest.mark.asyncio
-    async def test_real_pool_connections_carry_retry(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_real_pool_connections_carry_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """End-to-end through the real ConnectionPool: connections built from
         the pool's kwargs must have retries (asyncio default is 0)."""
         from aegra_api.settings import settings

--- a/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
+++ b/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
@@ -3,7 +3,9 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import redis.asyncio as aioredis
 from redis.asyncio.retry import Retry
+from redis.backoff import ExponentialBackoff
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from aegra_api.core.redis_manager import RedisManager
@@ -37,14 +39,20 @@ class TestRedisManager:
         manager._pool = None
 
     @pytest.mark.asyncio
-    async def test_initialize_configures_retry_and_health_checks(self) -> None:
+    async def test_initialize_configures_retry_and_health_checks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Pooled connections must survive server-side idle disconnects (#505).
 
         Every connection — including the one created by initialize()'s own
         PING — must carry a retry that covers ConnectionError, plus a
-        health-check interval. Passing them to from_url() guarantees this
-        for existing and future connections alike.
+        health-check interval. Non-default settings prove the values come
+        from RedisSettings rather than literals.
         """
+        from aegra_api.settings import settings
+
+        monkeypatch.setattr(settings.redis, "REDIS_HEALTH_CHECK_INTERVAL", 45)
+        monkeypatch.setattr(settings.redis, "REDIS_RETRY_ATTEMPTS", 5)
         manager = RedisManager()
         mock_client = AsyncMock()
 
@@ -55,10 +63,11 @@ class TestRedisManager:
             await manager.initialize()
 
             kwargs = mock_pool_cls.from_url.call_args.kwargs
-            assert kwargs["health_check_interval"] == 30
+            assert kwargs["health_check_interval"] == 45
             retry = kwargs["retry"]
             assert isinstance(retry, Retry)
-            assert retry.get_retries() == 3
+            assert retry.get_retries() == 5
+            assert isinstance(retry._backoff, ExponentialBackoff)
             assert any(issubclass(RedisConnectionError, e) for e in retry._supported_errors)
             assert RedisConnectionError in kwargs["retry_on_error"]
 
@@ -66,17 +75,21 @@ class TestRedisManager:
         manager._pool = None
 
     @pytest.mark.asyncio
-    async def test_real_pool_connections_carry_retry(self) -> None:
+    async def test_real_pool_connections_carry_retry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """End-to-end through the real ConnectionPool: connections built from
         the pool's kwargs must have retries (asyncio default is 0)."""
-        import redis.asyncio as aioredis
+        from aegra_api.settings import settings
 
+        monkeypatch.setattr(settings.redis, "REDIS_HEALTH_CHECK_INTERVAL", 45)
+        monkeypatch.setattr(settings.redis, "REDIS_RETRY_ATTEMPTS", 5)
         manager = RedisManager()
         mock_client = AsyncMock()
         real_from_url = aioredis.ConnectionPool.from_url
-        captured: dict = {}
+        captured: dict[str, aioredis.ConnectionPool] = {}
 
-        def capture_from_url(url, **kwargs):
+        def capture_from_url(url: str, **kwargs: object) -> aioredis.ConnectionPool:
             captured["pool"] = real_from_url("redis://localhost:1/0", **kwargs)
             return captured["pool"]
 
@@ -90,8 +103,8 @@ class TestRedisManager:
             await manager.initialize()
 
         conn = captured["pool"].make_connection()
-        assert conn.retry.get_retries() == 3
-        assert conn.health_check_interval == 30
+        assert conn.retry.get_retries() == 5
+        assert conn.health_check_interval == 45
 
         manager._client = None
         manager._pool = None

--- a/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
+++ b/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
@@ -3,6 +3,8 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from redis.asyncio.retry import Retry
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from aegra_api.core.redis_manager import RedisManager
 
@@ -31,6 +33,66 @@ class TestRedisManager:
             mock_client.ping.assert_awaited_once()
 
         # Clean up
+        manager._client = None
+        manager._pool = None
+
+    @pytest.mark.asyncio
+    async def test_initialize_configures_retry_and_health_checks(self) -> None:
+        """Pooled connections must survive server-side idle disconnects (#505).
+
+        Every connection — including the one created by initialize()'s own
+        PING — must carry a retry that covers ConnectionError, plus a
+        health-check interval. Passing them to from_url() guarantees this
+        for existing and future connections alike.
+        """
+        manager = RedisManager()
+        mock_client = AsyncMock()
+
+        with (
+            patch("aegra_api.core.redis_manager.aioredis.ConnectionPool") as mock_pool_cls,
+            patch("aegra_api.core.redis_manager.aioredis.Redis", return_value=mock_client),
+        ):
+            await manager.initialize()
+
+            kwargs = mock_pool_cls.from_url.call_args.kwargs
+            assert kwargs["health_check_interval"] == 30
+            retry = kwargs["retry"]
+            assert isinstance(retry, Retry)
+            assert retry.get_retries() == 3
+            assert any(issubclass(RedisConnectionError, e) for e in retry._supported_errors)
+            assert RedisConnectionError in kwargs["retry_on_error"]
+
+        manager._client = None
+        manager._pool = None
+
+    @pytest.mark.asyncio
+    async def test_real_pool_connections_carry_retry(self) -> None:
+        """End-to-end through the real ConnectionPool: connections built from
+        the pool's kwargs must have retries (asyncio default is 0)."""
+        import redis.asyncio as aioredis
+
+        manager = RedisManager()
+        mock_client = AsyncMock()
+        real_from_url = aioredis.ConnectionPool.from_url
+        captured: dict = {}
+
+        def capture_from_url(url, **kwargs):
+            captured["pool"] = real_from_url("redis://localhost:1/0", **kwargs)
+            return captured["pool"]
+
+        with (
+            patch(
+                "aegra_api.core.redis_manager.aioredis.ConnectionPool.from_url",
+                side_effect=capture_from_url,
+            ),
+            patch("aegra_api.core.redis_manager.aioredis.Redis", return_value=mock_client),
+        ):
+            await manager.initialize()
+
+        conn = captured["pool"].make_connection()
+        assert conn.retry.get_retries() == 3
+        assert conn.health_check_interval == 30
+
         manager._client = None
         manager._pool = None
 

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -1,4 +1,4 @@
-"""Tests for AppSettings, DatabaseSettings, and WorkerSettings."""
+"""Tests for environment-backed settings models."""
 
 from urllib.parse import quote_plus
 
@@ -6,7 +6,7 @@ import pytest
 from pydantic import ValidationError
 from sqlalchemy.engine import make_url
 
-from aegra_api.settings import AppSettings, CronSettings, DatabaseSettings, WorkerSettings
+from aegra_api.settings import AppSettings, CronSettings, DatabaseSettings, RedisSettings, WorkerSettings
 
 
 class TestAppSettingsServerURL:
@@ -548,6 +548,29 @@ class TestMultiHostDatabaseURL:
         assert "h1:5432,h2:5432" in db.database_url_sync
         assert "host=" not in db.database_url_sync
         assert db.database_url_sync.startswith("postgresql://")
+
+
+class TestRedisSettingsValidation:
+    """Test that Redis resilience settings cannot enable unbounded retries."""
+
+    @pytest.mark.parametrize(
+        "setting_name",
+        ("REDIS_HEALTH_CHECK_INTERVAL", "REDIS_RETRY_ATTEMPTS"),
+    )
+    def test_rejects_negative_values(self, monkeypatch: pytest.MonkeyPatch, setting_name: str) -> None:
+        monkeypatch.setenv(setting_name, "-1")
+
+        with pytest.raises(ValidationError, match=setting_name):
+            RedisSettings(_env_file=None)
+
+    def test_accepts_zero_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("REDIS_HEALTH_CHECK_INTERVAL", "0")
+        monkeypatch.setenv("REDIS_RETRY_ATTEMPTS", "0")
+
+        redis = RedisSettings(_env_file=None)
+
+        assert redis.REDIS_HEALTH_CHECK_INTERVAL == 0
+        assert redis.REDIS_RETRY_ATTEMPTS == 0
 
 
 class TestWorkerSettingsLeaseValidation:

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -65,7 +65,8 @@ REDIS_URL=redis://localhost:6379/0
 # Ping pooled connections idle longer than this (seconds) before reuse;
 # survives server-side idle disconnects (e.g. ElastiCache `timeout`). 0 disables.
 # REDIS_HEALTH_CHECK_INTERVAL=30
-# Command retry attempts on connection errors (exponential backoff 50ms..1s).
+# Retries after the initial attempt (up to 4 calls total) on connection and
+# timeout errors, with exponential backoff 50ms..1s.
 # REDIS_RETRY_ATTEMPTS=3
 
 # --- Worker Configuration ---

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -62,6 +62,11 @@ REDIS_BROKER_ENABLED=false
 REDIS_URL=redis://localhost:6379/0
 # REDIS_CHANNEL_PREFIX=aegra:run:
 # REDIS_MAX_CONNECTIONS=250
+# Ping pooled connections idle longer than this (seconds) before reuse;
+# survives server-side idle disconnects (e.g. ElastiCache `timeout`). 0 disables.
+# REDIS_HEALTH_CHECK_INTERVAL=30
+# Command retry attempts on connection errors (exponential backoff 50ms..1s).
+# REDIS_RETRY_ATTEMPTS=3
 
 # --- Worker Configuration ---
 # Controls worker concurrency when REDIS_BROKER_ENABLED=true.

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -65,8 +65,8 @@ REDIS_URL=redis://localhost:6379/0
 # Ping pooled connections idle longer than this (seconds) before reuse;
 # survives server-side idle disconnects (e.g. ElastiCache `timeout`). 0 disables.
 # REDIS_HEALTH_CHECK_INTERVAL=30
-# Retries after the initial attempt (up to 4 calls total) on connection and
-# timeout errors, with exponential backoff 50ms..1s.
+# Non-negative retries after the initial attempt (default 3, up to 4 calls total)
+# on connection and timeout errors, with exponential backoff 50ms..1s.
 # REDIS_RETRY_ATTEMPTS=3
 
 # --- Worker Configuration ---


### PR DESCRIPTION
Fixes #505.

## Problem

Pooled Redis connections don't survive server-side idle disconnects (ElastiCache/Valkey `timeout`), failovers, or network resets. Aegra constructs `ConnectionPool` directly, whose connections default to `Retry(NoBackoff(), 0)`, so the first command after a quiet period ? `worker_executor.submit()`'s `RPUSH` ? writes into a dead socket and surfaces `ConnectionError` as a 500 on run creation. The run row is created but never enqueued.

Observed twice in production (details and tracebacks in #505) and reproduced locally against a redis with `timeout 5`:

| Scenario | First command after idle |
| --- | --- |
| Aegra's directly constructed pool | ? ConnectionError |
| `health_check_interval` alone | ? ? the health-check PING itself dies in the stale socket and propagates (retries=0) |
| pool built with a real Retry (this PR) | ? dead connection discarded, command re-run on a fresh one |

## Fix

`RedisManager` builds the pool with:

- `retry=Retry(ExponentialBackoff(50ms..1s), REDIS_RETRY_ATTEMPTS=3)` + `retry_on_error=[ConnectionError, TimeoutError]` ? a bounded policy configured explicitly because directly constructed pools do not inherit the Redis client's default retry policy.
- `health_check_interval=REDIS_HEALTH_CHECK_INTERVAL=30` as defense in depth (idle connections are PINGed before reuse).

Both new settings are env-configurable with safe, non-negative defaults.

Two implementation notes:

1. Passing the options to `from_url()` (rather than retrofitting an initialized pool) matters: the connection created by `initialize()`'s own PING must carry the retry too. `pool.disconnect()` would not remove it from the pool ? it would reconnect later still holding zero retries. The real-pool test covers this.
2. Retrying `RPUSH` (non-idempotent) is safe here: the job queue is at-least-once by contract ? workers dedup via lease acquisition and replay de-duplication (#441 follow-ups), so a duplicated run_id costs one empty BLPOP.

## Tests

- `from_url` receives retry/health-check kwargs with the configured values;
- end-to-end through a real `ConnectionPool`: connections built from the pool carry `retries=3` and the health-check interval.

API unit and integration suites run in CI.

A follow-up could add the same retry semantics to `submit()` itself (app-level belt-and-suspenders for mid-command failures), but this PR alone removes the observed failure mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved Redis connection health monitoring with periodic checks.
  * Added automatic retries with exponential backoff for connection and timeout failures.
  * Added configurable defaults for health-check intervals and retry attempts.
  * Documented the new Redis settings in environment configuration templates.
  * Added validation to prevent negative health-check and retry settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR configures Redis connection pools with bounded exponential retries and idle-connection health checks, with environment-backed controls and focused tests.
- Passes retry and health-check options when constructing the Redis pool.
- Adds non-negative Redis resilience settings with documented defaults.
- Updates both environment templates and validates pool propagation and settings constraints.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/redis_manager.py | Constructs Redis pools with configurable health checks and bounded retries for connection and timeout errors. |
| libs/aegra-api/src/aegra_api/settings.py | Adds validated environment-backed settings for Redis health-check intervals and retry attempts. |
| libs/aegra-api/tests/unit/test_core/test_redis_manager.py | Verifies retry and health-check configuration reaches both the pool factory and real pool connections. |
| libs/aegra-api/tests/unit/test_settings.py | Verifies negative resilience settings are rejected while zero remains supported. |
| .env.example | Documents the new Redis resilience controls and their defaults. |
| libs/aegra-cli/src/aegra_cli/templates/env.example.template | Keeps newly scaffolded projects aligned with the server’s Redis settings. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(redis): validate resilience settings"](https://github.com/aegra/aegra/commit/4a2f7a85329c81b0083f109611ad1848faa5d0bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52527008)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/aegra/aegra/blob/main/CLAUDE.md))
- Knowledge Base — [Execution Engine: Broker, Executors, Leases, and Cleanup](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/execution-engine.md)
- Knowledge Base — [App core & server bootstrap](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/app-core-server.md)
- Knowledge Base — [Aegra CLI (`libs/aegra-cli`)](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/aegra-cli.md)
</details>

<!-- /greptile_comment -->